### PR TITLE
Storing user information as part of the job when security plugin is installed

### DIFF
--- a/src/main/kotlin/org/opensearch/indexmanagement/IndexManagementPlugin.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/IndexManagementPlugin.kt
@@ -339,6 +339,7 @@ class IndexManagementPlugin : JobSchedulerExtension, NetworkPlugin, ActionPlugin
             .registerIMIndex(indexManagementIndices)
             .registerHistoryIndex(indexStateManagementHistory)
             .registerSkipFlag(skipFlag)
+            .registerThreadPool(threadPool)
 
         val metadataService = MetadataService(client, clusterService, skipFlag, indexManagementIndices)
 

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/ManagedIndexCoordinator.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/ManagedIndexCoordinator.kt
@@ -53,6 +53,7 @@ import org.opensearch.cluster.block.ClusterBlockException
 import org.opensearch.cluster.metadata.IndexMetadata
 import org.opensearch.cluster.service.ClusterService
 import org.opensearch.common.component.LifecycleListener
+import org.opensearch.common.regex.Regex
 import org.opensearch.common.settings.Settings
 import org.opensearch.common.unit.TimeValue
 import org.opensearch.index.Index
@@ -61,14 +62,13 @@ import org.opensearch.index.query.QueryBuilders
 import org.opensearch.indexmanagement.IndexManagementIndices
 import org.opensearch.indexmanagement.IndexManagementPlugin
 import org.opensearch.indexmanagement.IndexManagementPlugin.Companion.INDEX_MANAGEMENT_INDEX
-import org.opensearch.indexmanagement.indexstatemanagement.model.ISMTemplate
 import org.opensearch.indexmanagement.indexstatemanagement.model.ManagedIndexConfig
 import org.opensearch.indexmanagement.indexstatemanagement.model.ManagedIndexMetaData
+import org.opensearch.indexmanagement.indexstatemanagement.model.Policy
 import org.opensearch.indexmanagement.indexstatemanagement.model.coordinator.ClusterStateManagedIndexConfig
 import org.opensearch.indexmanagement.indexstatemanagement.model.coordinator.SweptManagedIndexConfig
-import org.opensearch.indexmanagement.indexstatemanagement.opensearchapi.filterNotNullValues
-import org.opensearch.indexmanagement.indexstatemanagement.opensearchapi.getPolicyToTemplateMap
 import org.opensearch.indexmanagement.indexstatemanagement.opensearchapi.mgetManagedIndexMetadata
+import org.opensearch.indexmanagement.indexstatemanagement.opensearchapi.parsePolicies
 import org.opensearch.indexmanagement.indexstatemanagement.settings.ManagedIndexSettings.Companion.AUTO_MANAGE
 import org.opensearch.indexmanagement.indexstatemanagement.settings.ManagedIndexSettings.Companion.COORDINATOR_BACKOFF_COUNT
 import org.opensearch.indexmanagement.indexstatemanagement.settings.ManagedIndexSettings.Companion.COORDINATOR_BACKOFF_MILLIS
@@ -273,6 +273,7 @@ class ManagedIndexCoordinator(
      */
     @OpenForTesting
     suspend fun sweepClusterChangedEvent(event: ClusterChangedEvent) {
+        logger.info("test:      processing cluster change event")
         // indices delete event
         var removeManagedIndexReq = emptyList<DocWriteRequest<*>>()
         var indicesToClean = emptyList<Index>()
@@ -303,38 +304,86 @@ class ManagedIndexCoordinator(
         val updateManagedIndexReqs = mutableListOf<DocWriteRequest<IndexRequest>>()
         if (indexNames.isEmpty()) return updateManagedIndexReqs.toList()
 
-        val templates = getISMTemplates()
+        val policiesWithTemplates = getPoliciesWithISMTemplates()
 
         // Iterate over each unmanaged hot/warm index and if it matches an ISM template add a managed index config index request
         indexNames.forEach { indexName ->
-            if (clusterState.metadata.hasIndex(indexName)) {
+            val lookupName = findIndexLookupName(indexName, clusterState)
+            if (lookupName != null) {
                 val indexMetadata = clusterState.metadata.index(indexName)
-                val autoManage = indexMetadata.settings.getAsBoolean(AUTO_MANAGE.key, true)
-                if (autoManage) {
-                    val indexUuid = indexMetadata.indexUUID
-                    val isHiddenIndex =
-                        IndexMetadata.INDEX_HIDDEN_SETTING.get(indexMetadata.settings) || indexName.startsWith(".")
-                    val indexAbstraction = clusterState.metadata.indicesLookup[indexName]
-                    templates.findMatchingPolicy(indexName, indexMetadata.creationDate, isHiddenIndex, indexAbstraction)
-                        ?.let { policyID ->
-                            logger.info("Index [$indexName] matched ISM policy template and will be managed by $policyID")
-                            updateManagedIndexReqs.add(
-                                managedIndexConfigIndexRequest(
-                                    indexName,
-                                    indexUuid,
-                                    policyID,
-                                    jobInterval
-                                )
+                val creationDate = indexMetadata.creationDate
+                val indexUuid = indexMetadata.indexUUID
+                findMatchingPolicy(lookupName, creationDate, policiesWithTemplates)
+                    ?.let { policy ->
+                        logger.info("Index [$indexName] matched ISM policy template and will be managed by ${policy.id}")
+                        updateManagedIndexReqs.add(
+                            managedIndexConfigIndexRequest(
+                                indexName,
+                                indexUuid,
+                                policy.id,
+                                jobInterval,
+                                policy.user
                             )
-                        }
-                }
+                        )
+                    }
             }
         }
 
         return updateManagedIndexReqs.toList()
     }
 
-    suspend fun getISMTemplates(): Map<String, List<ISMTemplate>> {
+    private fun findIndexLookupName(indexName: String, clusterState: ClusterState): String? {
+        if (clusterState.metadata.hasIndex(indexName)) {
+            val indexMetadata = clusterState.metadata.index(indexName)
+            val autoManage = indexMetadata.settings.getAsBoolean(AUTO_MANAGE.key, true)
+            if (autoManage) {
+                val isHiddenIndex =
+                    IndexMetadata.INDEX_HIDDEN_SETTING.get(indexMetadata.settings) || indexName.startsWith(".")
+                val indexAbstraction = clusterState.metadata.indicesLookup[indexName]
+                val isDataStreamIndex = indexAbstraction?.parentDataStream != null
+                if (!isDataStreamIndex && isHiddenIndex) {
+                    return null
+                }
+
+                return when {
+                    isDataStreamIndex -> indexAbstraction?.parentDataStream?.name
+                    else -> indexName
+                }
+            }
+        }
+
+        return null
+    }
+
+    private fun findMatchingPolicy(indexName: String, creationDate: Long, policies: List<Policy>): Policy? {
+        // only process indices created after template
+        // traverse all ism templates for matching ones
+        val patternMatchPredicate = { pattern: String -> Regex.simpleMatch(pattern, indexName) }
+        var matchedPolicyId: String? = null
+        var matchedPolicy: Policy? = null
+        var highestPriority: Int = -1
+
+        policies.forEach { policy ->
+            policy.ismTemplate?.filter { template ->
+                template.lastUpdatedTime.toEpochMilli() < creationDate
+            }?.forEach { template ->
+                if (template.indexPatterns.stream().anyMatch(patternMatchPredicate)) {
+                    if (highestPriority < template.priority) {
+                        highestPriority = template.priority
+                        matchedPolicyId = policy.id
+                        matchedPolicy = policy
+                    } else if (highestPriority == template.priority) {
+                        logger.warn("Warning: index $indexName matches [$matchedPolicyId, ${policy.id}]")
+                    }
+                }
+            }
+        }
+
+        return matchedPolicy
+    }
+
+    suspend fun getPoliciesWithISMTemplates(): List<Policy> {
+        val errorMessage = "Failed to get ISM policies with templates"
         val searchRequest = SearchRequest()
             .source(
                 SearchSourceBuilder().query(
@@ -345,17 +394,18 @@ class ManagedIndexCoordinator(
 
         return try {
             val response: SearchResponse = client.suspendUntil { search(searchRequest, it) }
-            getPolicyToTemplateMap(response).filterNotNullValues()
+            parsePolicies(response)
         } catch (ex: IndexNotFoundException) {
-            emptyMap()
+            emptyList()
         } catch (ex: ClusterBlockException) {
-            emptyMap()
+            logger.error(errorMessage)
+            emptyList()
         } catch (e: SearchPhaseExecutionException) {
-            logger.error("Failed to get ISM templates: $e")
-            emptyMap()
+            logger.error("$errorMessage: $e")
+            emptyList()
         } catch (e: Exception) {
-            logger.error("Failed to get ISM templates", e)
-            emptyMap()
+            logger.error(errorMessage, e)
+            emptyList()
         }
     }
 

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/ManagedIndexCoordinator.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/ManagedIndexCoordinator.kt
@@ -273,7 +273,6 @@ class ManagedIndexCoordinator(
      */
     @OpenForTesting
     suspend fun sweepClusterChangedEvent(event: ClusterChangedEvent) {
-        logger.info("test:      processing cluster change event")
         // indices delete event
         var removeManagedIndexReq = emptyList<DocWriteRequest<*>>()
         var indicesToClean = emptyList<Index>()

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/ManagedIndexRunner.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/ManagedIndexRunner.kt
@@ -41,10 +41,8 @@ import org.opensearch.action.get.GetRequest
 import org.opensearch.action.get.GetResponse
 import org.opensearch.action.index.IndexResponse
 import org.opensearch.action.support.IndicesOptions
-import org.opensearch.action.support.master.AcknowledgedResponse
 import org.opensearch.action.update.UpdateResponse
 import org.opensearch.client.Client
-import org.opensearch.cluster.block.ClusterBlockException
 import org.opensearch.cluster.health.ClusterHealthStatus
 import org.opensearch.cluster.health.ClusterStateHealth
 import org.opensearch.cluster.metadata.IndexMetadata
@@ -59,7 +57,6 @@ import org.opensearch.common.xcontent.XContentHelper
 import org.opensearch.common.xcontent.XContentParser.Token
 import org.opensearch.common.xcontent.XContentParserUtils.ensureExpectedToken
 import org.opensearch.common.xcontent.XContentType
-import org.opensearch.index.Index
 import org.opensearch.index.engine.VersionConflictEngineException
 import org.opensearch.index.seqno.SequenceNumbers
 import org.opensearch.indexmanagement.IndexManagementIndices
@@ -81,8 +78,6 @@ import org.opensearch.indexmanagement.indexstatemanagement.settings.ManagedIndex
 import org.opensearch.indexmanagement.indexstatemanagement.settings.ManagedIndexSettings.Companion.INDEX_STATE_MANAGEMENT_ENABLED
 import org.opensearch.indexmanagement.indexstatemanagement.settings.ManagedIndexSettings.Companion.JOB_INTERVAL
 import org.opensearch.indexmanagement.indexstatemanagement.step.Step
-import org.opensearch.indexmanagement.indexstatemanagement.transport.action.updateindexmetadata.UpdateManagedIndexMetaDataAction
-import org.opensearch.indexmanagement.indexstatemanagement.transport.action.updateindexmetadata.UpdateManagedIndexMetaDataRequest
 import org.opensearch.indexmanagement.indexstatemanagement.util.getActionToExecute
 import org.opensearch.indexmanagement.indexstatemanagement.util.getCompletedManagedIndexMetaData
 import org.opensearch.indexmanagement.indexstatemanagement.util.getStartingManagedIndexMetaData
@@ -291,7 +286,7 @@ object ManagedIndexRunner :
         }
 
         val state = policy.getStateToExecute(managedIndexMetaData)
-        val action: Action? = state?.getActionToExecute(clusterService, scriptService, client, settings, managedIndexMetaData.copy(user = managedIndexConfig.user))
+        val action: Action? = state?.getActionToExecute(clusterService, scriptService, client, settings, managedIndexMetaData)
         val step: Step? = action?.getStepToExecute()
         val currentActionMetaData = action?.getUpdatedActionMetaData(managedIndexMetaData, state)
 
@@ -592,29 +587,6 @@ object ManagedIndexRunner :
         }
     }
 
-    // delete metadata in cluster state
-    private suspend fun deleteManagedIndexMetaData(managedIndexMetaData: ManagedIndexMetaData): Boolean {
-        var result = false
-        try {
-            val request = UpdateManagedIndexMetaDataRequest(
-                indicesToRemoveManagedIndexMetaDataFrom = listOf(Index(managedIndexMetaData.index, managedIndexMetaData.indexUuid))
-            )
-            updateMetaDataRetryPolicy.retry(logger) {
-                val response: AcknowledgedResponse = client.suspendUntil { execute(UpdateManagedIndexMetaDataAction.INSTANCE, request, it) }
-                if (response.isAcknowledged) {
-                    result = true
-                } else {
-                    logger.error("Failed to delete ManagedIndexMetaData for [index=${managedIndexMetaData.index}]")
-                }
-            }
-        } catch (e: ClusterBlockException) {
-            logger.error("There was ClusterBlockException trying to delete the metadata for ${managedIndexMetaData.index}. Message: ${e.message}", e)
-        } catch (e: Exception) {
-            logger.error("Failed to delete ManagedIndexMetaData for [index=${managedIndexMetaData.index}]", e)
-        }
-        return result
-    }
-
     /**
      * update metadata in config index, and save metadata in history after update
      * this can be called 2 times in one job run, so need to save seqNo & primeTerm
@@ -740,8 +712,8 @@ object ManagedIndexRunner :
 
         if (!updated.metadataSaved || policy == null) return
 
-        // this will save the new policy on the job and reset the change policy back to null
-        savePolicyToManagedIndexConfig(managedIndexConfig, policy)
+        // Change the policy and user stored on the job from changePolicy, this will also set the changePolicy to null on the job
+        savePolicyToManagedIndexConfig(managedIndexConfig.copy(user = changePolicy.user), policy)
     }
 
     @Suppress("TooGenericExceptionCaught")

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/model/ManagedIndexConfig.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/model/ManagedIndexConfig.kt
@@ -31,10 +31,13 @@ import org.opensearch.common.xcontent.XContentBuilder
 import org.opensearch.common.xcontent.XContentParser
 import org.opensearch.common.xcontent.XContentParser.Token
 import org.opensearch.common.xcontent.XContentParserUtils.ensureExpectedToken
+import org.opensearch.commons.authuser.User
 import org.opensearch.index.seqno.SequenceNumbers
+import org.opensearch.indexmanagement.indexstatemanagement.util.WITH_USER
 import org.opensearch.indexmanagement.indexstatemanagement.util.XCONTENT_WITHOUT_TYPE
 import org.opensearch.indexmanagement.opensearchapi.instant
 import org.opensearch.indexmanagement.opensearchapi.optionalTimeField
+import org.opensearch.indexmanagement.opensearchapi.optionalUserField
 import org.opensearch.jobscheduler.spi.ScheduledJobParameter
 import org.opensearch.jobscheduler.spi.schedule.Schedule
 import org.opensearch.jobscheduler.spi.schedule.ScheduleParser
@@ -56,7 +59,8 @@ data class ManagedIndexConfig(
     val policySeqNo: Long?,
     val policyPrimaryTerm: Long?,
     val policy: Policy?,
-    val changePolicy: ChangePolicy?
+    val changePolicy: ChangePolicy?,
+    val user: User? = null
 ) : ScheduledJobParameter {
 
     init {
@@ -95,9 +99,9 @@ data class ManagedIndexConfig(
             .field(POLICY_PRIMARY_TERM_FIELD, policyPrimaryTerm)
             .field(POLICY_FIELD, policy, XCONTENT_WITHOUT_TYPE)
             .field(CHANGE_POLICY_FIELD, changePolicy)
-            .endObject()
-            .endObject()
-        return builder
+        if (params.paramAsBoolean(WITH_USER, true)) builder.optionalUserField(USER_FIELD, user)
+        builder.endObject()
+        return builder.endObject()
     }
 
     companion object {
@@ -115,6 +119,7 @@ data class ManagedIndexConfig(
         const val POLICY_SEQ_NO_FIELD = "policy_seq_no"
         const val POLICY_PRIMARY_TERM_FIELD = "policy_primary_term"
         const val CHANGE_POLICY_FIELD = "change_policy"
+        const val USER_FIELD = "user"
 
         @Suppress("ComplexMethod", "LongMethod")
         @JvmStatic
@@ -138,6 +143,7 @@ data class ManagedIndexConfig(
             var enabled = true
             var policyPrimaryTerm: Long? = SequenceNumbers.UNASSIGNED_PRIMARY_TERM
             var policySeqNo: Long? = SequenceNumbers.UNASSIGNED_SEQ_NO
+            var user: User? = null
 
             ensureExpectedToken(Token.START_OBJECT, xcp.currentToken(), xcp)
             while (xcp.nextToken() != Token.END_OBJECT) {
@@ -164,6 +170,9 @@ data class ManagedIndexConfig(
                     }
                     CHANGE_POLICY_FIELD -> {
                         changePolicy = if (xcp.currentToken() == Token.VALUE_NULL) null else ChangePolicy.parse(xcp)
+                    }
+                    USER_FIELD -> {
+                        user = if (xcp.currentToken() == Token.VALUE_NULL) null else User.parse(xcp)
                     }
                     else -> throw IllegalArgumentException("Invalid field: [$fieldName] found in ManagedIndexConfig.")
                 }
@@ -193,7 +202,8 @@ data class ManagedIndexConfig(
                     seqNo = policySeqNo ?: SequenceNumbers.UNASSIGNED_SEQ_NO,
                     primaryTerm = policyPrimaryTerm ?: SequenceNumbers.UNASSIGNED_PRIMARY_TERM
                 ),
-                changePolicy = changePolicy
+                changePolicy = changePolicy,
+                user = user
             )
         }
     }

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/model/ManagedIndexConfig.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/model/ManagedIndexConfig.kt
@@ -34,7 +34,7 @@ import org.opensearch.common.xcontent.XContentParserUtils.ensureExpectedToken
 import org.opensearch.commons.authuser.User
 import org.opensearch.index.seqno.SequenceNumbers
 import org.opensearch.indexmanagement.indexstatemanagement.util.WITH_USER
-import org.opensearch.indexmanagement.indexstatemanagement.util.XCONTENT_WITHOUT_TYPE
+import org.opensearch.indexmanagement.indexstatemanagement.util.XCONTENT_WITHOUT_TYPE_AND_USER
 import org.opensearch.indexmanagement.opensearchapi.instant
 import org.opensearch.indexmanagement.opensearchapi.optionalTimeField
 import org.opensearch.indexmanagement.opensearchapi.optionalUserField
@@ -97,7 +97,7 @@ data class ManagedIndexConfig(
             .field(POLICY_ID_FIELD, policyID)
             .field(POLICY_SEQ_NO_FIELD, policySeqNo)
             .field(POLICY_PRIMARY_TERM_FIELD, policyPrimaryTerm)
-            .field(POLICY_FIELD, policy, XCONTENT_WITHOUT_TYPE)
+            .field(POLICY_FIELD, policy, XCONTENT_WITHOUT_TYPE_AND_USER)
             .field(CHANGE_POLICY_FIELD, changePolicy)
         if (params.paramAsBoolean(WITH_USER, true)) builder.optionalUserField(USER_FIELD, user)
         builder.endObject()

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/model/ManagedIndexMetaData.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/model/ManagedIndexMetaData.kt
@@ -39,7 +39,6 @@ import org.opensearch.common.xcontent.XContentParser
 import org.opensearch.common.xcontent.XContentParser.Token
 import org.opensearch.common.xcontent.XContentParserUtils.ensureExpectedToken
 import org.opensearch.common.xcontent.json.JsonXContent
-import org.opensearch.commons.authuser.User
 import org.opensearch.index.seqno.SequenceNumbers
 import org.opensearch.indexmanagement.indexstatemanagement.model.action.ActionConfig
 import org.opensearch.indexmanagement.indexstatemanagement.model.managedindexmetadata.ActionMetaData
@@ -65,8 +64,7 @@ data class ManagedIndexMetaData(
     val info: Map<String, Any>?,
     val id: String = NO_ID,
     val seqNo: Long = SequenceNumbers.UNASSIGNED_SEQ_NO,
-    val primaryTerm: Long = SequenceNumbers.UNASSIGNED_PRIMARY_TERM,
-    val user: User? = null
+    val primaryTerm: Long = SequenceNumbers.UNASSIGNED_PRIMARY_TERM
 ) : Writeable, ToXContentFragment {
 
     @Suppress("ComplexMethod")

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/model/ManagedIndexMetaData.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/model/ManagedIndexMetaData.kt
@@ -39,6 +39,7 @@ import org.opensearch.common.xcontent.XContentParser
 import org.opensearch.common.xcontent.XContentParser.Token
 import org.opensearch.common.xcontent.XContentParserUtils.ensureExpectedToken
 import org.opensearch.common.xcontent.json.JsonXContent
+import org.opensearch.commons.authuser.User
 import org.opensearch.index.seqno.SequenceNumbers
 import org.opensearch.indexmanagement.indexstatemanagement.model.action.ActionConfig
 import org.opensearch.indexmanagement.indexstatemanagement.model.managedindexmetadata.ActionMetaData
@@ -64,7 +65,8 @@ data class ManagedIndexMetaData(
     val info: Map<String, Any>?,
     val id: String = NO_ID,
     val seqNo: Long = SequenceNumbers.UNASSIGNED_SEQ_NO,
-    val primaryTerm: Long = SequenceNumbers.UNASSIGNED_PRIMARY_TERM
+    val primaryTerm: Long = SequenceNumbers.UNASSIGNED_PRIMARY_TERM,
+    val user: User? = null
 ) : Writeable, ToXContentFragment {
 
     @Suppress("ComplexMethod")

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/opensearchapi/OpenSearchExtensions.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/opensearchapi/OpenSearchExtensions.kt
@@ -52,7 +52,6 @@ import org.opensearch.common.xcontent.XContentType
 import org.opensearch.index.Index
 import org.opensearch.index.IndexNotFoundException
 import org.opensearch.indexmanagement.IndexManagementPlugin.Companion.INDEX_MANAGEMENT_INDEX
-import org.opensearch.indexmanagement.indexstatemanagement.model.ISMTemplate
 import org.opensearch.indexmanagement.indexstatemanagement.model.ManagedIndexMetaData
 import org.opensearch.indexmanagement.indexstatemanagement.model.Policy
 import org.opensearch.indexmanagement.indexstatemanagement.settings.LegacyOpenDistroManagedIndexSettings
@@ -105,15 +104,13 @@ fun getUuidsForClosedIndices(state: ClusterState): MutableList<String> {
 }
 
 /**
- * Do a exists search query to retrieve all policy with ism_template field
- * parse search response with this function
+ * Parse policies from SearchResponse
  *
- * @return map of policyID to ISMTemplate in this policy
+ * @return list of policies
  * @throws [IllegalArgumentException]
  */
 @Throws(Exception::class)
-fun getPolicyToTemplateMap(response: SearchResponse, xContentRegistry: NamedXContentRegistry = NamedXContentRegistry.EMPTY):
-    Map<String, List<ISMTemplate>?> {
+fun parsePolicies(response: SearchResponse, xContentRegistry: NamedXContentRegistry = NamedXContentRegistry.EMPTY): List<Policy> {
     return response.hits.hits.map {
         val id = it.id
         val seqNo = it.seqNo
@@ -122,7 +119,7 @@ fun getPolicyToTemplateMap(response: SearchResponse, xContentRegistry: NamedXCon
             .createParser(xContentRegistry, LoggingDeprecationHandler.INSTANCE, it.sourceAsString)
         xcp.parseWithType(id, seqNo, primaryTerm, Policy.Companion::parse)
             .copy(id = id, seqNo = seqNo, primaryTerm = primaryTerm)
-    }.map { it.id to it.ismTemplate }.toMap()
+    }
 }
 
 @Suppress("UNCHECKED_CAST")

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/transport/action/addpolicy/AddPolicyRequest.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/transport/action/addpolicy/AddPolicyRequest.kt
@@ -33,18 +33,10 @@ import org.opensearch.common.io.stream.StreamInput
 import org.opensearch.common.io.stream.StreamOutput
 import java.io.IOException
 
-class AddPolicyRequest : ActionRequest {
-
-    val indices: List<String>
+class AddPolicyRequest(
+    val indices: List<String>,
     val policyID: String
-
-    constructor(
-        indices: List<String>,
-        policyID: String
-    ) : super() {
-        this.indices = indices
-        this.policyID = policyID
-    }
+) : ActionRequest() {
 
     @Throws(IOException::class)
     constructor(sin: StreamInput) : this(

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/transport/action/addpolicy/TransportAddPolicyAction.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/transport/action/addpolicy/TransportAddPolicyAction.kt
@@ -55,6 +55,7 @@ import org.opensearch.indexmanagement.indexstatemanagement.settings.ManagedIndex
 import org.opensearch.indexmanagement.indexstatemanagement.transport.action.ISMStatusResponse
 import org.opensearch.indexmanagement.indexstatemanagement.util.FailedIndex
 import org.opensearch.indexmanagement.indexstatemanagement.util.managedIndexConfigIndexRequest
+import org.opensearch.indexmanagement.util.SecurityUtils.Companion.buildUser
 import org.opensearch.rest.RestStatus
 import org.opensearch.tasks.Task
 import org.opensearch.transport.TransportService
@@ -213,7 +214,9 @@ class TransportAddPolicyAction @Inject constructor(
 
                 val bulkReq = BulkRequest().timeout(TimeValue.timeValueMillis(bulkReqTimeout))
                 indicesToAdd.forEach { (uuid, name) ->
-                    bulkReq.add(managedIndexConfigIndexRequest(name, uuid, request.policyID, jobInterval))
+                    bulkReq.add(
+                        managedIndexConfigIndexRequest(name, uuid, request.policyID, jobInterval, user = buildUser(client.threadPool().threadContext))
+                    )
                 }
 
                 client.bulk(

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/transport/action/changepolicy/ChangePolicyRequest.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/transport/action/changepolicy/ChangePolicyRequest.kt
@@ -34,18 +34,10 @@ import org.opensearch.common.io.stream.StreamOutput
 import org.opensearch.indexmanagement.indexstatemanagement.model.ChangePolicy
 import java.io.IOException
 
-class ChangePolicyRequest : ActionRequest {
-
-    val indices: List<String>
+class ChangePolicyRequest(
+    val indices: List<String>,
     val changePolicy: ChangePolicy
-
-    constructor(
-        indices: List<String>,
-        changePolicy: ChangePolicy
-    ) : super() {
-        this.indices = indices
-        this.changePolicy = changePolicy
-    }
+) : ActionRequest() {
 
     @Throws(IOException::class)
     constructor(sin: StreamInput) : this(

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/transport/action/changepolicy/TransportChangePolicyAction.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/transport/action/changepolicy/TransportChangePolicyAction.kt
@@ -68,6 +68,7 @@ import org.opensearch.indexmanagement.opensearchapi.contentParser
 import org.opensearch.indexmanagement.opensearchapi.parseWithType
 import org.opensearch.indexmanagement.util.IndexUtils
 import org.opensearch.indexmanagement.util.NO_ID
+import org.opensearch.indexmanagement.util.SecurityUtils.Companion.buildUser
 import org.opensearch.rest.RestStatus
 import org.opensearch.search.fetch.subphase.FetchSourceContext
 import org.opensearch.tasks.Task
@@ -272,7 +273,7 @@ class TransportChangePolicyAction @Inject constructor(
                 val currentStateName = indexUuidToCurrentState[sweptConfig.uuid]
                 val updatedChangePolicy = changePolicy
                     .copy(isSafe = sweptConfig.policy?.isSafeToChange(currentStateName, policy, changePolicy) == true)
-                bulkUpdateManagedIndexRequest.add(updateManagedIndexRequest(sweptConfig.copy(changePolicy = updatedChangePolicy)))
+                bulkUpdateManagedIndexRequest.add(updateManagedIndexRequest(sweptConfig.copy(changePolicy = updatedChangePolicy), user = buildUser(client.threadPool().threadContext)))
                 mapOfItemIdToIndex[id] = Index(sweptConfig.index, sweptConfig.uuid)
             }
             client.bulk(

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/transport/action/changepolicy/TransportChangePolicyAction.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/transport/action/changepolicy/TransportChangePolicyAction.kt
@@ -272,8 +272,8 @@ class TransportChangePolicyAction @Inject constructor(
                 // compare the sweptConfig policy to the get policy here and update changePolicy
                 val currentStateName = indexUuidToCurrentState[sweptConfig.uuid]
                 val updatedChangePolicy = changePolicy
-                    .copy(isSafe = sweptConfig.policy?.isSafeToChange(currentStateName, policy, changePolicy) == true)
-                bulkUpdateManagedIndexRequest.add(updateManagedIndexRequest(sweptConfig.copy(changePolicy = updatedChangePolicy), user = buildUser(client.threadPool().threadContext)))
+                    .copy(isSafe = sweptConfig.policy?.isSafeToChange(currentStateName, policy, changePolicy) == true, user = buildUser(client.threadPool().threadContext))
+                bulkUpdateManagedIndexRequest.add(updateManagedIndexRequest(sweptConfig.copy(changePolicy = updatedChangePolicy)))
                 mapOfItemIdToIndex[id] = Index(sweptConfig.index, sweptConfig.uuid)
             }
             client.bulk(

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/transport/action/explain/ExplainAllResponse.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/transport/action/explain/ExplainAllResponse.kt
@@ -34,6 +34,7 @@ import org.opensearch.common.xcontent.XContentBuilder
 import org.opensearch.indexmanagement.indexstatemanagement.model.ManagedIndexMetaData
 import org.opensearch.indexmanagement.indexstatemanagement.settings.LegacyOpenDistroManagedIndexSettings
 import org.opensearch.indexmanagement.indexstatemanagement.settings.ManagedIndexSettings
+import org.opensearch.indexmanagement.indexstatemanagement.util.XCONTENT_WITHOUT_USER
 import java.io.IOException
 
 class ExplainAllResponse : ExplainResponse, ToXContentObject {
@@ -74,7 +75,7 @@ class ExplainAllResponse : ExplainResponse, ToXContentObject {
             builder.startObject(name)
             builder.field(LegacyOpenDistroManagedIndexSettings.POLICY_ID.key, indexPolicyIDs[ind])
             builder.field(ManagedIndexSettings.POLICY_ID.key, indexPolicyIDs[ind])
-            indexMetadatas[ind]?.toXContent(builder, ToXContent.EMPTY_PARAMS)
+            indexMetadatas[ind]?.toXContent(builder, XCONTENT_WITHOUT_USER)
             builder.field("enabled", enabledState[name])
             builder.endObject()
         }

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/transport/action/explain/ExplainResponse.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/transport/action/explain/ExplainResponse.kt
@@ -35,6 +35,7 @@ import org.opensearch.common.xcontent.XContentBuilder
 import org.opensearch.indexmanagement.indexstatemanagement.model.ManagedIndexMetaData
 import org.opensearch.indexmanagement.indexstatemanagement.settings.LegacyOpenDistroManagedIndexSettings
 import org.opensearch.indexmanagement.indexstatemanagement.settings.ManagedIndexSettings
+import org.opensearch.indexmanagement.indexstatemanagement.util.XCONTENT_WITHOUT_USER
 import java.io.IOException
 
 open class ExplainResponse : ActionResponse, ToXContentObject {
@@ -74,7 +75,7 @@ open class ExplainResponse : ActionResponse, ToXContentObject {
             builder.startObject(name)
             builder.field(LegacyOpenDistroManagedIndexSettings.POLICY_ID.key, indexPolicyIDs[ind])
             builder.field(ManagedIndexSettings.POLICY_ID.key, indexPolicyIDs[ind])
-            indexMetadatas[ind]?.toXContent(builder, ToXContent.EMPTY_PARAMS)
+            indexMetadatas[ind]?.toXContent(builder, XCONTENT_WITHOUT_USER)
             builder.endObject()
         }
         return builder.endObject()

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/transport/action/getpolicy/GetPoliciesResponse.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/transport/action/getpolicy/GetPoliciesResponse.kt
@@ -33,7 +33,7 @@ import org.opensearch.common.xcontent.ToXContent
 import org.opensearch.common.xcontent.ToXContentObject
 import org.opensearch.common.xcontent.XContentBuilder
 import org.opensearch.indexmanagement.indexstatemanagement.model.Policy
-import org.opensearch.indexmanagement.indexstatemanagement.util.XCONTENT_WITHOUT_TYPE
+import org.opensearch.indexmanagement.indexstatemanagement.util.XCONTENT_WITHOUT_TYPE_AND_USER
 import org.opensearch.indexmanagement.util._ID
 import org.opensearch.indexmanagement.util._PRIMARY_TERM
 import org.opensearch.indexmanagement.util._SEQ_NO
@@ -72,7 +72,7 @@ class GetPoliciesResponse : ActionResponse, ToXContentObject {
                         .field(_ID, policy.id)
                         .field(_SEQ_NO, policy.seqNo)
                         .field(_PRIMARY_TERM, policy.primaryTerm)
-                        .field(Policy.POLICY_TYPE, policy, XCONTENT_WITHOUT_TYPE)
+                        .field(Policy.POLICY_TYPE, policy, XCONTENT_WITHOUT_TYPE_AND_USER)
                         .endObject()
                 }
             }

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/transport/action/indexpolicy/TransportIndexPolicyAction.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/transport/action/indexpolicy/TransportIndexPolicyAction.kt
@@ -56,6 +56,7 @@ import org.opensearch.indexmanagement.indexstatemanagement.util.ISM_TEMPLATE_FIE
 import org.opensearch.indexmanagement.indexstatemanagement.validateFormat
 import org.opensearch.indexmanagement.util.IndexManagementException
 import org.opensearch.indexmanagement.util.IndexUtils
+import org.opensearch.indexmanagement.util.SecurityUtils.Companion.buildUser
 import org.opensearch.rest.RestStatus
 import org.opensearch.search.builder.SearchSourceBuilder
 import org.opensearch.tasks.Task
@@ -98,7 +99,6 @@ class TransportIndexPolicyAction @Inject constructor(
                 log.info("Successfully created or updated ${IndexManagementPlugin.INDEX_MANAGEMENT_INDEX} with newest mappings.")
 
                 // if there is template field, we will check
-                val reqTemplate = request.policy.ismTemplate
                 val reqTemplates = request.policy.ismTemplate
                 if (reqTemplates != null) {
                     validateISMTemplates(reqTemplates)
@@ -175,11 +175,13 @@ class TransportIndexPolicyAction @Inject constructor(
         }
 
         private fun putPolicy() {
-            request.policy.copy(schemaVersion = IndexUtils.indexManagementConfigSchemaVersion)
+            val policy = request.policy.copy(
+                schemaVersion = IndexUtils.indexManagementConfigSchemaVersion, user = buildUser(client.threadPool().threadContext)
+            )
 
             val indexRequest = IndexRequest(IndexManagementPlugin.INDEX_MANAGEMENT_INDEX)
                 .setRefreshPolicy(request.refreshPolicy)
-                .source(request.policy.toXContent(XContentFactory.jsonBuilder()))
+                .source(policy.toXContent(XContentFactory.jsonBuilder()))
                 .id(request.policyID)
                 .timeout(IndexRequest.DEFAULT_TIMEOUT)
 

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/transport/action/indexpolicy/TransportIndexPolicyAction.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/transport/action/indexpolicy/TransportIndexPolicyAction.kt
@@ -51,7 +51,7 @@ import org.opensearch.indexmanagement.indexstatemanagement.findConflictingPolicy
 import org.opensearch.indexmanagement.indexstatemanagement.findSelfConflictingTemplates
 import org.opensearch.indexmanagement.indexstatemanagement.model.ISMTemplate
 import org.opensearch.indexmanagement.indexstatemanagement.opensearchapi.filterNotNullValues
-import org.opensearch.indexmanagement.indexstatemanagement.opensearchapi.getPolicyToTemplateMap
+import org.opensearch.indexmanagement.indexstatemanagement.opensearchapi.parsePolicies
 import org.opensearch.indexmanagement.indexstatemanagement.util.ISM_TEMPLATE_FIELD
 import org.opensearch.indexmanagement.indexstatemanagement.validateFormat
 import org.opensearch.indexmanagement.util.IndexManagementException
@@ -144,7 +144,8 @@ class TransportIndexPolicyAction @Inject constructor(
                 searchRequest,
                 object : ActionListener<SearchResponse> {
                     override fun onResponse(response: SearchResponse) {
-                        val policyToTemplateMap = getPolicyToTemplateMap(response, xContentRegistry).filterNotNullValues()
+                        val policies = parsePolicies(response, xContentRegistry)
+                        val policyToTemplateMap: Map<String, List<ISMTemplate>> = policies.map { it.id to it.ismTemplate }.toMap().filterNotNullValues()
                         ismTemplateList.forEach {
                             val conflictingPolicyTemplates = policyToTemplateMap
                                 .findConflictingPolicyTemplates(request.policyID, it.indexPatterns, it.priority)

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/util/ManagedIndexUtils.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/util/ManagedIndexUtils.kt
@@ -45,6 +45,7 @@ import org.opensearch.common.unit.ByteSizeValue
 import org.opensearch.common.unit.TimeValue
 import org.opensearch.common.xcontent.ToXContent
 import org.opensearch.common.xcontent.XContentFactory
+import org.opensearch.commons.authuser.User
 import org.opensearch.index.Index
 import org.opensearch.index.query.BoolQueryBuilder
 import org.opensearch.index.query.QueryBuilders
@@ -76,7 +77,7 @@ import java.net.InetAddress
 import java.time.Instant
 import java.time.temporal.ChronoUnit
 
-fun managedIndexConfigIndexRequest(index: String, uuid: String, policyID: String, jobInterval: Int): IndexRequest {
+fun managedIndexConfigIndexRequest(index: String, uuid: String, policyID: String, jobInterval: Int, user: User? = null): IndexRequest {
     val managedIndexConfig = ManagedIndexConfig(
         jobName = index,
         index = index,
@@ -89,7 +90,8 @@ fun managedIndexConfigIndexRequest(index: String, uuid: String, policyID: String
         policy = null,
         policySeqNo = null,
         policyPrimaryTerm = null,
-        changePolicy = null
+        changePolicy = null,
+        user = user
     )
 
     return IndexRequest(INDEX_MANAGEMENT_INDEX)
@@ -160,11 +162,11 @@ fun deleteManagedIndexMetadataRequest(uuid: String): DeleteRequest {
     return DeleteRequest(INDEX_MANAGEMENT_INDEX, managedIndexMetadataID(uuid))
 }
 
-fun updateManagedIndexRequest(sweptManagedIndexConfig: SweptManagedIndexConfig): UpdateRequest {
+fun updateManagedIndexRequest(sweptManagedIndexConfig: SweptManagedIndexConfig, user: User? = null): UpdateRequest {
     return UpdateRequest(INDEX_MANAGEMENT_INDEX, sweptManagedIndexConfig.uuid)
         .setIfPrimaryTerm(sweptManagedIndexConfig.primaryTerm)
         .setIfSeqNo(sweptManagedIndexConfig.seqNo)
-        .doc(getPartialChangePolicyBuilder(sweptManagedIndexConfig.changePolicy))
+        .doc(getPartialChangePolicyBuilder(sweptManagedIndexConfig.changePolicy, user))
 }
 
 /**

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/util/RestHandlerUtils.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/util/RestHandlerUtils.kt
@@ -113,22 +113,11 @@ fun getPartialChangePolicyBuilder(
     changePolicy: ChangePolicy?,
     user: User? = null
 ): XContentBuilder {
-    if (user == null) {
-        return XContentFactory.jsonBuilder()
-            .startObject()
-            .startObject(ManagedIndexConfig.MANAGED_INDEX_TYPE)
-            .optionalTimeField(ManagedIndexConfig.LAST_UPDATED_TIME_FIELD, Instant.now())
-            .field(ManagedIndexConfig.CHANGE_POLICY_FIELD, changePolicy)
-            .endObject()
-            .endObject()
-    } else {
-        return XContentFactory.jsonBuilder()
-            .startObject()
-            .startObject(ManagedIndexConfig.MANAGED_INDEX_TYPE)
-            .optionalTimeField(ManagedIndexConfig.LAST_UPDATED_TIME_FIELD, Instant.now())
-            .field(ManagedIndexConfig.CHANGE_POLICY_FIELD, changePolicy)
-            .field(ManagedIndexConfig.USER_FIELD, user)
-            .endObject()
-            .endObject()
-    }
+    val builder = XContentFactory.jsonBuilder()
+        .startObject()
+        .startObject(ManagedIndexConfig.MANAGED_INDEX_TYPE)
+        .optionalTimeField(ManagedIndexConfig.LAST_UPDATED_TIME_FIELD, Instant.now())
+        .field(ManagedIndexConfig.CHANGE_POLICY_FIELD, changePolicy)
+    if (user != null) builder.field(ManagedIndexConfig.USER_FIELD, user)
+    return builder.endObject().endObject()
 }

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/util/RestHandlerUtils.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/util/RestHandlerUtils.kt
@@ -34,13 +34,17 @@ import org.opensearch.common.xcontent.ToXContent
 import org.opensearch.common.xcontent.ToXContentFragment
 import org.opensearch.common.xcontent.XContentBuilder
 import org.opensearch.common.xcontent.XContentFactory
+import org.opensearch.commons.authuser.User
 import org.opensearch.indexmanagement.indexstatemanagement.model.ChangePolicy
 import org.opensearch.indexmanagement.indexstatemanagement.model.ManagedIndexConfig
 import org.opensearch.indexmanagement.opensearchapi.optionalTimeField
 import java.time.Instant
 
 const val WITH_TYPE = "with_type"
+const val WITH_USER = "with_user"
 val XCONTENT_WITHOUT_TYPE = ToXContent.MapParams(mapOf(WITH_TYPE to "false"))
+val XCONTENT_WITHOUT_USER = ToXContent.MapParams(mapOf(WITH_USER to "false"))
+val XCONTENT_WITHOUT_TYPE_AND_USER = ToXContent.MapParams(mapOf(WITH_TYPE to "false", WITH_USER to "false"))
 
 const val FAILURES = "failures"
 const val FAILED_INDICES = "failed_indices"
@@ -106,13 +110,25 @@ data class FailedIndex(val name: String, val uuid: String, val reason: String) :
  * Gets the XContentBuilder for partially updating a [ManagedIndexConfig]'s ChangePolicy
  */
 fun getPartialChangePolicyBuilder(
-    changePolicy: ChangePolicy?
+    changePolicy: ChangePolicy?,
+    user: User? = null
 ): XContentBuilder {
-    return XContentFactory.jsonBuilder()
-        .startObject()
-        .startObject(ManagedIndexConfig.MANAGED_INDEX_TYPE)
-        .optionalTimeField(ManagedIndexConfig.LAST_UPDATED_TIME_FIELD, Instant.now())
-        .field(ManagedIndexConfig.CHANGE_POLICY_FIELD, changePolicy)
-        .endObject()
-        .endObject()
+    if (user == null) {
+        return XContentFactory.jsonBuilder()
+            .startObject()
+            .startObject(ManagedIndexConfig.MANAGED_INDEX_TYPE)
+            .optionalTimeField(ManagedIndexConfig.LAST_UPDATED_TIME_FIELD, Instant.now())
+            .field(ManagedIndexConfig.CHANGE_POLICY_FIELD, changePolicy)
+            .endObject()
+            .endObject()
+    } else {
+        return XContentFactory.jsonBuilder()
+            .startObject()
+            .startObject(ManagedIndexConfig.MANAGED_INDEX_TYPE)
+            .optionalTimeField(ManagedIndexConfig.LAST_UPDATED_TIME_FIELD, Instant.now())
+            .field(ManagedIndexConfig.CHANGE_POLICY_FIELD, changePolicy)
+            .field(ManagedIndexConfig.USER_FIELD, user)
+            .endObject()
+            .endObject()
+    }
 }

--- a/src/main/kotlin/org/opensearch/indexmanagement/opensearchapi/OpenSearchExtensions.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/opensearchapi/OpenSearchExtensions.kt
@@ -247,7 +247,7 @@ class IndexManagementSecurityContext(
      * Clean up the thread context before the coroutine executed by thread is suspended
      */
     override fun restoreThreadContext(context: CoroutineContext, oldState: Unit) {
-        logger.info("Cleaning up secuirty context in thread ${Thread.currentThread().name} for job $id")
+        logger.info("Cleaning up security context in thread ${Thread.currentThread().name} for job $id")
         injector.close()
     }
 }

--- a/src/main/kotlin/org/opensearch/indexmanagement/opensearchapi/OpenSearchExtensions.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/opensearchapi/OpenSearchExtensions.kt
@@ -225,14 +225,14 @@ class IndexManagementSecurityContext(
     private val logger: Logger = LogManager.getLogger(javaClass)
     override val key: CoroutineContext.Key<*>
         get() = Key
-    val injector = InjectSecurity(id, settings, threadContext)
+    private val injector = InjectSecurity(id, settings, threadContext)
 
     /**
      * Before the thread executes the coroutine we want the thread context to contain user roles so they are used when executing the code inside
      * the coroutine
      */
     override fun updateThreadContext(context: CoroutineContext) {
-        logger.info("Setting security context in thread ${Thread.currentThread().name} for job $id")
+        logger.debug("Setting security context in thread ${Thread.currentThread().name} for job $id")
         injector.injectRoles(if (user == null) DEFAULT_INJECT_ROLES else user.roles)
         // TODO: implement this in InjectSecurity to be able to set specific transient properties in ThreadContext
         if (threadContext.getTransient<Boolean>(INTERNAL_REQUEST) == null) {
@@ -247,7 +247,7 @@ class IndexManagementSecurityContext(
      * Clean up the thread context before the coroutine executed by thread is suspended
      */
     override fun restoreThreadContext(context: CoroutineContext, oldState: Unit) {
-        logger.info("Cleaning up security context in thread ${Thread.currentThread().name} for job $id")
+        logger.debug("Cleaning up security context in thread ${Thread.currentThread().name} for job $id")
         injector.close()
     }
 }

--- a/src/main/kotlin/org/opensearch/indexmanagement/util/SecurityUtils.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/util/SecurityUtils.kt
@@ -1,0 +1,39 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.indexmanagement.util
+
+import org.opensearch.common.util.concurrent.ThreadContext
+import org.opensearch.commons.ConfigConstants
+import org.opensearch.commons.authuser.User
+
+class SecurityUtils {
+    companion object {
+        const val INTERNAL_REQUEST = "index_management_plugin_internal_user"
+        val DEFAULT_INJECT_ROLES: List<String> = listOf("all_access", "AmazonES_all_access")
+        /**
+         * Helper method to build the user object either from the threadContext or from the requested user.
+         */
+        fun buildUser(threadContext: ThreadContext, requestedUser: User? = null): User? {
+            if (threadContext.getTransient<Boolean>(INTERNAL_REQUEST) != null && threadContext.getTransient<Boolean>(INTERNAL_REQUEST)) {
+                // received internal request
+                return requestedUser
+            }
+
+            val injectedUser: User? = User.parse(threadContext.getTransient<String>(ConfigConstants.OPENSEARCH_SECURITY_USER_INFO_THREAD_CONTEXT))
+            return if (injectedUser == null) {
+                null
+            } else {
+                User(injectedUser.name, injectedUser.backendRoles, injectedUser.roles, injectedUser.customAttNames)
+            }
+        }
+    }
+}

--- a/src/main/resources/mappings/opendistro-ism-config.json
+++ b/src/main/resources/mappings/opendistro-ism-config.json
@@ -1,6 +1,6 @@
 {
   "_meta" : {
-    "schema_version": 10
+    "schema_version": 11
   },
   "dynamic": "strict",
   "properties": {
@@ -456,6 +456,43 @@
               "format": "strict_date_time||epoch_millis"
             }
           }
+        },
+        "user": {
+          "properties": {
+            "name": {
+              "type": "text",
+              "fields": {
+                "keyword": {
+                  "type": "keyword",
+                  "ignore_above": 256
+                }
+              }
+            },
+            "backend_roles": {
+              "type" : "text",
+              "fields" : {
+                "keyword" : {
+                  "type" : "keyword"
+                }
+              }
+            },
+            "roles": {
+              "type" : "text",
+              "fields" : {
+                "keyword" : {
+                  "type" : "keyword"
+                }
+              }
+            },
+            "custom_attribute_names": {
+              "type" : "text",
+              "fields" : {
+                "keyword" : {
+                  "type" : "keyword"
+                }
+              }
+            }
+          }
         }
       }
     },
@@ -536,6 +573,43 @@
                 },
                 "timezone": {
                   "type": "keyword"
+                }
+              }
+            }
+          }
+        },
+        "user": {
+          "properties": {
+            "name": {
+              "type": "text",
+              "fields": {
+                "keyword": {
+                  "type": "keyword",
+                  "ignore_above": 256
+                }
+              }
+            },
+            "backend_roles": {
+              "type" : "text",
+              "fields" : {
+                "keyword" : {
+                  "type" : "keyword"
+                }
+              }
+            },
+            "roles": {
+              "type" : "text",
+              "fields" : {
+                "keyword" : {
+                  "type" : "keyword"
+                }
+              }
+            },
+            "custom_attribute_names": {
+              "type" : "text",
+              "fields" : {
+                "keyword" : {
+                  "type" : "keyword"
                 }
               }
             }
@@ -851,6 +925,43 @@
               }
             }
           }
+        },
+        "user": {
+          "properties": {
+            "name": {
+              "type": "text",
+              "fields": {
+                "keyword": {
+                  "type": "keyword",
+                  "ignore_above": 256
+                }
+              }
+            },
+            "backend_roles": {
+              "type" : "text",
+              "fields" : {
+                "keyword" : {
+                  "type" : "keyword"
+                }
+              }
+            },
+            "roles": {
+              "type" : "text",
+              "fields" : {
+                "keyword" : {
+                  "type" : "keyword"
+                }
+              }
+            },
+            "custom_attribute_names": {
+              "type" : "text",
+              "fields" : {
+                "keyword" : {
+                  "type" : "keyword"
+                }
+              }
+            }
+          }
         }
       }
     },
@@ -1039,6 +1150,43 @@
         "data_selection_query": {
           "type": "object",
           "enabled": false
+        },
+        "user": {
+          "properties": {
+            "name": {
+              "type": "text",
+              "fields": {
+                "keyword": {
+                  "type": "keyword",
+                  "ignore_above": 256
+                }
+              }
+            },
+            "backend_roles": {
+              "type" : "text",
+              "fields" : {
+                "keyword" : {
+                  "type" : "keyword"
+                }
+              }
+            },
+            "roles": {
+              "type" : "text",
+              "fields" : {
+                "keyword" : {
+                  "type" : "keyword"
+                }
+              }
+            },
+            "custom_attribute_names": {
+              "type" : "text",
+              "fields" : {
+                "keyword" : {
+                  "type" : "keyword"
+                }
+              }
+            }
+          }
         }
       }
     },

--- a/src/main/resources/mappings/opendistro-ism-config.json
+++ b/src/main/resources/mappings/opendistro-ism-config.json
@@ -547,6 +547,43 @@
             },
             "is_safe": {
               "type": "boolean"
+            },
+            "user": {
+              "properties": {
+                "name": {
+                  "type": "text",
+                  "fields": {
+                    "keyword": {
+                      "type": "keyword",
+                      "ignore_above": 256
+                    }
+                  }
+                },
+                "backend_roles": {
+                  "type" : "text",
+                  "fields" : {
+                    "keyword" : {
+                      "type" : "keyword"
+                    }
+                  }
+                },
+                "roles": {
+                  "type" : "text",
+                  "fields" : {
+                    "keyword" : {
+                      "type" : "keyword"
+                    }
+                  }
+                },
+                "custom_attribute_names": {
+                  "type" : "text",
+                  "fields" : {
+                    "keyword" : {
+                      "type" : "keyword"
+                    }
+                  }
+                }
+              }
             }
           }
         },

--- a/src/test/kotlin/org/opensearch/indexmanagement/IndexManagementRestTestCase.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/IndexManagementRestTestCase.kt
@@ -46,7 +46,7 @@ import javax.management.remote.JMXServiceURL
 
 abstract class IndexManagementRestTestCase : ODFERestTestCase() {
 
-    val configSchemaVersion = 10
+    val configSchemaVersion = 11
     val historySchemaVersion = 3
 
     // Having issues with tests leaking into other tests and mappings being incorrect and they are not caught by any pending task wait check as

--- a/src/test/resources/mappings/cached-opendistro-ism-config.json
+++ b/src/test/resources/mappings/cached-opendistro-ism-config.json
@@ -1,6 +1,6 @@
 {
   "_meta" : {
-    "schema_version": 10
+    "schema_version": 11
   },
   "dynamic": "strict",
   "properties": {
@@ -456,6 +456,43 @@
               "format": "strict_date_time||epoch_millis"
             }
           }
+        },
+        "user": {
+          "properties": {
+            "name": {
+              "type": "text",
+              "fields": {
+                "keyword": {
+                  "type": "keyword",
+                  "ignore_above": 256
+                }
+              }
+            },
+            "backend_roles": {
+              "type" : "text",
+              "fields" : {
+                "keyword" : {
+                  "type" : "keyword"
+                }
+              }
+            },
+            "roles": {
+              "type" : "text",
+              "fields" : {
+                "keyword" : {
+                  "type" : "keyword"
+                }
+              }
+            },
+            "custom_attribute_names": {
+              "type" : "text",
+              "fields" : {
+                "keyword" : {
+                  "type" : "keyword"
+                }
+              }
+            }
+          }
         }
       }
     },
@@ -536,6 +573,43 @@
                 },
                 "timezone": {
                   "type": "keyword"
+                }
+              }
+            }
+          }
+        },
+        "user": {
+          "properties": {
+            "name": {
+              "type": "text",
+              "fields": {
+                "keyword": {
+                  "type": "keyword",
+                  "ignore_above": 256
+                }
+              }
+            },
+            "backend_roles": {
+              "type" : "text",
+              "fields" : {
+                "keyword" : {
+                  "type" : "keyword"
+                }
+              }
+            },
+            "roles": {
+              "type" : "text",
+              "fields" : {
+                "keyword" : {
+                  "type" : "keyword"
+                }
+              }
+            },
+            "custom_attribute_names": {
+              "type" : "text",
+              "fields" : {
+                "keyword" : {
+                  "type" : "keyword"
                 }
               }
             }
@@ -851,6 +925,43 @@
               }
             }
           }
+        },
+        "user": {
+          "properties": {
+            "name": {
+              "type": "text",
+              "fields": {
+                "keyword": {
+                  "type": "keyword",
+                  "ignore_above": 256
+                }
+              }
+            },
+            "backend_roles": {
+              "type" : "text",
+              "fields" : {
+                "keyword" : {
+                  "type" : "keyword"
+                }
+              }
+            },
+            "roles": {
+              "type" : "text",
+              "fields" : {
+                "keyword" : {
+                  "type" : "keyword"
+                }
+              }
+            },
+            "custom_attribute_names": {
+              "type" : "text",
+              "fields" : {
+                "keyword" : {
+                  "type" : "keyword"
+                }
+              }
+            }
+          }
         }
       }
     },
@@ -1039,6 +1150,43 @@
         "data_selection_query": {
           "type": "object",
           "enabled": false
+        },
+        "user": {
+          "properties": {
+            "name": {
+              "type": "text",
+              "fields": {
+                "keyword": {
+                  "type": "keyword",
+                  "ignore_above": 256
+                }
+              }
+            },
+            "backend_roles": {
+              "type" : "text",
+              "fields" : {
+                "keyword" : {
+                  "type" : "keyword"
+                }
+              }
+            },
+            "roles": {
+              "type" : "text",
+              "fields" : {
+                "keyword" : {
+                  "type" : "keyword"
+                }
+              }
+            },
+            "custom_attribute_names": {
+              "type" : "text",
+              "fields" : {
+                "keyword" : {
+                  "type" : "keyword"
+                }
+              }
+            }
+          }
         }
       }
     },

--- a/src/test/resources/mappings/cached-opendistro-ism-config.json
+++ b/src/test/resources/mappings/cached-opendistro-ism-config.json
@@ -547,6 +547,43 @@
             },
             "is_safe": {
               "type": "boolean"
+            },
+            "user": {
+              "properties": {
+                "name": {
+                  "type": "text",
+                  "fields": {
+                    "keyword": {
+                      "type": "keyword",
+                      "ignore_above": 256
+                    }
+                  }
+                },
+                "backend_roles": {
+                  "type" : "text",
+                  "fields" : {
+                    "keyword" : {
+                      "type" : "keyword"
+                    }
+                  }
+                },
+                "roles": {
+                  "type" : "text",
+                  "fields" : {
+                    "keyword" : {
+                      "type" : "keyword"
+                    }
+                  }
+                },
+                "custom_attribute_names": {
+                  "type" : "text",
+                  "fields" : {
+                    "keyword" : {
+                      "type" : "keyword"
+                    }
+                  }
+                }
+              }
             }
           }
         },


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/opensearch-project/index-management/issues/75

*Description of changes:*
Storing user object as part of the job when information is available and setting the user roles in threadcontext while running the ISM policy actions to ensure the user who created managed indices have the necessary permissions before running the action

*CheckList:*
[  ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/index-management/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
