### PR TITLE
pre check for rollover action

### DIFF
--- a/.github/workflows/multi-node-test-workflow.yml
+++ b/.github/workflows/multi-node-test-workflow.yml
@@ -56,7 +56,7 @@ jobs:
         with:
           repository: 'opensearch-project/alerting'
           path: alerting
-          ref: 'main'
+          ref: '1.0'
       - name: Build alerting
         working-directory: ./alerting
         run: ./gradlew :alerting-notification:publishToMavenLocal -Dopensearch.version=1.0.0 -Dbuild.snapshot=false

--- a/.github/workflows/test-and-build-workflow.yml
+++ b/.github/workflows/test-and-build-workflow.yml
@@ -56,7 +56,7 @@ jobs:
         with:
           repository: 'opensearch-project/alerting'
           path: alerting
-          ref: 'main'
+          ref: '1.0'
       - name: Build alerting
         working-directory: ./alerting
         run: ./gradlew :alerting-notification:publishToMavenLocal -Dopensearch.version=1.0.0 -Dbuild.snapshot=false

--- a/build.gradle
+++ b/build.gradle
@@ -155,7 +155,7 @@ dependencies {
     compile "org.jetbrains.kotlin:kotlin-stdlib-common:${kotlin_version}"
     compile 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.3.7'
     compile "org.jetbrains:annotations:13.0"
-    compile "org.opensearch:notification:1.0.0.0-rc1"
+    compile "org.opensearch:notification:1.0.0.0"
     compile "org.opensearch:common-utils:1.0.0.0"
     compile "com.github.seancfoley:ipaddress:5.3.3"
 

--- a/src/main/kotlin/org/opensearch/indexmanagement/IndexManagementPlugin.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/IndexManagementPlugin.kt
@@ -363,6 +363,7 @@ class IndexManagementPlugin : JobSchedulerExtension, NetworkPlugin, ActionPlugin
             ManagedIndexSettings.HISTORY_NUMBER_OF_REPLICAS,
             ManagedIndexSettings.POLICY_ID,
             ManagedIndexSettings.ROLLOVER_ALIAS,
+            ManagedIndexSettings.ROLLOVER_SKIP,
             ManagedIndexSettings.INDEX_STATE_MANAGEMENT_ENABLED,
             ManagedIndexSettings.METADATA_SERVICE_ENABLED,
             ManagedIndexSettings.JOB_INTERVAL,

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/opensearchapi/OpenSearchExtensions.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/opensearchapi/OpenSearchExtensions.kt
@@ -79,6 +79,10 @@ fun IndexMetadata.getRolloverAlias(): String? {
     return this.settings.get(ManagedIndexSettings.ROLLOVER_ALIAS.key)
 }
 
+fun IndexMetadata.getRolloverSkip(): Boolean {
+    return this.settings.getAsBoolean(ManagedIndexSettings.ROLLOVER_SKIP.key, false)
+}
+
 fun IndexMetadata.getManagedIndexMetadata(): ManagedIndexMetaData? {
     val existingMetaDataMap = this.getCustomData(ManagedIndexMetaData.MANAGED_INDEX_METADATA_TYPE)
 

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/settings/ManagedIndexSettings.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/settings/ManagedIndexSettings.kt
@@ -69,6 +69,13 @@ class ManagedIndexSettings {
             Setting.Property.Dynamic
         )
 
+        val ROLLOVER_SKIP: Setting<Boolean> = Setting.boolSetting(
+            "index.plugins.index_state_management.rollover_skip",
+            false,
+            Setting.Property.IndexScope,
+            Setting.Property.Dynamic
+        )
+
         val JOB_INTERVAL: Setting<Int> = Setting.intSetting(
             "plugins.index_state_management.job_interval",
             LegacyOpenDistroManagedIndexSettings.JOB_INTERVAL,

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/rollover/AttemptRolloverStep.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/rollover/AttemptRolloverStep.kt
@@ -195,17 +195,17 @@ class AttemptRolloverStep(
      *
      * @param alias user defined ISM rollover alias
      */
-    private fun preCheckIndexAlias(alias: String?): Boolean {
+    private fun preCheckIndexAlias(alias: String): Boolean {
         val metadata = clusterService.state().metadata
-        val indexAlias = metadata.index(indexName).aliases[alias]
-        logger.debug("index $indexName has aliases $indexAlias")
+        val indexAlias = metadata.index(indexName)?.aliases?.get(alias)
+        logger.debug("Index $indexName has aliases $indexAlias")
         if (indexAlias == null) {
             return false
         }
         val isWriteIndex = indexAlias.writeIndex() // this could be null
-        if (isWriteIndex == null || !isWriteIndex) {
+        if (isWriteIndex != true) {
             val aliasIndices = metadata.indicesLookup[alias]?.indices?.map { it.index }
-            logger.debug("alias $alias contains indices $aliasIndices")
+            logger.debug("Alias $alias contains indices $aliasIndices")
             if (aliasIndices != null && aliasIndices.size > 1) {
                 return false
             }
@@ -291,6 +291,6 @@ class AttemptRolloverStep(
         fun getSuccessDataStreamRolloverMessage(dataStream: String, index: String) =
             "Successfully rolled over data stream [data_stream=$dataStream index=$index]"
         fun getFailedPreCheckMessage(index: String) = "Missing alias or not the write index when rollover [index=$index]"
-        fun getSkipRolloverMessage(index: String) = "Skip rollover action for [index=$index]"
+        fun getSkipRolloverMessage(index: String) = "Skipped rollover action for [index=$index]"
     }
 }


### PR DESCRIPTION
Signed-off-by: bowenlan-amzn <bowenlan23@gmail.com>

*Issue #, if available:*
#45 

*Description of changes:*

Add pre-condition check to rollover action. 

We are only using info from cluster state, but not doing a `GET _aliases` call. Theoretically this could have a 30s delay. But even this delay bypass our pre-check (user did manually rollover just within 30s delay and write index moved to new index), this wont break the whole workflow.

*CheckList:*
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/index-management/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
