### PR TITLE
Build and test against a stable version of OpenSearch (1.0)

### DIFF
--- a/.github/workflows/multi-node-test-workflow.yml
+++ b/.github/workflows/multi-node-test-workflow.yml
@@ -28,7 +28,7 @@ jobs:
         with:
           repository: 'opensearch-project/OpenSearch'
           path: OpenSearch
-          ref: '1.x'
+          ref: '1.0'
       - name: Build OpenSearch
         working-directory: ./OpenSearch
         run: ./gradlew publishToMavenLocal -Dbuild.version_qualifier=rc1 -Dbuild.snapshot=false

--- a/.github/workflows/test-and-build-workflow.yml
+++ b/.github/workflows/test-and-build-workflow.yml
@@ -30,7 +30,7 @@ jobs:
         with:
           repository: 'opensearch-project/OpenSearch'
           path: OpenSearch
-          ref: '1.x'
+          ref: '1.0'
       - name: Build OpenSearch
         working-directory: ./OpenSearch
         run: ./gradlew publishToMavenLocal -Dbuild.version_qualifier=rc1 -Dbuild.snapshot=false

--- a/build.gradle
+++ b/build.gradle
@@ -304,10 +304,6 @@ integTest {
             excludeTestsMatching "org.opensearch.indexmanagement.indexstatemanagement.action.NotificationActionIT"
         }
     }
-
-    filter {
-        excludeTestsMatching "org.opensearch.indexmanagement.indexstatemanagement.MetadataRegressionIT"
-    }
 }
 
 run {


### PR DESCRIPTION
Changes:
1. Updated GitHub workflows to build and test against a stable version of OpenSearch (1.0). 
2. Re-enabled MetadataRegressionIT tests.

Signed-off-by: Ketan Verma <ketan9495@gmail.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/index-management/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
