### PR TITLE
Enhance ISM template

### DIFF
--- a/src/main/kotlin/org/opensearch/indexmanagement/IndexManagementPlugin.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/IndexManagementPlugin.kt
@@ -367,6 +367,7 @@ class IndexManagementPlugin : JobSchedulerExtension, NetworkPlugin, ActionPlugin
             ManagedIndexSettings.ROLLOVER_SKIP,
             ManagedIndexSettings.INDEX_STATE_MANAGEMENT_ENABLED,
             ManagedIndexSettings.METADATA_SERVICE_ENABLED,
+            ManagedIndexSettings.AUTO_MANAGE,
             ManagedIndexSettings.JOB_INTERVAL,
             ManagedIndexSettings.SWEEP_PERIOD,
             ManagedIndexSettings.COORDINATOR_BACKOFF_COUNT,

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/ISMTemplateService.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/ISMTemplateService.kt
@@ -29,8 +29,7 @@ package org.opensearch.indexmanagement.indexstatemanagement
 import org.apache.logging.log4j.LogManager
 import org.apache.lucene.util.automaton.Operations
 import org.opensearch.OpenSearchException
-import org.opensearch.cluster.ClusterState
-import org.opensearch.cluster.metadata.IndexMetadata
+import org.opensearch.cluster.metadata.IndexAbstraction
 import org.opensearch.common.Strings
 import org.opensearch.common.ValidationException
 import org.opensearch.common.regex.Regex
@@ -40,26 +39,24 @@ import org.opensearch.indexmanagement.util.IndexManagementException
 private val log = LogManager.getLogger("ISMTemplateService")
 
 /**
- * find the matching policy based on ISM template field for the given index
+ * find the matching policy for the given index
  *
- * filter out hidden index
- * filter out older index than template lastUpdateTime
+ * return early if it's hidden index
+ * filter out templates that were last updated after the index creation time
  *
- * @param ismTemplates current ISM templates saved in metadata
- * @param indexMetadata cluster state index metadata
  * @return policyID
  */
-@Suppress("ReturnCount")
-fun Map<String, ISMTemplate>.findMatchingPolicy(clusterState: ClusterState, indexName: String): String? {
-    if (this.isEmpty()) return null
-
-    val indexMetadata = clusterState.metadata.index(indexName)
-    val indexAbstraction = clusterState.metadata.indicesLookup[indexName]
+@Suppress("ReturnCount", "NestedBlockDepth")
+fun Map<String, List<ISMTemplate>>.findMatchingPolicy(
+    indexName: String,
+    indexCreationDate: Long,
+    isHiddenIndex: Boolean,
+    indexAbstraction: IndexAbstraction?
+): String? {
     val isDataStreamIndex = indexAbstraction?.parentDataStream != null
-
-    // Don't include hidden index unless it belongs to a data stream.
-    val isHidden = IndexMetadata.INDEX_HIDDEN_SETTING.get(indexMetadata.settings)
-    if (!isDataStreamIndex && isHidden) return null
+    if (this.isEmpty()) return null
+    // don't include hidden index
+    if (!isDataStreamIndex && isHiddenIndex) return null
 
     // If the index belongs to a data stream, then find the matching policy using the data stream name.
     val lookupName = when {
@@ -72,14 +69,19 @@ fun Map<String, ISMTemplate>.findMatchingPolicy(clusterState: ClusterState, inde
     val patternMatchPredicate = { pattern: String -> Regex.simpleMatch(pattern, lookupName) }
     var matchedPolicy: String? = null
     var highestPriority: Int = -1
-    this.filter { (_, template) ->
-        template.lastUpdatedTime.toEpochMilli() < indexMetadata.creationDate
-    }.forEach { (policyID, template) ->
-        val matched = template.indexPatterns.stream().anyMatch(patternMatchPredicate)
-        if (matched && highestPriority < template.priority) {
-            highestPriority = template.priority
-            matchedPolicy = policyID
-        }
+
+    this.forEach { (policyID, templateList) ->
+        templateList.filter { it.lastUpdatedTime.toEpochMilli() < indexCreationDate }
+            .forEach {
+                if (it.indexPatterns.stream().anyMatch(patternMatchPredicate)) {
+                    if (highestPriority < it.priority) {
+                        highestPriority = it.priority
+                        matchedPolicy = policyID
+                    } else if (highestPriority == it.priority) {
+                        log.warn("Warning: index $lookupName matches [$matchedPolicy, $policyID]")
+                    }
+                }
+            }
     }
 
     return matchedPolicy
@@ -120,30 +122,61 @@ fun validateFormat(indexPatterns: List<String>): OpenSearchException? {
     return null
 }
 
+fun List<ISMTemplate>.findSelfConflictingTemplates(): Pair<List<String>, List<String>>? {
+    val priorityToTemplates = mutableMapOf<Int, List<ISMTemplate>>()
+    this.forEach {
+        val templateList = priorityToTemplates[it.priority]
+        if (templateList != null) {
+            priorityToTemplates[it.priority] = templateList.plus(it)
+        } else {
+            priorityToTemplates[it.priority] = mutableListOf(it)
+        }
+    }
+    priorityToTemplates.forEach { (_, templateList) ->
+        // same priority
+        val indexPatternsList = templateList.map { it.indexPatterns }
+        if (indexPatternsList.size > 1) {
+            indexPatternsList.forEachIndexed { ind, indexPatterns ->
+                val comparePatterns = indexPatternsList.subList(ind + 1, indexPatternsList.size).flatten()
+                if (overlapping(indexPatterns, comparePatterns)) {
+                    return indexPatterns to comparePatterns
+                }
+            }
+        }
+    }
+
+    return null
+}
+
+@Suppress("SpreadOperator")
+fun overlapping(p1: List<String>, p2: List<String>): Boolean {
+    if (p1.isEmpty() || p2.isEmpty()) return false
+    val a1 = Regex.simpleMatchToAutomaton(*p1.toTypedArray())
+    val a2 = Regex.simpleMatchToAutomaton(*p2.toTypedArray())
+    return !Operations.isEmpty(Operations.intersection(a1, a2))
+}
+
 /**
  * find policy templates whose index patterns overlap with given template
  *
  * @return map of overlapping template name to its index patterns
  */
-@Suppress("SpreadOperator")
-fun Map<String, ISMTemplate>.findConflictingPolicyTemplates(
+fun Map<String, List<ISMTemplate>>.findConflictingPolicyTemplates(
     candidate: String,
     indexPatterns: List<String>,
     priority: Int
 ): Map<String, List<String>> {
-    val automaton1 = Regex.simpleMatchToAutomaton(*indexPatterns.toTypedArray())
     val overlappingTemplates = mutableMapOf<String, List<String>>()
 
-    // focus on template with same priority
-    this.filter { it.value.priority == priority }
-        .forEach { (policyID, template) ->
-            val automaton2 = Regex.simpleMatchToAutomaton(*template.indexPatterns.toTypedArray())
-            if (!Operations.isEmpty(Operations.intersection(automaton1, automaton2))) {
-                log.info("Existing ism_template for $policyID overlaps candidate $candidate")
-                overlappingTemplates[policyID] = template.indexPatterns
+    this.forEach { (policyID, templateList) ->
+        templateList.filter { it.priority == priority }
+            .map { it.indexPatterns }
+            .forEach {
+                if (overlapping(indexPatterns, it)) {
+                    overlappingTemplates[policyID] = it
+                }
             }
-        }
+    }
     overlappingTemplates.remove(candidate)
-
     return overlappingTemplates
 }

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/opensearchapi/OpenSearchExtensions.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/opensearchapi/OpenSearchExtensions.kt
@@ -113,7 +113,7 @@ fun getUuidsForClosedIndices(state: ClusterState): MutableList<String> {
  */
 @Throws(Exception::class)
 fun getPolicyToTemplateMap(response: SearchResponse, xContentRegistry: NamedXContentRegistry = NamedXContentRegistry.EMPTY):
-    Map<String, ISMTemplate?> {
+    Map<String, List<ISMTemplate>?> {
     return response.hits.hits.map {
         val id = it.id
         val seqNo = it.seqNo

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/settings/ManagedIndexSettings.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/settings/ManagedIndexSettings.kt
@@ -76,6 +76,13 @@ class ManagedIndexSettings {
             Setting.Property.Dynamic
         )
 
+        val AUTO_MANAGE: Setting<Boolean> = Setting.boolSetting(
+            "index.plugins.index_state_management.auto_manage",
+            true,
+            Setting.Property.IndexScope,
+            Setting.Property.Dynamic
+        )
+
         val JOB_INTERVAL: Setting<Int> = Setting.intSetting(
             "plugins.index_state_management.job_interval",
             LegacyOpenDistroManagedIndexSettings.JOB_INTERVAL,

--- a/src/main/kotlin/org/opensearch/indexmanagement/opensearchapi/OpenSearchExtensions.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/opensearchapi/OpenSearchExtensions.kt
@@ -92,11 +92,11 @@ fun XContentBuilder.optionalTimeField(name: String, instant: Instant?): XContent
     return this.timeField(name, "${name}_in_millis", instant.toEpochMilli())
 }
 
-fun XContentBuilder.optionalISMTemplateField(name: String, ismTemplate: ISMTemplate?): XContentBuilder {
-    if (ismTemplate == null) {
+fun XContentBuilder.optionalISMTemplateField(name: String, ismTemplates: List<ISMTemplate>?): XContentBuilder {
+    if (ismTemplates == null) {
         return nullField(name)
     }
-    return this.field(Policy.ISM_TEMPLATE, ismTemplate)
+    return this.field(Policy.ISM_TEMPLATE, ismTemplates.toTypedArray())
 }
 
 /**

--- a/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/IndexStateManagementRestTestCase.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/IndexStateManagementRestTestCase.kt
@@ -508,6 +508,14 @@ abstract class IndexStateManagementRestTestCase : IndexManagementRestTestCase() 
     }
 
     @Suppress("UNCHECKED_CAST")
+    protected fun getIndexAutoManageSetting(indexName: String): Boolean? {
+        val indexSettings = getIndexSettings(indexName) as Map<String, Map<String, Map<String, Any?>>>
+        val autoManageSetting = indexSettings[indexName]!!["settings"]!!["index.plugins.index_state_management.auto_manage"]
+        if (autoManageSetting != null) return (autoManageSetting as String).toBoolean()
+        return null
+    }
+
+    @Suppress("UNCHECKED_CAST")
     protected fun getUuid(indexName: String): String {
         val indexSettings = getIndexSettings(indexName) as Map<String, Map<String, Map<String, Any?>>>
         return indexSettings[indexName]!!["settings"]!!["index.uuid"] as String

--- a/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/TestHelpers.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/TestHelpers.kt
@@ -79,7 +79,7 @@ fun randomPolicy(
     lastUpdatedTime: Instant = Instant.now().truncatedTo(ChronoUnit.MILLIS),
     errorNotification: ErrorNotification? = randomErrorNotification(),
     states: List<State> = List(OpenSearchRestTestCase.randomIntBetween(1, 10)) { randomState() },
-    ismTemplate: ISMTemplate? = null
+    ismTemplate: List<ISMTemplate>? = null
 ): Policy {
     return Policy(
         id = id, schemaVersion = schemaVersion, lastUpdatedTime = lastUpdatedTime,

--- a/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/action/RolloverActionIT.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/action/RolloverActionIT.kt
@@ -364,7 +364,7 @@ class RolloverActionIT : IndexStateManagementRestTestCase() {
             errorNotification = randomErrorNotification(),
             defaultState = states[0].name,
             states = states,
-            ismTemplate = ISMTemplate(listOf(dataStreamName), 100, Instant.now().truncatedTo(ChronoUnit.MILLIS))
+            ismTemplate = listOf(ISMTemplate(listOf(dataStreamName), 100, Instant.now().truncatedTo(ChronoUnit.MILLIS)))
         )
         createPolicy(policy, policyID)
 
@@ -420,7 +420,7 @@ class RolloverActionIT : IndexStateManagementRestTestCase() {
             errorNotification = randomErrorNotification(),
             defaultState = states[0].name,
             states = states,
-            ismTemplate = ISMTemplate(listOf(dataStreamName), 100, Instant.now().truncatedTo(ChronoUnit.MILLIS))
+            ismTemplate = listOf(ISMTemplate(listOf(dataStreamName), 100, Instant.now().truncatedTo(ChronoUnit.MILLIS)))
         )
         createPolicy(policy, policyID)
 

--- a/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/action/RollupActionIT.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/action/RollupActionIT.kt
@@ -126,7 +126,7 @@ class RollupActionIT : IndexStateManagementRestTestCase() {
             errorNotification = randomErrorNotification(),
             defaultState = states[0].name,
             states = states,
-            ismTemplate = ISMTemplate(listOf(dataStreamName), 100, Instant.now().truncatedTo(ChronoUnit.MILLIS))
+            ismTemplate = listOf(ISMTemplate(listOf(dataStreamName), 100, Instant.now().truncatedTo(ChronoUnit.MILLIS)))
         )
         createPolicy(policy, policyID)
 

--- a/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/resthandler/ISMTemplateRestAPIIT.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/resthandler/ISMTemplateRestAPIIT.kt
@@ -55,7 +55,7 @@ class ISMTemplateRestAPIIT : IndexStateManagementRestTestCase() {
     fun `test add template with invalid index pattern`() {
         try {
             val ismTemp = ISMTemplate(listOf(" "), 100, randomInstant())
-            createPolicy(randomPolicy(ismTemplate = ismTemp), policyID1)
+            createPolicy(randomPolicy(ismTemplate = listOf(ismTemp)), policyID1)
             fail("Expect a failure")
         } catch (e: ResponseException) {
             assertEquals("Unexpected RestStatus", RestStatus.BAD_REQUEST, e.response.restStatus())
@@ -65,14 +65,28 @@ class ISMTemplateRestAPIIT : IndexStateManagementRestTestCase() {
         }
     }
 
+    fun `test add template with self-overlapping index pattern`() {
+        try {
+            val ismTemp = ISMTemplate(listOf("ab*"), 100, randomInstant())
+            val ismTemp2 = ISMTemplate(listOf("abc*"), 100, randomInstant())
+            createPolicy(randomPolicy(ismTemplate = listOf(ismTemp, ismTemp2)), policyID1)
+            fail("Expect a failure")
+        } catch (e: ResponseException) {
+            assertEquals("Unexpected RestStatus", RestStatus.BAD_REQUEST, e.response.restStatus())
+            val actualMessage = e.response.asMap()["error"] as Map<String, Any>
+            val expectedReason = "New policy $policyID1 has an ISM template with index pattern [ab*] matching this policy's other ISM templates with index patterns [abc*], please use different priority"
+            assertEquals(expectedReason, actualMessage["reason"])
+        }
+    }
+
     fun `test add template with overlapping index pattern`() {
         try {
             val ismTemp = ISMTemplate(listOf("log*"), 100, randomInstant())
             val ismTemp2 = ISMTemplate(listOf("abc*"), 100, randomInstant())
             val ismTemp3 = ISMTemplate(listOf("*"), 100, randomInstant())
-            createPolicy(randomPolicy(ismTemplate = ismTemp), policyID1)
-            createPolicy(randomPolicy(ismTemplate = ismTemp2), policyID2)
-            createPolicy(randomPolicy(ismTemplate = ismTemp3), policyID3)
+            createPolicy(randomPolicy(ismTemplate = listOf(ismTemp)), policyID1)
+            createPolicy(randomPolicy(ismTemplate = listOf(ismTemp2)), policyID2)
+            createPolicy(randomPolicy(ismTemplate = listOf(ismTemp3)), policyID3)
             fail("Expect a failure")
         } catch (e: ResponseException) {
             assertEquals("Unexpected RestStatus", RestStatus.BAD_REQUEST, e.response.restStatus())
@@ -105,7 +119,7 @@ class ISMTemplateRestAPIIT : IndexStateManagementRestTestCase() {
             errorNotification = randomErrorNotification(),
             defaultState = states[0].name,
             states = states,
-            ismTemplate = ismTemp
+            ismTemplate = listOf(ismTemp)
         )
         createPolicy(policy, policyID)
 

--- a/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/resthandler/RestRemovePolicyActionIT.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/resthandler/RestRemovePolicyActionIT.kt
@@ -188,4 +188,21 @@ class RestRemovePolicyActionIT : IndexStateManagementRestTestCase() {
             assertEquals(null, getPolicyIDOfManagedIndex(indexThree))
         }
     }
+
+    fun `test remove policy update auto_manage setting`() {
+        val index = "movies"
+        val policy = createRandomPolicy()
+        createIndex(index, policy.id)
+        assertEquals("auto manage setting not null at index creation time", null, getIndexAutoManageSetting(index))
+
+        val response = client().makeRequest(
+            POST.toString(),
+            "${RestRemovePolicyAction.REMOVE_POLICY_BASE_URI}/$index"
+        )
+        assertEquals("Unexpected RestStatus", RestStatus.OK, response.restStatus())
+
+        waitFor {
+            assertEquals("auto manage setting not false after removing policy", false, getIndexAutoManageSetting(index))
+        }
+    }
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Backport changes from service side.
1. ISM template field in policy can be list of previous ism_template object.
2. Remove policy API will block the index from being auto managed again.

*CheckList:*
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/index-management/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
