### PR TITLE
Fix 7.10 rollover blocking thread issue

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -304,6 +304,10 @@ integTest {
             excludeTestsMatching "org.opensearch.indexmanagement.indexstatemanagement.action.NotificationActionIT"
         }
     }
+
+    filter {
+        excludeTestsMatching "org.opensearch.indexmanagement.indexstatemanagement.MetadataRegressionIT"
+    }
 }
 
 run {

--- a/release-notes/opensearch-index-management.release-notes-1.0.0.0-rc1.md
+++ b/release-notes/opensearch-index-management.release-notes-1.0.0.0-rc1.md
@@ -20,3 +20,7 @@ Compatible with OpenSearch 1.0.0-rc1
 ### Enhancements
 
 * Improve integration with data streams ([#13](https://github.com/opensearch-project/index-management/pull/13))
+
+### Bug Fixes
+
+* Fix 7.10 rollover blocking thread issue ([#70](https://github.com/opensearch-project/index-management/pull/70))


### PR DESCRIPTION
Signed-off-by: bowenlan-amzn <bowenlan23@gmail.com>

*Issue #, if available:*
#68 

*Description of changes:*
This issue starts on ES 7.10/OpenSearch 1.0, `LocalNodeMasterListener` will use the same thread for cluster state update which is a single thread pool. So our ism history rollover task will block this thread. This will happen when there is a master re-election and rollover satisfy the contition.

*CheckList:*
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/index-management/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
