### PR TITLE
Fix issues with security changes in rollup runnner

### DIFF
--- a/src/main/kotlin/org/opensearch/indexmanagement/transform/TransformRunner.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/transform/TransformRunner.kt
@@ -194,7 +194,7 @@ object TransformRunner :
             refreshPolicy = WriteRequest.RefreshPolicy.IMMEDIATE
         )
         return withClosableContext(
-            IndexManagementSecurityContext(transform.id, settings, threadPool.threadContext, transform.user)
+            IndexManagementSecurityContext(transform.id, settings, threadPool.threadContext, null)
         ) {
             val response: IndexTransformResponse = client.suspendUntil {
                 execute(IndexTransformAction.INSTANCE, request, it)

--- a/src/main/kotlin/org/opensearch/indexmanagement/util/SecurityUtils.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/util/SecurityUtils.kt
@@ -103,12 +103,13 @@ class SecurityUtils {
             resourceUser: User?,
             filterEnabled: Boolean = false
         ): Boolean {
-            if (!filterEnabled || resourceUser == null || (requestedUser != null && requestedUser.roles.contains(ADMIN_ROLE))) {
+            // Will not filter if filter is not enabled or stored user is null or requested user is null or if the user is admin
+            if (!filterEnabled || resourceUser == null || requestedUser == null || requestedUser.roles.contains(ADMIN_ROLE)) {
                 return true
             }
 
             val resourceBackendRoles = resourceUser.backendRoles
-            val requestedBackendRoles = requestedUser?.backendRoles
+            val requestedBackendRoles = requestedUser.backendRoles
 
             return !(resourceBackendRoles == null || requestedBackendRoles == null || resourceBackendRoles.intersect(requestedBackendRoles).isEmpty())
         }


### PR DESCRIPTION
*Issue #, if available:*
* https://github.com/opensearch-project/index-management/issues/162
* https://github.com/opensearch-project/index-management/issues/163

*Description of changes:*
* Correct filtering logic - if the requested user is null then filter is not applied
* Not setting user in the thread context when calling GetRollup/UpdateRollup and UpdateTransform in Rollup/TransformRunners
* Correcting retry logic in TransformIndexer and RollupIndexer

*CheckList:*
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/index-management/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
