### PR TITLE
Explain response still use old opendistro policy id

### DIFF
--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/transport/action/explain/ExplainAllResponse.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/transport/action/explain/ExplainAllResponse.kt
@@ -32,6 +32,7 @@ import org.opensearch.common.xcontent.ToXContent
 import org.opensearch.common.xcontent.ToXContentObject
 import org.opensearch.common.xcontent.XContentBuilder
 import org.opensearch.indexmanagement.indexstatemanagement.model.ManagedIndexMetaData
+import org.opensearch.indexmanagement.indexstatemanagement.settings.LegacyOpenDistroManagedIndexSettings
 import org.opensearch.indexmanagement.indexstatemanagement.settings.ManagedIndexSettings
 import java.io.IOException
 
@@ -71,6 +72,7 @@ class ExplainAllResponse : ExplainResponse, ToXContentObject {
         builder.startObject()
         indexNames.forEachIndexed { ind, name ->
             builder.startObject(name)
+            builder.field(LegacyOpenDistroManagedIndexSettings.POLICY_ID.key, indexPolicyIDs[ind])
             builder.field(ManagedIndexSettings.POLICY_ID.key, indexPolicyIDs[ind])
             indexMetadatas[ind]?.toXContent(builder, ToXContent.EMPTY_PARAMS)
             builder.field("enabled", enabledState[name])

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/transport/action/explain/ExplainResponse.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/transport/action/explain/ExplainResponse.kt
@@ -33,6 +33,7 @@ import org.opensearch.common.xcontent.ToXContent
 import org.opensearch.common.xcontent.ToXContentObject
 import org.opensearch.common.xcontent.XContentBuilder
 import org.opensearch.indexmanagement.indexstatemanagement.model.ManagedIndexMetaData
+import org.opensearch.indexmanagement.indexstatemanagement.settings.LegacyOpenDistroManagedIndexSettings
 import org.opensearch.indexmanagement.indexstatemanagement.settings.ManagedIndexSettings
 import java.io.IOException
 
@@ -71,6 +72,7 @@ open class ExplainResponse : ActionResponse, ToXContentObject {
         builder.startObject()
         indexNames.forEachIndexed { ind, name ->
             builder.startObject(name)
+            builder.field(LegacyOpenDistroManagedIndexSettings.POLICY_ID.key, indexPolicyIDs[ind])
             builder.field(ManagedIndexSettings.POLICY_ID.key, indexPolicyIDs[ind])
             indexMetadatas[ind]?.toXContent(builder, ToXContent.EMPTY_PARAMS)
             builder.endObject()

--- a/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/IndexStateManagementRestTestCase.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/IndexStateManagementRestTestCase.kt
@@ -67,6 +67,7 @@ import org.opensearch.indexmanagement.indexstatemanagement.model.managedindexmet
 import org.opensearch.indexmanagement.indexstatemanagement.model.managedindexmetadata.StateMetaData
 import org.opensearch.indexmanagement.indexstatemanagement.model.managedindexmetadata.StepMetaData
 import org.opensearch.indexmanagement.indexstatemanagement.resthandler.RestExplainAction
+import org.opensearch.indexmanagement.indexstatemanagement.settings.LegacyOpenDistroManagedIndexSettings
 import org.opensearch.indexmanagement.indexstatemanagement.settings.ManagedIndexSettings
 import org.opensearch.indexmanagement.indexstatemanagement.util.FAILED_INDICES
 import org.opensearch.indexmanagement.indexstatemanagement.util.FAILURES
@@ -247,7 +248,7 @@ abstract class IndexStateManagementRestTestCase : IndexManagementRestTestCase() 
     @Suppress("UNCHECKED_CAST")
     protected fun getPolicyFromIndex(index: String): String? {
         val indexSettings = getIndexSettings(index) as Map<String, Map<String, Map<String, Any?>>>
-        return indexSettings[index]!!["settings"]!![ManagedIndexSettings.POLICY_ID.key] as? String
+        return indexSettings[index]!!["settings"]!![LegacyOpenDistroManagedIndexSettings.POLICY_ID.key] as? String
     }
 
     protected fun getPolicyIDOfManagedIndex(index: String): String? {

--- a/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/IndexStateManagementRestTestCase.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/IndexStateManagementRestTestCase.kt
@@ -67,7 +67,6 @@ import org.opensearch.indexmanagement.indexstatemanagement.model.managedindexmet
 import org.opensearch.indexmanagement.indexstatemanagement.model.managedindexmetadata.StateMetaData
 import org.opensearch.indexmanagement.indexstatemanagement.model.managedindexmetadata.StepMetaData
 import org.opensearch.indexmanagement.indexstatemanagement.resthandler.RestExplainAction
-import org.opensearch.indexmanagement.indexstatemanagement.settings.LegacyOpenDistroManagedIndexSettings
 import org.opensearch.indexmanagement.indexstatemanagement.settings.ManagedIndexSettings
 import org.opensearch.indexmanagement.indexstatemanagement.util.FAILED_INDICES
 import org.opensearch.indexmanagement.indexstatemanagement.util.FAILURES
@@ -92,6 +91,9 @@ import java.time.Instant
 import java.util.Locale
 
 abstract class IndexStateManagementRestTestCase : IndexManagementRestTestCase() {
+
+    val explainResponseOpendistroPolicyIdSetting = "index.opendistro.index_state_management.policy_id"
+    val explainResponseOpenSearchPolicyIdSetting = "index.plugins.index_state_management.policy_id"
 
     protected fun createPolicy(
         policy: Policy,
@@ -243,12 +245,6 @@ abstract class IndexStateManagementRestTestCase : IndexManagementRestTestCase() 
 
     protected fun removePolicyFromIndex(index: String) {
         client().makeRequest("POST", "/_opendistro/_ism/remove/$index")
-    }
-
-    @Suppress("UNCHECKED_CAST")
-    protected fun getPolicyFromIndex(index: String): String? {
-        val indexSettings = getIndexSettings(index) as Map<String, Map<String, Map<String, Any?>>>
-        return indexSettings[index]!!["settings"]!![LegacyOpenDistroManagedIndexSettings.POLICY_ID.key] as? String
     }
 
     protected fun getPolicyIDOfManagedIndex(index: String): String? {

--- a/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/action/ActionRetryIT.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/action/ActionRetryIT.kt
@@ -32,7 +32,7 @@ import org.opensearch.indexmanagement.indexstatemanagement.model.managedindexmet
 import org.opensearch.indexmanagement.indexstatemanagement.model.managedindexmetadata.PolicyRetryInfoMetaData
 import org.opensearch.indexmanagement.indexstatemanagement.model.managedindexmetadata.StateMetaData
 import org.opensearch.indexmanagement.indexstatemanagement.model.managedindexmetadata.StepMetaData
-import org.opensearch.indexmanagement.indexstatemanagement.settings.ManagedIndexSettings
+import org.opensearch.indexmanagement.indexstatemanagement.settings.LegacyOpenDistroManagedIndexSettings
 import org.opensearch.indexmanagement.indexstatemanagement.step.Step
 import org.opensearch.indexmanagement.indexstatemanagement.step.rollover.AttemptRolloverStep
 import org.opensearch.indexmanagement.waitFor
@@ -159,7 +159,7 @@ class ActionRetryIT : IndexStateManagementRestTestCase() {
             assertPredicatesOnMetaData(
                 listOf(
                     indexName to listOf(
-                        ManagedIndexSettings.POLICY_ID.key to policyID::equals,
+                        LegacyOpenDistroManagedIndexSettings.POLICY_ID.key to policyID::equals,
                         ManagedIndexMetaData.INDEX to managedIndexConfig.index::equals,
                         ManagedIndexMetaData.INDEX_UUID to managedIndexConfig.indexUuid::equals,
                         ManagedIndexMetaData.POLICY_ID to managedIndexConfig.policyID::equals,

--- a/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/action/ActionRetryIT.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/action/ActionRetryIT.kt
@@ -32,7 +32,6 @@ import org.opensearch.indexmanagement.indexstatemanagement.model.managedindexmet
 import org.opensearch.indexmanagement.indexstatemanagement.model.managedindexmetadata.PolicyRetryInfoMetaData
 import org.opensearch.indexmanagement.indexstatemanagement.model.managedindexmetadata.StateMetaData
 import org.opensearch.indexmanagement.indexstatemanagement.model.managedindexmetadata.StepMetaData
-import org.opensearch.indexmanagement.indexstatemanagement.settings.LegacyOpenDistroManagedIndexSettings
 import org.opensearch.indexmanagement.indexstatemanagement.step.Step
 import org.opensearch.indexmanagement.indexstatemanagement.step.rollover.AttemptRolloverStep
 import org.opensearch.indexmanagement.waitFor
@@ -159,7 +158,8 @@ class ActionRetryIT : IndexStateManagementRestTestCase() {
             assertPredicatesOnMetaData(
                 listOf(
                     indexName to listOf(
-                        LegacyOpenDistroManagedIndexSettings.POLICY_ID.key to policyID::equals,
+                        explainResponseOpendistroPolicyIdSetting to policyID::equals,
+                        explainResponseOpenSearchPolicyIdSetting to policyID::equals,
                         ManagedIndexMetaData.INDEX to managedIndexConfig.index::equals,
                         ManagedIndexMetaData.INDEX_UUID to managedIndexConfig.indexUuid::equals,
                         ManagedIndexMetaData.POLICY_ID to managedIndexConfig.policyID::equals,

--- a/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/coordinator/ManagedIndexCoordinatorIT.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/coordinator/ManagedIndexCoordinatorIT.kt
@@ -40,7 +40,6 @@ import org.opensearch.indexmanagement.indexstatemanagement.model.action.ForceMer
 import org.opensearch.indexmanagement.indexstatemanagement.model.action.RolloverActionConfig
 import org.opensearch.indexmanagement.indexstatemanagement.randomErrorNotification
 import org.opensearch.indexmanagement.indexstatemanagement.resthandler.RestExplainAction
-import org.opensearch.indexmanagement.indexstatemanagement.settings.LegacyOpenDistroManagedIndexSettings
 import org.opensearch.indexmanagement.indexstatemanagement.settings.ManagedIndexSettings
 import org.opensearch.indexmanagement.indexstatemanagement.step.forcemerge.WaitForForceMergeStep
 import org.opensearch.indexmanagement.indexstatemanagement.step.rollover.AttemptRolloverStep
@@ -128,7 +127,9 @@ class ManagedIndexCoordinatorIT : IndexStateManagementRestTestCase() {
             assertPredicatesOnMetaData(
                 listOf(
                     index to listOf(
-                        LegacyOpenDistroManagedIndexSettings.POLICY_ID.key to fun(policyID: Any?): Boolean =
+                        explainResponseOpendistroPolicyIdSetting to fun(policyID: Any?): Boolean =
+                            policyID == null,
+                        explainResponseOpenSearchPolicyIdSetting to fun(policyID: Any?): Boolean =
                             policyID == null
                     )
                 ),

--- a/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/coordinator/ManagedIndexCoordinatorIT.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/coordinator/ManagedIndexCoordinatorIT.kt
@@ -269,7 +269,9 @@ class ManagedIndexCoordinatorIT : IndexStateManagementRestTestCase() {
         }
 
         // TODO seen version conflict flaky failure here
-        // could be same reason as the test failure in ChangePolicyActionIT
+        logger.info("Config we use on update: $enabledManagedIndexConfig")
+        logger.info("Latest config: ${getExistingManagedIndexConfig(indexName)}")
+        // seems the config from above waitFor, after that, config got updated again?
         updateManagedIndexConfigStartTime(enabledManagedIndexConfig)
 
         waitFor {

--- a/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/coordinator/ManagedIndexCoordinatorIT.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/coordinator/ManagedIndexCoordinatorIT.kt
@@ -40,6 +40,7 @@ import org.opensearch.indexmanagement.indexstatemanagement.model.action.ForceMer
 import org.opensearch.indexmanagement.indexstatemanagement.model.action.RolloverActionConfig
 import org.opensearch.indexmanagement.indexstatemanagement.randomErrorNotification
 import org.opensearch.indexmanagement.indexstatemanagement.resthandler.RestExplainAction
+import org.opensearch.indexmanagement.indexstatemanagement.settings.LegacyOpenDistroManagedIndexSettings
 import org.opensearch.indexmanagement.indexstatemanagement.settings.ManagedIndexSettings
 import org.opensearch.indexmanagement.indexstatemanagement.step.forcemerge.WaitForForceMergeStep
 import org.opensearch.indexmanagement.indexstatemanagement.step.rollover.AttemptRolloverStep
@@ -127,7 +128,7 @@ class ManagedIndexCoordinatorIT : IndexStateManagementRestTestCase() {
             assertPredicatesOnMetaData(
                 listOf(
                     index to listOf(
-                        ManagedIndexSettings.POLICY_ID.key to fun(policyID: Any?): Boolean =
+                        LegacyOpenDistroManagedIndexSettings.POLICY_ID.key to fun(policyID: Any?): Boolean =
                             policyID == null
                     )
                 ),

--- a/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/coordinator/ManagedIndexCoordinatorTests.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/coordinator/ManagedIndexCoordinatorTests.kt
@@ -42,6 +42,7 @@ import org.opensearch.common.xcontent.NamedXContentRegistry
 import org.opensearch.indexmanagement.IndexManagementIndices
 import org.opensearch.indexmanagement.indexstatemanagement.ManagedIndexCoordinator
 import org.opensearch.indexmanagement.indexstatemanagement.MetadataService
+import org.opensearch.indexmanagement.indexstatemanagement.settings.LegacyOpenDistroManagedIndexSettings
 import org.opensearch.indexmanagement.indexstatemanagement.settings.ManagedIndexSettings
 import org.opensearch.test.ClusterServiceUtils
 import org.opensearch.test.OpenSearchTestCase
@@ -142,7 +143,7 @@ class ManagedIndexCoordinatorTests : OpenSearchAllocationTestCase() {
     private fun createIndexMetaData(indexName: String, replicaNumber: Int, shardNumber: Int, policyID: String?): IndexMetadata.Builder {
         val defaultSettings = Settings.builder()
             .put(IndexMetadata.SETTING_VERSION_CREATED, Version.CURRENT)
-            .put(ManagedIndexSettings.POLICY_ID.key, policyID)
+            .put(LegacyOpenDistroManagedIndexSettings.POLICY_ID.key, policyID)
             .put(SETTING_INDEX_UUID, randomAlphaOfLength(20))
             .build()
         return IndexMetadata.Builder(indexName)

--- a/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/coordinator/ManagedIndexCoordinatorTests.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/coordinator/ManagedIndexCoordinatorTests.kt
@@ -31,8 +31,6 @@ import org.mockito.Mockito
 import org.opensearch.Version
 import org.opensearch.client.Client
 import org.opensearch.cluster.OpenSearchAllocationTestCase
-import org.opensearch.cluster.metadata.IndexMetadata
-import org.opensearch.cluster.metadata.IndexMetadata.SETTING_INDEX_UUID
 import org.opensearch.cluster.node.DiscoveryNode
 import org.opensearch.cluster.service.ClusterService
 import org.opensearch.common.settings.ClusterSettings
@@ -42,7 +40,6 @@ import org.opensearch.common.xcontent.NamedXContentRegistry
 import org.opensearch.indexmanagement.IndexManagementIndices
 import org.opensearch.indexmanagement.indexstatemanagement.ManagedIndexCoordinator
 import org.opensearch.indexmanagement.indexstatemanagement.MetadataService
-import org.opensearch.indexmanagement.indexstatemanagement.settings.LegacyOpenDistroManagedIndexSettings
 import org.opensearch.indexmanagement.indexstatemanagement.settings.ManagedIndexSettings
 import org.opensearch.test.ClusterServiceUtils
 import org.opensearch.test.OpenSearchTestCase
@@ -138,18 +135,6 @@ class ManagedIndexCoordinatorTests : OpenSearchAllocationTestCase() {
         coordinator.initBackgroundSweep()
         Mockito.verify(cancellable).cancel()
         Mockito.verify(threadPool, Mockito.times(2)).scheduleWithFixedDelay(Mockito.any(), Mockito.any(), Mockito.anyString())
-    }
-
-    private fun createIndexMetaData(indexName: String, replicaNumber: Int, shardNumber: Int, policyID: String?): IndexMetadata.Builder {
-        val defaultSettings = Settings.builder()
-            .put(IndexMetadata.SETTING_VERSION_CREATED, Version.CURRENT)
-            .put(LegacyOpenDistroManagedIndexSettings.POLICY_ID.key, policyID)
-            .put(SETTING_INDEX_UUID, randomAlphaOfLength(20))
-            .build()
-        return IndexMetadata.Builder(indexName)
-            .settings(defaultSettings)
-            .numberOfReplicas(replicaNumber)
-            .numberOfShards(shardNumber)
     }
 
     private fun <T> any(): T {

--- a/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/resthandler/ISMTemplateRestAPIIT.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/resthandler/ISMTemplateRestAPIIT.kt
@@ -35,7 +35,7 @@ import org.opensearch.indexmanagement.indexstatemanagement.model.State
 import org.opensearch.indexmanagement.indexstatemanagement.model.action.ReadOnlyActionConfig
 import org.opensearch.indexmanagement.indexstatemanagement.randomErrorNotification
 import org.opensearch.indexmanagement.indexstatemanagement.randomPolicy
-import org.opensearch.indexmanagement.indexstatemanagement.settings.ManagedIndexSettings
+import org.opensearch.indexmanagement.indexstatemanagement.settings.LegacyOpenDistroManagedIndexSettings
 import org.opensearch.indexmanagement.indexstatemanagement.util.INDEX_HIDDEN
 import org.opensearch.indexmanagement.randomInstant
 import org.opensearch.indexmanagement.waitFor
@@ -135,7 +135,7 @@ class ISMTemplateRestAPIIT : IndexStateManagementRestTestCase() {
 
         // only index create after template can be managed
         assertPredicatesOnMetaData(
-            listOf(indexName1 to listOf(ManagedIndexSettings.POLICY_ID.key to fun(policyID: Any?): Boolean = policyID == null)),
+            listOf(indexName1 to listOf(LegacyOpenDistroManagedIndexSettings.POLICY_ID.key to fun(policyID: Any?): Boolean = policyID == null)),
             getExplainMap(indexName1),
             true
         )
@@ -143,7 +143,7 @@ class ISMTemplateRestAPIIT : IndexStateManagementRestTestCase() {
 
         // hidden index will not be manage
         assertPredicatesOnMetaData(
-            listOf(indexName1 to listOf(ManagedIndexSettings.POLICY_ID.key to fun(policyID: Any?): Boolean = policyID == null)),
+            listOf(indexName1 to listOf(LegacyOpenDistroManagedIndexSettings.POLICY_ID.key to fun(policyID: Any?): Boolean = policyID == null)),
             getExplainMap(indexName1),
             true
         )

--- a/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/resthandler/ISMTemplateRestAPIIT.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/resthandler/ISMTemplateRestAPIIT.kt
@@ -35,7 +35,6 @@ import org.opensearch.indexmanagement.indexstatemanagement.model.State
 import org.opensearch.indexmanagement.indexstatemanagement.model.action.ReadOnlyActionConfig
 import org.opensearch.indexmanagement.indexstatemanagement.randomErrorNotification
 import org.opensearch.indexmanagement.indexstatemanagement.randomPolicy
-import org.opensearch.indexmanagement.indexstatemanagement.settings.LegacyOpenDistroManagedIndexSettings
 import org.opensearch.indexmanagement.indexstatemanagement.util.INDEX_HIDDEN
 import org.opensearch.indexmanagement.randomInstant
 import org.opensearch.indexmanagement.waitFor
@@ -135,7 +134,12 @@ class ISMTemplateRestAPIIT : IndexStateManagementRestTestCase() {
 
         // only index create after template can be managed
         assertPredicatesOnMetaData(
-            listOf(indexName1 to listOf(LegacyOpenDistroManagedIndexSettings.POLICY_ID.key to fun(policyID: Any?): Boolean = policyID == null)),
+            listOf(
+                indexName1 to listOf(
+                    explainResponseOpendistroPolicyIdSetting to fun(policyID: Any?): Boolean = policyID == null,
+                    explainResponseOpenSearchPolicyIdSetting to fun(policyID: Any?): Boolean = policyID == null
+                )
+            ),
             getExplainMap(indexName1),
             true
         )
@@ -143,7 +147,12 @@ class ISMTemplateRestAPIIT : IndexStateManagementRestTestCase() {
 
         // hidden index will not be manage
         assertPredicatesOnMetaData(
-            listOf(indexName1 to listOf(LegacyOpenDistroManagedIndexSettings.POLICY_ID.key to fun(policyID: Any?): Boolean = policyID == null)),
+            listOf(
+                indexName1 to listOf(
+                    explainResponseOpendistroPolicyIdSetting to fun(policyID: Any?): Boolean = policyID == null,
+                    explainResponseOpenSearchPolicyIdSetting to fun(policyID: Any?): Boolean = policyID == null
+                )
+            ),
             getExplainMap(indexName1),
             true
         )

--- a/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/resthandler/RestChangePolicyActionIT.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/resthandler/RestChangePolicyActionIT.kt
@@ -29,6 +29,7 @@ package org.opensearch.indexmanagement.indexstatemanagement.resthandler
 import org.junit.Before
 import org.opensearch.client.ResponseException
 import org.opensearch.common.settings.Settings
+import org.opensearch.indexmanagement.IndexManagementPlugin.Companion.INDEX_MANAGEMENT_INDEX
 import org.opensearch.indexmanagement.indexstatemanagement.IndexStateManagementRestTestCase
 import org.opensearch.indexmanagement.indexstatemanagement.model.ChangePolicy
 import org.opensearch.indexmanagement.indexstatemanagement.model.ManagedIndexConfig
@@ -108,6 +109,7 @@ class RestChangePolicyActionIT : IndexStateManagementRestTestCase() {
     }
 
     fun `test nonexistent ism config index`() {
+        deleteIndex(INDEX_MANAGEMENT_INDEX)
         try {
             val changePolicy = ChangePolicy("some_id", null, emptyList(), false)
             client().makeRequest(
@@ -493,7 +495,10 @@ class RestChangePolicyActionIT : IndexStateManagementRestTestCase() {
             FAILED_INDICES to emptyList<Any>(),
             UPDATED_INDICES to 1
         )
-        assertAffectedIndicesResponseIsEqual(expectedResponse, response.asMap())
+        // TODO flaky part, log for more info
+        val responseMap = response.asMap()
+        logger.info("Change policy response: $responseMap")
+        assertAffectedIndicesResponseIsEqual(expectedResponse, responseMap)
 
         waitFor {
             // The first managed index should not have a change policy added to it as it should of been filtered out from the states filter

--- a/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/resthandler/RestChangePolicyActionIT.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/resthandler/RestChangePolicyActionIT.kt
@@ -47,7 +47,6 @@ import org.opensearch.indexmanagement.indexstatemanagement.randomPolicy
 import org.opensearch.indexmanagement.indexstatemanagement.randomReplicaCountActionConfig
 import org.opensearch.indexmanagement.indexstatemanagement.randomState
 import org.opensearch.indexmanagement.indexstatemanagement.resthandler.RestChangePolicyAction.Companion.INDEX_NOT_MANAGED
-import org.opensearch.indexmanagement.indexstatemanagement.settings.LegacyOpenDistroManagedIndexSettings
 import org.opensearch.indexmanagement.indexstatemanagement.step.rollover.AttemptRolloverStep
 import org.opensearch.indexmanagement.indexstatemanagement.util.FAILED_INDICES
 import org.opensearch.indexmanagement.indexstatemanagement.util.FAILURES
@@ -109,7 +108,7 @@ class RestChangePolicyActionIT : IndexStateManagementRestTestCase() {
     }
 
     fun `test nonexistent ism config index`() {
-        deleteIndex(INDEX_MANAGEMENT_INDEX)
+        if (indexExists(INDEX_MANAGEMENT_INDEX)) deleteIndex(INDEX_MANAGEMENT_INDEX)
         try {
             val changePolicy = ChangePolicy("some_id", null, emptyList(), false)
             client().makeRequest(
@@ -342,7 +341,8 @@ class RestChangePolicyActionIT : IndexStateManagementRestTestCase() {
             assertPredicatesOnMetaData(
                 listOf(
                     index to listOf(
-                        LegacyOpenDistroManagedIndexSettings.POLICY_ID.key to policy.id::equals,
+                        explainResponseOpendistroPolicyIdSetting to policy.id::equals,
+                        explainResponseOpenSearchPolicyIdSetting to policy.id::equals,
                         ManagedIndexMetaData.INDEX to executedManagedIndexConfig.index::equals,
                         ManagedIndexMetaData.INDEX_UUID to executedManagedIndexConfig.indexUuid::equals,
                         ManagedIndexMetaData.POLICY_ID to executedManagedIndexConfig.policyID::equals,
@@ -386,7 +386,8 @@ class RestChangePolicyActionIT : IndexStateManagementRestTestCase() {
             assertPredicatesOnMetaData(
                 listOf(
                     index to listOf(
-                        LegacyOpenDistroManagedIndexSettings.POLICY_ID.key to policy.id::equals,
+                        explainResponseOpendistroPolicyIdSetting to policy.id::equals,
+                        explainResponseOpenSearchPolicyIdSetting to policy.id::equals,
                         ManagedIndexMetaData.INDEX to executedManagedIndexConfig.index::equals,
                         ManagedIndexMetaData.INDEX_UUID to executedManagedIndexConfig.indexUuid::equals,
                         ManagedIndexMetaData.POLICY_ID to executedManagedIndexConfig.policyID::equals,
@@ -424,7 +425,8 @@ class RestChangePolicyActionIT : IndexStateManagementRestTestCase() {
             assertPredicatesOnMetaData(
                 listOf(
                     index to listOf(
-                        LegacyOpenDistroManagedIndexSettings.POLICY_ID.key to newPolicy.id::equals,
+                        explainResponseOpendistroPolicyIdSetting to newPolicy.id::equals,
+                        explainResponseOpenSearchPolicyIdSetting to newPolicy.id::equals,
                         ManagedIndexMetaData.INDEX to changedManagedIndexConfig.index::equals,
                         ManagedIndexMetaData.INDEX_UUID to changedManagedIndexConfig.indexUuid::equals,
                         ManagedIndexMetaData.POLICY_ID to changedManagedIndexConfig.policyID::equals,

--- a/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/resthandler/RestChangePolicyActionIT.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/resthandler/RestChangePolicyActionIT.kt
@@ -47,7 +47,7 @@ import org.opensearch.indexmanagement.indexstatemanagement.randomPolicy
 import org.opensearch.indexmanagement.indexstatemanagement.randomReplicaCountActionConfig
 import org.opensearch.indexmanagement.indexstatemanagement.randomState
 import org.opensearch.indexmanagement.indexstatemanagement.resthandler.RestChangePolicyAction.Companion.INDEX_NOT_MANAGED
-import org.opensearch.indexmanagement.indexstatemanagement.settings.ManagedIndexSettings
+import org.opensearch.indexmanagement.indexstatemanagement.settings.LegacyOpenDistroManagedIndexSettings
 import org.opensearch.indexmanagement.indexstatemanagement.step.rollover.AttemptRolloverStep
 import org.opensearch.indexmanagement.indexstatemanagement.util.FAILED_INDICES
 import org.opensearch.indexmanagement.indexstatemanagement.util.FAILURES
@@ -342,7 +342,7 @@ class RestChangePolicyActionIT : IndexStateManagementRestTestCase() {
             assertPredicatesOnMetaData(
                 listOf(
                     index to listOf(
-                        ManagedIndexSettings.POLICY_ID.key to policy.id::equals,
+                        LegacyOpenDistroManagedIndexSettings.POLICY_ID.key to policy.id::equals,
                         ManagedIndexMetaData.INDEX to executedManagedIndexConfig.index::equals,
                         ManagedIndexMetaData.INDEX_UUID to executedManagedIndexConfig.indexUuid::equals,
                         ManagedIndexMetaData.POLICY_ID to executedManagedIndexConfig.policyID::equals,
@@ -386,7 +386,7 @@ class RestChangePolicyActionIT : IndexStateManagementRestTestCase() {
             assertPredicatesOnMetaData(
                 listOf(
                     index to listOf(
-                        ManagedIndexSettings.POLICY_ID.key to policy.id::equals,
+                        LegacyOpenDistroManagedIndexSettings.POLICY_ID.key to policy.id::equals,
                         ManagedIndexMetaData.INDEX to executedManagedIndexConfig.index::equals,
                         ManagedIndexMetaData.INDEX_UUID to executedManagedIndexConfig.indexUuid::equals,
                         ManagedIndexMetaData.POLICY_ID to executedManagedIndexConfig.policyID::equals,
@@ -424,7 +424,7 @@ class RestChangePolicyActionIT : IndexStateManagementRestTestCase() {
             assertPredicatesOnMetaData(
                 listOf(
                     index to listOf(
-                        ManagedIndexSettings.POLICY_ID.key to newPolicy.id::equals,
+                        LegacyOpenDistroManagedIndexSettings.POLICY_ID.key to newPolicy.id::equals,
                         ManagedIndexMetaData.INDEX to changedManagedIndexConfig.index::equals,
                         ManagedIndexMetaData.INDEX_UUID to changedManagedIndexConfig.indexUuid::equals,
                         ManagedIndexMetaData.POLICY_ID to changedManagedIndexConfig.policyID::equals,

--- a/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/resthandler/RestChangePolicyActionIT.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/resthandler/RestChangePolicyActionIT.kt
@@ -470,11 +470,15 @@ class RestChangePolicyActionIT : IndexStateManagementRestTestCase() {
         // speed up to third execution where we transition to second state
         updateManagedIndexConfigStartTime(firstManagedIndexConfig)
 
+        logger.info("time before check")
         waitFor {
-            getExplainManagedIndexMetaData(firstIndex).let {
-                assertEquals(it.copy(stateMetaData = it.stateMetaData?.copy(name = secondState.name)), it)
-            }
+//            getExplainManagedIndexMetaData(firstIndex).let {
+//                assertEquals(it.copy(stateMetaData = it.stateMetaData?.copy(name = secondState.name)), it)
+//            }
+            assertEquals(secondState.name, getExplainManagedIndexMetaData(firstIndex).stateMetaData?.name)
+            logger.info("Explain firstIndex before change policy: ${getExplainManagedIndexMetaData(firstIndex)}")
         }
+        logger.info("time after check")
 
         // create second index
         val (secondIndex) = createIndex("second_index", policy.id)

--- a/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/resthandler/RestExplainActionIT.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/resthandler/RestExplainActionIT.kt
@@ -30,7 +30,6 @@ import org.opensearch.indexmanagement.indexstatemanagement.IndexStateManagementR
 import org.opensearch.indexmanagement.indexstatemanagement.model.ManagedIndexMetaData
 import org.opensearch.indexmanagement.indexstatemanagement.model.managedindexmetadata.PolicyRetryInfoMetaData
 import org.opensearch.indexmanagement.indexstatemanagement.model.managedindexmetadata.StateMetaData
-import org.opensearch.indexmanagement.indexstatemanagement.settings.LegacyOpenDistroManagedIndexSettings
 import org.opensearch.indexmanagement.waitFor
 import java.time.Instant
 import java.util.Locale
@@ -44,7 +43,8 @@ class RestExplainActionIT : IndexStateManagementRestTestCase() {
         createIndex(indexName, null)
         val expected = mapOf(
             indexName to mapOf<String, String?>(
-                LegacyOpenDistroManagedIndexSettings.POLICY_ID.key to null
+                explainResponseOpendistroPolicyIdSetting to null,
+                explainResponseOpenSearchPolicyIdSetting to null
             )
         )
         assertResponseMap(expected, getExplainMap(indexName))
@@ -69,13 +69,15 @@ class RestExplainActionIT : IndexStateManagementRestTestCase() {
 
         val expected = mapOf(
             indexName1 to mapOf<String, Any>(
-                LegacyOpenDistroManagedIndexSettings.POLICY_ID.key to policy.id,
+                explainResponseOpendistroPolicyIdSetting to policy.id,
+                explainResponseOpenSearchPolicyIdSetting to policy.id,
                 "index" to indexName1,
                 "index_uuid" to getUuid(indexName1),
                 "policy_id" to policy.id
             ),
             indexName2 to mapOf<String, Any?>(
-                LegacyOpenDistroManagedIndexSettings.POLICY_ID.key to null
+                explainResponseOpendistroPolicyIdSetting to null,
+                explainResponseOpenSearchPolicyIdSetting to null
             )
         )
         waitFor {
@@ -93,7 +95,8 @@ class RestExplainActionIT : IndexStateManagementRestTestCase() {
 
         val expected = mapOf(
             indexName1 to mapOf<String, Any>(
-                LegacyOpenDistroManagedIndexSettings.POLICY_ID.key to policy.id,
+                explainResponseOpendistroPolicyIdSetting to policy.id,
+                explainResponseOpenSearchPolicyIdSetting to policy.id,
                 "index" to indexName1,
                 "index_uuid" to getUuid(indexName1),
                 "policy_id" to policy.id,
@@ -116,19 +119,22 @@ class RestExplainActionIT : IndexStateManagementRestTestCase() {
         createIndex(indexName3, null)
         val expected = mapOf(
             indexName1 to mapOf<String, Any>(
-                LegacyOpenDistroManagedIndexSettings.POLICY_ID.key to policy.id,
+                explainResponseOpendistroPolicyIdSetting to policy.id,
+                explainResponseOpenSearchPolicyIdSetting to policy.id,
                 "index" to indexName1,
                 "index_uuid" to getUuid(indexName1),
                 "policy_id" to policy.id
             ),
             indexName2 to mapOf<String, Any>(
-                LegacyOpenDistroManagedIndexSettings.POLICY_ID.key to policy.id,
+                explainResponseOpendistroPolicyIdSetting to policy.id,
+                explainResponseOpenSearchPolicyIdSetting to policy.id,
                 "index" to indexName2,
                 "index_uuid" to getUuid(indexName2),
                 "policy_id" to policy.id
             ),
             indexName3 to mapOf<String, Any?>(
-                LegacyOpenDistroManagedIndexSettings.POLICY_ID.key to null
+                explainResponseOpendistroPolicyIdSetting to null,
+                explainResponseOpenSearchPolicyIdSetting to null
             )
         )
         waitFor {
@@ -151,7 +157,8 @@ class RestExplainActionIT : IndexStateManagementRestTestCase() {
             assertPredicatesOnMetaData(
                 listOf(
                     indexName to listOf(
-                        LegacyOpenDistroManagedIndexSettings.POLICY_ID.key to policy.id::equals,
+                        explainResponseOpendistroPolicyIdSetting to policy.id::equals,
+                        explainResponseOpenSearchPolicyIdSetting to policy.id::equals,
                         ManagedIndexMetaData.INDEX to managedIndexConfig.index::equals,
                         ManagedIndexMetaData.INDEX_UUID to managedIndexConfig.indexUuid::equals,
                         ManagedIndexMetaData.POLICY_ID to managedIndexConfig.policyID::equals,
@@ -186,7 +193,8 @@ class RestExplainActionIT : IndexStateManagementRestTestCase() {
             assertPredicatesOnMetaData(
                 listOf(
                     indexName to listOf(
-                        LegacyOpenDistroManagedIndexSettings.POLICY_ID.key to policyID::equals,
+                        explainResponseOpendistroPolicyIdSetting to policyID::equals,
+                        explainResponseOpenSearchPolicyIdSetting to policyID::equals,
                         ManagedIndexMetaData.INDEX to managedIndexConfig.index::equals,
                         ManagedIndexMetaData.INDEX_UUID to managedIndexConfig.indexUuid::equals,
                         ManagedIndexMetaData.POLICY_ID to managedIndexConfig.policyID::equals,

--- a/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/resthandler/RestExplainActionIT.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/resthandler/RestExplainActionIT.kt
@@ -30,7 +30,7 @@ import org.opensearch.indexmanagement.indexstatemanagement.IndexStateManagementR
 import org.opensearch.indexmanagement.indexstatemanagement.model.ManagedIndexMetaData
 import org.opensearch.indexmanagement.indexstatemanagement.model.managedindexmetadata.PolicyRetryInfoMetaData
 import org.opensearch.indexmanagement.indexstatemanagement.model.managedindexmetadata.StateMetaData
-import org.opensearch.indexmanagement.indexstatemanagement.settings.ManagedIndexSettings
+import org.opensearch.indexmanagement.indexstatemanagement.settings.LegacyOpenDistroManagedIndexSettings
 import org.opensearch.indexmanagement.waitFor
 import java.time.Instant
 import java.util.Locale
@@ -44,7 +44,7 @@ class RestExplainActionIT : IndexStateManagementRestTestCase() {
         createIndex(indexName, null)
         val expected = mapOf(
             indexName to mapOf<String, String?>(
-                ManagedIndexSettings.POLICY_ID.key to null
+                LegacyOpenDistroManagedIndexSettings.POLICY_ID.key to null
             )
         )
         assertResponseMap(expected, getExplainMap(indexName))
@@ -69,13 +69,13 @@ class RestExplainActionIT : IndexStateManagementRestTestCase() {
 
         val expected = mapOf(
             indexName1 to mapOf<String, Any>(
-                ManagedIndexSettings.POLICY_ID.key to policy.id,
+                LegacyOpenDistroManagedIndexSettings.POLICY_ID.key to policy.id,
                 "index" to indexName1,
                 "index_uuid" to getUuid(indexName1),
                 "policy_id" to policy.id
             ),
             indexName2 to mapOf<String, Any?>(
-                ManagedIndexSettings.POLICY_ID.key to null
+                LegacyOpenDistroManagedIndexSettings.POLICY_ID.key to null
             )
         )
         waitFor {
@@ -93,7 +93,7 @@ class RestExplainActionIT : IndexStateManagementRestTestCase() {
 
         val expected = mapOf(
             indexName1 to mapOf<String, Any>(
-                ManagedIndexSettings.POLICY_ID.key to policy.id,
+                LegacyOpenDistroManagedIndexSettings.POLICY_ID.key to policy.id,
                 "index" to indexName1,
                 "index_uuid" to getUuid(indexName1),
                 "policy_id" to policy.id,
@@ -116,19 +116,19 @@ class RestExplainActionIT : IndexStateManagementRestTestCase() {
         createIndex(indexName3, null)
         val expected = mapOf(
             indexName1 to mapOf<String, Any>(
-                ManagedIndexSettings.POLICY_ID.key to policy.id,
+                LegacyOpenDistroManagedIndexSettings.POLICY_ID.key to policy.id,
                 "index" to indexName1,
                 "index_uuid" to getUuid(indexName1),
                 "policy_id" to policy.id
             ),
             indexName2 to mapOf<String, Any>(
-                ManagedIndexSettings.POLICY_ID.key to policy.id,
+                LegacyOpenDistroManagedIndexSettings.POLICY_ID.key to policy.id,
                 "index" to indexName2,
                 "index_uuid" to getUuid(indexName2),
                 "policy_id" to policy.id
             ),
             indexName3 to mapOf<String, Any?>(
-                ManagedIndexSettings.POLICY_ID.key to null
+                LegacyOpenDistroManagedIndexSettings.POLICY_ID.key to null
             )
         )
         waitFor {
@@ -151,7 +151,7 @@ class RestExplainActionIT : IndexStateManagementRestTestCase() {
             assertPredicatesOnMetaData(
                 listOf(
                     indexName to listOf(
-                        ManagedIndexSettings.POLICY_ID.key to policy.id::equals,
+                        LegacyOpenDistroManagedIndexSettings.POLICY_ID.key to policy.id::equals,
                         ManagedIndexMetaData.INDEX to managedIndexConfig.index::equals,
                         ManagedIndexMetaData.INDEX_UUID to managedIndexConfig.indexUuid::equals,
                         ManagedIndexMetaData.POLICY_ID to managedIndexConfig.policyID::equals,
@@ -186,7 +186,7 @@ class RestExplainActionIT : IndexStateManagementRestTestCase() {
             assertPredicatesOnMetaData(
                 listOf(
                     indexName to listOf(
-                        ManagedIndexSettings.POLICY_ID.key to policyID::equals,
+                        LegacyOpenDistroManagedIndexSettings.POLICY_ID.key to policyID::equals,
                         ManagedIndexMetaData.INDEX to managedIndexConfig.index::equals,
                         ManagedIndexMetaData.INDEX_UUID to managedIndexConfig.indexUuid::equals,
                         ManagedIndexMetaData.POLICY_ID to managedIndexConfig.policyID::equals,


### PR DESCRIPTION
Signed-off-by: bowenlan-amzn <bowenlan23@gmail.com>

*Issue #, if available:*
#108 

*Description of changes:*

For this flaky test part [link](https://github.com/opensearch-project/index-management/blob/main/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/resthandler/RestChangePolicyActionIT.kt#L469-L473)
Seems `copy` is a shallow copy here, and this assert directly pass.

*CheckList:*
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/index-management/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
