### PR TITLE
Removes dependency checkout and local build/publish steps in workflow…

### DIFF
--- a/.github/workflows/multi-node-test-workflow.yml
+++ b/.github/workflows/multi-node-test-workflow.yml
@@ -20,46 +20,6 @@ jobs:
         uses: actions/setup-java@v1
         with:
           java-version: 14
-      # dependencies: OpenSearch
-      - name: Checkout OpenSearch
-        uses: actions/checkout@v2
-        with:
-          repository: 'opensearch-project/OpenSearch'
-          path: OpenSearch
-          ref: '1.x'
-      - name: Build OpenSearch
-        working-directory: ./OpenSearch
-        run: ./gradlew publishToMavenLocal
-      # dependencies: common-utils
-      - name: Checkout common-utils
-        uses: actions/checkout@v2
-        with:
-          repository: 'opensearch-project/common-utils'
-          path: common-utils
-          ref: 'main'
-      - name: Build common-utils
-        working-directory: ./common-utils
-        run: ./gradlew publishToMavenLocal -Dopensearch.version=1.1.0-SNAPSHOT
-      # dependencies: job-scheduler
-      - name: Checkout job-scheduler
-        uses: actions/checkout@v2
-        with:
-          repository: 'opensearch-project/job-scheduler'
-          path: job-scheduler
-          ref: 'main'
-      - name: Build job-scheduler
-        working-directory: ./job-scheduler
-        run: ./gradlew publishToMavenLocal -Dopensearch.version=1.1.0-SNAPSHOT
-      # dependencies: alerting-notification
-      - name: Checkout alerting
-        uses: actions/checkout@v2
-        with:
-          repository: 'opensearch-project/alerting'
-          path: alerting
-          ref: 'main'
-      - name: Build alerting
-        working-directory: ./alerting
-        run: ./gradlew :alerting-notification:publishToMavenLocal -Dopensearch.version=1.1.0-SNAPSHOT
       # index-management
       - name: Checkout Branch
         uses: actions/checkout@v2

--- a/.github/workflows/test-and-build-workflow.yml
+++ b/.github/workflows/test-and-build-workflow.yml
@@ -20,46 +20,6 @@ jobs:
         uses: actions/setup-java@v1
         with:
           java-version: 14
-      # dependencies: OpenSearch
-      - name: Checkout OpenSearch
-        uses: actions/checkout@v2
-        with:
-          repository: 'opensearch-project/OpenSearch'
-          path: OpenSearch
-          ref: '1.x'
-      - name: Build OpenSearch
-        working-directory: ./OpenSearch
-        run: ./gradlew publishToMavenLocal
-      # dependencies: common-utils
-      - name: Checkout common-utils
-        uses: actions/checkout@v2
-        with:
-          repository: 'opensearch-project/common-utils'
-          path: common-utils
-          ref: 'main'
-      - name: Build common-utils
-        working-directory: ./common-utils
-        run: ./gradlew publishToMavenLocal -Dopensearch.version=1.1.0-SNAPSHOT
-      # dependencies: job-scheduler
-      - name: Checkout job-scheduler
-        uses: actions/checkout@v2
-        with:
-          repository: 'opensearch-project/job-scheduler'
-          path: job-scheduler
-          ref: 'main'
-      - name: Build job-scheduler
-        working-directory: ./job-scheduler
-        run: ./gradlew publishToMavenLocal -Dopensearch.version=1.1.0-SNAPSHOT
-      # dependencies: alerting-notification
-      - name: Checkout alerting
-        uses: actions/checkout@v2
-        with:
-          repository: 'opensearch-project/alerting'
-          path: alerting
-          ref: 'main'
-      - name: Build alerting
-        working-directory: ./alerting
-        run: ./gradlew :alerting-notification:publishToMavenLocal -Dopensearch.version=1.1.0-SNAPSHOT
       # build index management
       - name: Checkout Branch
         uses: actions/checkout@v2

--- a/build.gradle
+++ b/build.gradle
@@ -44,6 +44,7 @@ buildscript {
         mavenLocal()
         mavenCentral()
         maven { url "https://plugins.gradle.org/m2/" }
+        maven { url "https://aws.oss.sonatype.org/content/repositories/snapshots/" }
     }
 
     dependencies {


### PR DESCRIPTION
… as the staging artifacts are on maven now

Signed-off-by: Drew Baugher <46505179+dbbaughe@users.noreply.github.com>

*CheckList:*
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/index-management/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
