### PR TITLE
Fix: Rollup start/stop API

### DIFF
--- a/src/main/kotlin/org/opensearch/indexmanagement/rollup/action/start/TransportStartRollupAction.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/rollup/action/start/TransportStartRollupAction.kt
@@ -183,6 +183,7 @@ class TransportStartRollupAction @Inject constructor(
                     )
                 )
             )
+            .routing(rollup.id)
         client.update(
             updateRequest,
             object : ActionListener<UpdateResponse> {

--- a/src/main/kotlin/org/opensearch/indexmanagement/rollup/action/stop/TransportStopRollupAction.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/rollup/action/stop/TransportStopRollupAction.kt
@@ -200,6 +200,7 @@ class TransportStopRollupAction @Inject constructor(
                     )
                 )
             )
+            .routing(rollup.id)
         client.update(
             request,
             object : ActionListener<UpdateResponse> {


### PR DESCRIPTION

*Issue #, if available:*
N/A

*Description of changes:*
Fix start/stop rollup API when the IndexManagement config index is configured for multiple primary shards

*CheckList:*
[ X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/index-management/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
