### PR TITLE
Fix: correct legacy endpoint for get ISM policies

### DIFF
--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/resthandler/RestGetPolicyAction.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/resthandler/RestGetPolicyAction.kt
@@ -40,7 +40,6 @@ import org.opensearch.indexmanagement.indexstatemanagement.util.DEFAULT_SORT_ORD
 import org.apache.logging.log4j.LogManager
 import org.opensearch.client.node.NodeClient
 import org.opensearch.indexmanagement.IndexManagementPlugin.Companion.LEGACY_POLICY_BASE_URI
-import org.opensearch.indexmanagement.IndexManagementPlugin.Companion.LEGACY_ROLLUP_BASE_URI
 import org.opensearch.rest.BaseRestHandler
 import org.opensearch.rest.BaseRestHandler.RestChannelConsumer
 import org.opensearch.rest.RestHandler.Route
@@ -64,7 +63,7 @@ class RestGetPolicyAction : BaseRestHandler() {
         return listOf(
             ReplacedRoute(
                 GET, POLICY_BASE_URI,
-                GET, LEGACY_ROLLUP_BASE_URI
+                GET, LEGACY_POLICY_BASE_URI
             ),
             ReplacedRoute(
                 GET, "$POLICY_BASE_URI/{policyID}",

--- a/src/test/kotlin/org/opensearch/indexmanagement/IndexManagementIndicesIT.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/IndexManagementIndicesIT.kt
@@ -200,6 +200,9 @@ class IndexManagementIndicesIT : IndexStateManagementRestTestCase() {
             RestRequest.Method.DELETE.toString(),
             "${IndexManagementPlugin.LEGACY_POLICY_BASE_URI}/$policyId")
         assertEquals("Unexpected RestStatus", RestStatus.OK, deletePolicyResponse.restStatus())
+
+        val getPolicies = client().makeRequest(RestRequest.Method.GET.toString(), "${IndexManagementPlugin.LEGACY_POLICY_BASE_URI}")
+        assertEquals("Unexpected RestStatus", RestStatus.OK, getPolicies.restStatus())
     }
 
     fun `test refresh search analyzer backward compatibility with opendistro`() {


### PR DESCRIPTION
Signed-off-by: Ravi Thaluru <ravi1092@gmail.com>

*Issue #, if available:*

*Description of changes:*
* Support the legacy endpoint - `GET _opendistro/_ism/policies`

*CheckList:*
[X ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/index-management/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
