### PR TITLE
rolling upgrade issues fixes

### DIFF
--- a/.github/workflows/multi-node-test-workflow.yml
+++ b/.github/workflows/multi-node-test-workflow.yml
@@ -36,7 +36,7 @@ jobs:
         with:
           repository: 'opensearch-project/common-utils'
           path: common-utils
-          ref: 'main'
+          ref: '1.0'
       - name: Build common-utils
         working-directory: ./common-utils
         run: ./gradlew publishToMavenLocal -Dopensearch.version=1.0.0
@@ -46,7 +46,7 @@ jobs:
         with:
           repository: 'opensearch-project/job-scheduler'
           path: job-scheduler
-          ref: 'main'
+          ref: '1.0'
       - name: Build job-scheduler
         working-directory: ./job-scheduler
         run: ./gradlew publishToMavenLocal -Dopensearch.version=1.0.0 -Dbuild.snapshot=false

--- a/.github/workflows/test-and-build-workflow.yml
+++ b/.github/workflows/test-and-build-workflow.yml
@@ -36,7 +36,7 @@ jobs:
         with:
           repository: 'opensearch-project/common-utils'
           path: common-utils
-          ref: 'main'
+          ref: '1.0'
       - name: Build common-utils
         working-directory: ./common-utils
         run: ./gradlew publishToMavenLocal -Dopensearch.version=1.0.0
@@ -46,7 +46,7 @@ jobs:
         with:
           repository: 'opensearch-project/job-scheduler'
           path: job-scheduler
-          ref: 'main'
+          ref: '1.0'
       - name: Build job-scheduler
         working-directory: ./job-scheduler
         run: ./gradlew publishToMavenLocal -Dopensearch.version=1.0.0 -Dbuild.snapshot=false

--- a/build.gradle
+++ b/build.gradle
@@ -271,6 +271,12 @@ testClusters.integTest {
         }))
     }
     setting 'path.repo', repo.absolutePath
+
+    if (System.getProperty("tests.clustername") != null) {
+        filter {
+            excludeTestsMatching "org.opensearch.indexmanagement.indexstatemanagement.MetadataRegressionIT"
+        }
+    }
 }
 integTest {
     systemProperty 'tests.security.manager', 'false'

--- a/src/main/kotlin/org/opensearch/indexmanagement/IndexManagementPlugin.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/IndexManagementPlugin.kt
@@ -335,6 +335,7 @@ class IndexManagementPlugin : JobSchedulerExtension, NetworkPlugin, ActionPlugin
             .registerScriptService(scriptService)
             .registerSettings(settings)
             .registerConsumers() // registerConsumers must happen after registerSettings/clusterService
+            .registerIMIndex(indexManagementIndices)
             .registerHistoryIndex(indexStateManagementHistory)
             .registerSkipFlag(skipFlag)
 

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/ManagedIndexCoordinator.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/ManagedIndexCoordinator.kt
@@ -569,6 +569,8 @@ class ManagedIndexCoordinator(
     @OpenForTesting
     @Suppress("TooGenericExceptionCaught")
     suspend fun clearManagedIndexMetaData(deleteRequests: List<DocWriteRequest<*>>) {
+        if (!ismIndices.indexManagementIndexExists()) return
+
         try {
             if (deleteRequests.isEmpty()) return
 

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/model/ManagedIndexConfig.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/model/ManagedIndexConfig.kt
@@ -189,6 +189,7 @@ data class ManagedIndexConfig(
                 policySeqNo = policySeqNo,
                 policyPrimaryTerm = policyPrimaryTerm,
                 policy = policy?.copy(
+                    id = policyID ?: NO_ID,
                     seqNo = policySeqNo ?: SequenceNumbers.UNASSIGNED_SEQ_NO,
                     primaryTerm = policyPrimaryTerm ?: SequenceNumbers.UNASSIGNED_PRIMARY_TERM
                 ),

--- a/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/TestHelpers.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/TestHelpers.kt
@@ -288,7 +288,7 @@ fun randomManagedIndexConfig(
         policyID = policy?.id ?: policyID,
         policySeqNo = policy?.seqNo,
         policyPrimaryTerm = policy?.primaryTerm,
-        policy = policy?.copy(id = ManagedIndexConfig.NO_ID, seqNo = SequenceNumbers.UNASSIGNED_SEQ_NO, primaryTerm = SequenceNumbers.UNASSIGNED_PRIMARY_TERM),
+        policy = policy?.copy(seqNo = SequenceNumbers.UNASSIGNED_SEQ_NO, primaryTerm = SequenceNumbers.UNASSIGNED_PRIMARY_TERM),
         changePolicy = changePolicy
     )
 }


### PR DESCRIPTION
Signed-off-by: bowenlan-amzn <bowenlan23@gmail.com>

*Issue #, if available:*
#82 

*Description of changes:*
Fix several issues found during rolling upgrade tests:
1. Policy saved in managed index are not parsed out with non-empty `policy_id` field. This previously is only for user to do search on it, we treat it as read-only but not needed for parse out.
2. Update metadata in Runner is checking config index mapping schema version now.
3. Coordinator clean metadata throw a lot of error when config index not exist.


*CheckList:*
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/index-management/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
