### PR TITLE
Fix: Stopping the call in case of errors when fetching transforms

### DIFF
--- a/src/main/kotlin/org/opensearch/indexmanagement/transform/action/get/TransportGetTransformAction.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/transform/action/get/TransportGetTransformAction.kt
@@ -50,10 +50,12 @@ class TransportGetTransformAction @Inject constructor(
                 override fun onResponse(response: GetResponse) {
                     if (!response.isExists) {
                         listener.onFailure(OpenSearchStatusException("Transform not found", RestStatus.NOT_FOUND))
+                        return
                     }
 
                     if (response.isSourceEmpty && getRequest.fetchSourceContext() != FetchSourceContext.DO_NOT_FETCH_SOURCE) {
                         listener.onFailure(OpenSearchStatusException("Missing transform data", RestStatus.INTERNAL_SERVER_ERROR))
+                        return
                     } else if (response.isSourceEmpty) {
                         // For HEAD requests only
                         listener.onResponse(
@@ -66,6 +68,7 @@ class TransportGetTransformAction @Inject constructor(
                                 null
                             )
                         )
+                        return
                     }
 
                     try {


### PR DESCRIPTION
Signed-off-by: Ravi Thaluru <ravi1092@gmail.com>

*Issue #, if available:*
N/A

*Description of changes:*
* Return the call after doing callback for failure/success cases while fetching transforms

*CheckList:*
[X ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/index-management/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
