### PR TITLE
Fix: support custom `_type` specified indices in rollup jobs

### DIFF
--- a/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexmanagement/rollup/RollupMapperService.kt
+++ b/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexmanagement/rollup/RollupMapperService.kt
@@ -157,8 +157,15 @@ class RollupMapperService(
                     return RollupJobValidationResult.Failure(getMappingsResult.message, getMappingsResult.cause)
             }
 
-            val indexMapping: MappingMetadata = res.mappings[index][_DOC]
-            val indexMappingSource = indexMapping.sourceAsMap
+            val indexTypeMappings = res.mappings[index]
+            if (indexTypeMappings.isEmpty) {
+                return RollupJobValidationResult.Invalid("Source index [$index] mappings are empty, cannot validate the job.")
+            }
+
+            // Starting from 6.0.0 an index can only have one mapping, but mapping type is still part of the APIs in 7.x
+            // Since a custom mapping type can be set for index using the first type mappings instead of _DOC mappings to validate
+            // https://www.elastic.co/guide/en/elasticsearch/reference/7.x/removal-of-types.html
+            val indexMappingSource = indexTypeMappings.first().value.sourceAsMap
 
             val issues = mutableSetOf<String>()
             // Validate source fields in dimensions
@@ -194,7 +201,9 @@ class RollupMapperService(
                 RollupJobValidationResult.Invalid("Invalid mappings for index [$index] because $issues")
             }
         } catch (e: Exception) {
-            return RollupJobValidationResult.Failure("Failed to validate the source index mappings", e)
+            val errorMessage = "Failed to validate the source index mappings"
+            logger.error(errorMessage, e)
+            return RollupJobValidationResult.Failure(errorMessage, e)
         }
     }
 

--- a/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexmanagement/rollup/RollupMapperService.kt
+++ b/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexmanagement/rollup/RollupMapperService.kt
@@ -162,9 +162,8 @@ class RollupMapperService(
                 return RollupJobValidationResult.Invalid("Source index [$index] mappings are empty, cannot validate the job.")
             }
 
-            // Starting from 6.0.0 an index can only have one mapping, but mapping type is still part of the APIs in 7.x
-            // Since a custom mapping type can be set for index using the first type mappings instead of _DOC mappings to validate
-            // https://www.elastic.co/guide/en/elasticsearch/reference/7.x/removal-of-types.html
+            // Starting from 6.0.0 an index can only have one mapping type, but mapping type is still part of the APIs in 7.x, allowing users to
+            // set a custom mapping type. As a result using first mapping type found instead of _DOC mapping type to validate
             val indexMappingSource = indexTypeMappings.first().value.sourceAsMap
 
             val issues = mutableSetOf<String>()


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Support source indices which have custom specified `_type`.

*CheckList:*
[ X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/index-management/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
