### PR TITLE
Point to correct version of notification

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -139,7 +139,7 @@ dependencies {
     compile "org.jetbrains.kotlin:kotlin-stdlib-common:${kotlin_version}"
     compile 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.3.7'
     compile "org.jetbrains:annotations:13.0"
-    compile "org.opensearch:notification:1.0.0.0-beta1"
+    compile "org.opensearch:notification:1.0.0.0-rc1"
     compile "org.opensearch:common-utils:1.0.0.0-rc1"
     compile "com.github.seancfoley:ipaddress:5.3.3"
 


### PR DESCRIPTION
*Issue #, if available:*
N/A
*Description of changes:*
* Update notification dependency to point to correct version. This will fix the github workflow integration test
*CheckList:*
[X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/index-management/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
