### PR TITLE
Improve integration with data streams

### DIFF
--- a/release-notes/opensearch-index-management.release-notes-1.0.0.0-rc1.md
+++ b/release-notes/opensearch-index-management.release-notes-1.0.0.0-rc1.md
@@ -16,3 +16,7 @@ Compatible with OpenSearch 1.0.0-rc1
 ### Features
 
 * Adds support for Transform feature ([#17](https://github.com/opensearch-project/index-management/pull/17))
+
+### Enhancements
+
+* Improve integration with data streams ([#13](https://github.com/opensearch-project/index-management/pull/13))

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/ISMTemplateService.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/ISMTemplateService.kt
@@ -54,8 +54,8 @@ fun Map<String, ISMTemplate>.findMatchingPolicy(clusterState: ClusterState, inde
     if (this.isEmpty()) return null
 
     val indexMetadata = clusterState.metadata.index(indexName)
-    val indexAbstraction = clusterState.metadata.indicesLookup[indexName]!!
-    val isDataStreamIndex = indexAbstraction.parentDataStream != null
+    val indexAbstraction = clusterState.metadata.indicesLookup[indexName]
+    val isDataStreamIndex = indexAbstraction?.parentDataStream != null
 
     // Don't include hidden index unless it belongs to a data stream.
     val isHidden = IndexMetadata.INDEX_HIDDEN_SETTING.get(indexMetadata.settings)
@@ -63,7 +63,7 @@ fun Map<String, ISMTemplate>.findMatchingPolicy(clusterState: ClusterState, inde
 
     // If the index belongs to a data stream, then find the matching policy using the data stream name.
     val lookupName = when {
-        isDataStreamIndex -> indexAbstraction.parentDataStream!!.name!!
+        isDataStreamIndex -> indexAbstraction?.parentDataStream?.name
         else -> indexName
     }
 

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/ManagedIndexCoordinator.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/ManagedIndexCoordinator.kt
@@ -302,7 +302,7 @@ class ManagedIndexCoordinator(
         val templates = getISMTemplates()
 
         val indexToMatchedPolicy = indexNames.map { indexName ->
-            indexName to templates.findMatchingPolicy(indexMetadatas[indexName])
+            indexName to templates.findMatchingPolicy(clusterState, indexName)
         }.toMap()
 
         indexToMatchedPolicy.filterNotNullValues()

--- a/src/main/kotlin/org/opensearch/indexmanagement/rollup/RollupMapperService.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/rollup/RollupMapperService.kt
@@ -134,7 +134,7 @@ class RollupMapperService(
         // Allow no indices, open and closed
         // Rolling up on closed indices will not be caught here
         val concreteIndices =
-            indexNameExpressionResolver.concreteIndexNames(clusterService.state(), IndicesOptions.lenientExpand(), rollup.sourceIndex)
+            indexNameExpressionResolver.concreteIndexNames(clusterService.state(), IndicesOptions.lenientExpand(), true, rollup.sourceIndex)
         if (concreteIndices.isEmpty()) return RollupJobValidationResult.Invalid("No indices found for [${rollup.sourceIndex}]")
 
         // Validate mappings for each concrete index resolved from the rollup source index

--- a/src/main/kotlin/org/opensearch/indexmanagement/rollup/actionfilter/FieldCapsFilter.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/rollup/actionfilter/FieldCapsFilter.kt
@@ -84,7 +84,7 @@ class FieldCapsFilter(
             val localIndices = remoteClusterIndices.remove(RemoteClusterAware.LOCAL_CLUSTER_GROUP_KEY)
 
             localIndices?.let {
-                val concreteIndices = indexNameExpressionResolver.concreteIndexNames(clusterService.state(), it)
+                val concreteIndices = indexNameExpressionResolver.concreteIndexNames(clusterService.state(), request.indicesOptions(), it)
                 for (index in concreteIndices) {
                     val isRollupIndex = isRollupIndex(index, clusterService.state())
                     if (isRollupIndex) {

--- a/src/main/kotlin/org/opensearch/indexmanagement/rollup/actionfilter/FieldCapsFilter.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/rollup/actionfilter/FieldCapsFilter.kt
@@ -84,7 +84,7 @@ class FieldCapsFilter(
             val localIndices = remoteClusterIndices.remove(RemoteClusterAware.LOCAL_CLUSTER_GROUP_KEY)
 
             localIndices?.let {
-                val concreteIndices = indexNameExpressionResolver.concreteIndexNames(clusterService.state(), request.indicesOptions(), it)
+                val concreteIndices = indexNameExpressionResolver.concreteIndexNames(clusterService.state(), it)
                 for (index in concreteIndices) {
                     val isRollupIndex = isRollupIndex(index, clusterService.state())
                     if (isRollupIndex) {
@@ -216,7 +216,12 @@ class FieldCapsFilter(
 
     private fun populateSourceFieldMappingsForRollupJob(rollup: Rollup): Set<RollupFieldMapping> {
         val rollupFieldMappings = rollup.populateFieldMappings()
-        val sourceIndices = indexNameExpressionResolver.concreteIndexNames(clusterService.state(), IndicesOptions.lenientExpand(), rollup.sourceIndex)
+        val sourceIndices = indexNameExpressionResolver.concreteIndexNames(
+            clusterService.state(),
+            IndicesOptions.lenientExpand(),
+            true,
+            rollup.sourceIndex
+        )
         sourceIndices.forEach {
             val mappings = clusterService.state().metadata.index(it).mapping()?.sourceAsMap ?: return rollupFieldMappings
             rollupFieldMappings.forEach { fieldMapping ->

--- a/src/main/kotlin/org/opensearch/indexmanagement/rollup/interceptor/RollupInterceptor.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/rollup/interceptor/RollupInterceptor.kt
@@ -101,9 +101,7 @@ class RollupInterceptor(
                             throw IllegalArgumentException("Rollup search must have size explicitly set to 0, but found ${request.source().size()}")
                         }
 
-                        val indices = request.indices().map { it.toString() }.toTypedArray()
-                        val concreteIndices = indexNameExpressionResolver
-                                .concreteIndexNames(clusterService.state(), request.indicesOptions(), *indices)
+                        val concreteIndices = indexNameExpressionResolver.concreteIndexNames(clusterService.state(), request)
 
                         if (concreteIndices.size > 1) {
                             logger.warn("There can be only one index in search request if its a rollup search - requested to search [${concreteIndices

--- a/src/main/kotlin/org/opensearch/indexmanagement/rollup/interceptor/RollupInterceptor.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/rollup/interceptor/RollupInterceptor.kt
@@ -101,7 +101,9 @@ class RollupInterceptor(
                             throw IllegalArgumentException("Rollup search must have size explicitly set to 0, but found ${request.source().size()}")
                         }
 
-                        val concreteIndices = indexNameExpressionResolver.concreteIndexNames(clusterService.state(), request)
+                        val indices = request.indices().map { it.toString() }.toTypedArray()
+                        val concreteIndices = indexNameExpressionResolver
+                            .concreteIndexNames(clusterService.state(), request.indicesOptions(), *indices)
 
                         if (concreteIndices.size > 1) {
                             logger.warn("There can be only one index in search request if its a rollup search - requested to search [${concreteIndices

--- a/src/test/kotlin/org/opensearch/indexmanagement/rollup/RollupMapperServiceTests.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/rollup/RollupMapperServiceTests.kt
@@ -35,6 +35,7 @@ import com.nhaarman.mockitokotlin2.doReturn
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.whenever
 import kotlinx.coroutines.runBlocking
+import org.mockito.ArgumentMatchers.anyBoolean
 import org.opensearch.action.ActionListener
 import org.opensearch.action.admin.indices.mapping.get.GetMappingsResponse
 import org.opensearch.client.AdminClient
@@ -197,7 +198,7 @@ class RollupMapperServiceTests : OpenSearchTestCase() {
 
     // Returns a mocked IndexNameExpressionResolver which returns the provided list of concrete indices
     private fun getIndexNameExpressionResolver(concreteIndices: List<String>): IndexNameExpressionResolver =
-        mock { on { concreteIndexNames(any(), any(), anyVararg<String>()) } doReturn concreteIndices.toTypedArray() }
+        mock { on { concreteIndexNames(any(), any(), anyBoolean(), anyVararg<String>()) } doReturn concreteIndices.toTypedArray() }
 
     private fun getKibanaSampleDataMappingResponse(indexName: String): GetMappingsResponse {
         val mappingSourceMap = createParser(

--- a/src/test/kotlin/org/opensearch/indexmanagement/rollup/RollupRestTestCase.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/rollup/RollupRestTestCase.kt
@@ -62,6 +62,8 @@ abstract class RollupRestTestCase : IndexManagementRestTestCase() {
 
     override fun preserveIndicesUponCompletion(): Boolean = true
 
+    override fun preserveDataStreamsUponCompletion(): Boolean = true
+
     protected fun createRollup(
         rollup: Rollup,
         rollupId: String = OpenSearchTestCase.randomAlphaOfLength(10),
@@ -104,7 +106,7 @@ abstract class RollupRestTestCase : IndexManagementRestTestCase() {
     }
 
     // TODO: Maybe clean-up and use XContentFactory.jsonBuilder() to create mappings json
-    protected fun createRollupSourceIndex(rollup: Rollup, settings: Settings = Settings.EMPTY) {
+    protected fun createRollupMappingString(rollup: Rollup): String {
         var mappingString = ""
         var addCommaPrefix = false
         rollup.dimensions.forEach {
@@ -123,7 +125,11 @@ abstract class RollupRestTestCase : IndexManagementRestTestCase() {
             mappingString += string
         }
         mappingString = "\"properties\":{$mappingString}"
-        createIndex(rollup.sourceIndex, settings, mappingString)
+        return mappingString
+    }
+
+    protected fun createRollupSourceIndex(rollup: Rollup, settings: Settings = Settings.EMPTY) {
+        createIndex(rollup.sourceIndex, settings, createRollupMappingString(rollup))
     }
 
     protected fun putDateDocumentInSourceIndex(rollup: Rollup) {


### PR DESCRIPTION
### Description

This PR aims to resolve the limitations/enhancements pointed out in https://github.com/opensearch-project/index-management/issues/12. Here's a short summary.

1. Fixes the ISM policy association behaviour when a new backing index of a data stream is created.
2. When executing the rollover action on a backing index of a data stream, ISM will automatically identify the data stream name and use it as the rollover target. Users no longer need to specify the `rollover_alias` index setting.
3. Fixes the index expression resolution in rollups when the source is a data stream. The data stream name will be resolved to its corresponding backing indices.

### Issues
+ Closes https://github.com/opensearch-project/index-management/issues/12
+ Relates https://github.com/opensearch-project/OpenSearch/issues/675

### CheckList
- [x] Commits are signed per the DCO using --signoff
- [x] New functionality includes tests
- [x] All tests pass

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/index-management/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).

Signed-off-by: Ketan Verma ketan9495@gmail.com