### PR TITLE
Successful deletes of an index still adds history document

### DIFF
--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/ManagedIndexRunner.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/ManagedIndexRunner.kt
@@ -381,6 +381,9 @@ object ManagedIndexRunner :
             }
 
             if (executedManagedIndexMetaData.isSuccessfulDelete) {
+                GlobalScope.launch(Dispatchers.IO + CoroutineName("ManagedIndexMetaData-AddHistory")) {
+                    ismHistory.addManagedIndexMetaDataHistory(listOf(executedManagedIndexMetaData))
+                }
                 return
             }
 

--- a/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/action/DeleteActionIT.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/action/DeleteActionIT.kt
@@ -1,0 +1,76 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.indexmanagement.indexstatemanagement.action
+
+import org.opensearch.indexmanagement.indexstatemanagement.IndexStateManagementRestTestCase
+import org.opensearch.indexmanagement.indexstatemanagement.model.Policy
+import org.opensearch.indexmanagement.indexstatemanagement.model.State
+import org.opensearch.indexmanagement.indexstatemanagement.model.action.DeleteActionConfig
+import org.opensearch.indexmanagement.indexstatemanagement.randomErrorNotification
+import org.opensearch.indexmanagement.waitFor
+import java.time.Instant
+import java.time.temporal.ChronoUnit
+import java.util.Locale
+
+class DeleteActionIT : IndexStateManagementRestTestCase() {
+
+    private val testIndexName = javaClass.simpleName.toLowerCase(Locale.ROOT)
+
+    fun `test basic`() {
+        val indexName = "${testIndexName}_index_1"
+        val policyID = "${testIndexName}_testPolicyName_1"
+        val actionConfig = DeleteActionConfig(0)
+        val states = listOf(
+            State("DeleteState", listOf(actionConfig), listOf())
+        )
+
+        val policy = Policy(
+            id = policyID,
+            description = "$testIndexName description",
+            schemaVersion = 1L,
+            lastUpdatedTime = Instant.now().truncatedTo(ChronoUnit.MILLIS),
+            errorNotification = randomErrorNotification(),
+            defaultState = states[0].name,
+            states = states
+        )
+        createPolicy(policy, policyID)
+        createIndex(indexName, policyID)
+
+        waitFor { assertIndexExists(indexName) }
+
+        val managedIndexConfig = getExistingManagedIndexConfig(indexName)
+        // Change the start time so the job will trigger in 2 seconds.
+        updateManagedIndexConfigStartTime(managedIndexConfig)
+
+        waitFor { assertEquals(policyID, getExplainManagedIndexMetaData(indexName).policyID) }
+
+        // Need to wait two cycles.
+        // Change the start time so the job will trigger in 2 seconds.
+        updateManagedIndexConfigStartTime(managedIndexConfig)
+
+        // confirm index does not exist anymore
+        waitFor { assertIndexDoesNotExist(indexName) }
+
+        // confirm we added a history document that says we did a successful delete operation
+        waitFor {
+            val response = getHistorySearchResponse(indexName)
+            assertTrue(
+                response.hits.hits
+                    .map { it.sourceAsMap }
+                    .any {
+                        val metadata = it["managed_index_meta_data"] as Map<*, *>
+                        val index = metadata["index"] as String
+                        val action = metadata["action"] as Map<*, *>
+                        val actionName = action["name"] as String
+                        val step = metadata["step"] as Map<*, *>
+                        val stepName = step["name"] as String
+                        val stepStatus = step["step_status"] as String
+                        index == indexName && actionName == "delete" && stepName == "attempt_delete" && stepStatus == "completed"
+                    }
+            )
+        }
+    }
+}


### PR DESCRIPTION
Signed-off-by: Drew Baugher <46505179+dbbaughe@users.noreply.github.com>

*Issue #, if available:*
https://github.com/opensearch-project/index-management/issues/159

*Description of changes:*
Previously when an index was successfully deleted by ISM it would just return early without adding a history document. This fixes that so we can see the successful delete in the history indices.

*CheckList:*
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/index-management/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
