### PR TITLE
Remove policy API on read only indices

### DIFF
--- a/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/IndexStateManagementRestTestCase.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/IndexStateManagementRestTestCase.kt
@@ -524,6 +524,22 @@ abstract class IndexStateManagementRestTestCase : IndexManagementRestTestCase() 
     }
 
     @Suppress("UNCHECKED_CAST")
+    protected fun getIndexReadOnlySetting(indexName: String): Boolean? {
+        val indexSettings = getIndexSettings(indexName) as Map<String, Map<String, Map<String, Any?>>>
+        val readOnlySetting = indexSettings[indexName]!!["settings"]!![IndexMetadata.SETTING_READ_ONLY]
+        if (readOnlySetting != null) return (readOnlySetting as String).toBoolean()
+        return null
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    protected fun getIndexReadOnlyAllowDeleteSetting(indexName: String): Boolean? {
+        val indexSettings = getIndexSettings(indexName) as Map<String, Map<String, Map<String, Any?>>>
+        val readOnlyAllowDeleteSetting = indexSettings[indexName]!!["settings"]!![IndexMetadata.SETTING_READ_ONLY_ALLOW_DELETE]
+        if (readOnlyAllowDeleteSetting != null) return (readOnlyAllowDeleteSetting as String).toBoolean()
+        return null
+    }
+
+    @Suppress("UNCHECKED_CAST")
     protected fun getUuid(indexName: String): String {
         val indexSettings = getIndexSettings(indexName) as Map<String, Map<String, Map<String, Any?>>>
         return indexSettings[indexName]!!["settings"]!!["index.uuid"] as String

--- a/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/resthandler/RestRemovePolicyActionIT.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/resthandler/RestRemovePolicyActionIT.kt
@@ -27,7 +27,9 @@
 package org.opensearch.indexmanagement.indexstatemanagement.resthandler
 
 import org.opensearch.client.ResponseException
+import org.opensearch.cluster.metadata.IndexMetadata
 import org.opensearch.indexmanagement.indexstatemanagement.IndexStateManagementRestTestCase
+import org.opensearch.indexmanagement.indexstatemanagement.settings.ManagedIndexSettings
 import org.opensearch.indexmanagement.indexstatemanagement.util.FAILED_INDICES
 import org.opensearch.indexmanagement.indexstatemanagement.util.FAILURES
 import org.opensearch.indexmanagement.indexstatemanagement.util.UPDATED_INDICES
@@ -190,20 +192,48 @@ class RestRemovePolicyActionIT : IndexStateManagementRestTestCase() {
         }
     }
 
-    fun `test remove policy update auto_manage setting`() {
-        val index = "movies"
+    fun `test remove policy on read only index update auto_manage setting`() {
+        val index1 = "read_only_index"
+        val index2 = "read_only_allow_delete_index"
+        val index3 = "normal_index"
+        val index4 = "auto_manage_false_index"
+        val indexPattern = "*index"
         val policy = createRandomPolicy()
-        createIndex(index, policy.id)
-        assertEquals("auto manage setting not null at index creation time", null, getIndexAutoManageSetting(index))
+        createIndex(index1, policy.id)
+        createIndex(index2, policy.id)
+        createIndex(index3, policy.id)
+        createIndex(index4, policy.id)
+        updateIndexSetting(index1, IndexMetadata.SETTING_READ_ONLY, "true")
+        updateIndexSetting(index2, IndexMetadata.SETTING_READ_ONLY_ALLOW_DELETE, "true")
+        updateIndexSetting(index4, ManagedIndexSettings.AUTO_MANAGE.key, "false")
 
         val response = client().makeRequest(
             POST.toString(),
-            "${RestRemovePolicyAction.REMOVE_POLICY_BASE_URI}/$index"
+            "${RestRemovePolicyAction.REMOVE_POLICY_BASE_URI}/$indexPattern"
         )
         assertEquals("Unexpected RestStatus", RestStatus.OK, response.restStatus())
+        val actualMessage = response.asMap()
+        val expectedMessage = mapOf(
+            UPDATED_INDICES to 4,
+            FAILURES to false,
+            FAILED_INDICES to emptyList<Any>()
+        )
+        assertAffectedIndicesResponseIsEqual(expectedMessage, actualMessage)
 
         waitFor {
-            assertEquals("auto manage setting not false after removing policy", false, getIndexAutoManageSetting(index))
+            assertEquals("auto manage setting not false after removing policy for index $index1", false, getIndexAutoManageSetting(index1))
+            assertEquals("read only allow delete setting changed after removing policy for index $index1", null, getIndexReadOnlyAllowDeleteSetting(index1))
+            assertEquals("auto manage setting not false after removing policy for index $index2", false, getIndexAutoManageSetting(index2))
+            assertEquals("read only setting changed after removing policy for index $index2", null, getIndexReadOnlySetting(index2))
+            assertEquals("auto manage setting not false after removing policy for index $index3", false, getIndexAutoManageSetting(index3))
+            assertEquals("read only setting changed after removing policy for index $index3", null, getIndexReadOnlySetting(index3))
+            assertEquals("read only allow delete setting changed after removing policy for index $index3", null, getIndexReadOnlyAllowDeleteSetting(index3))
+            assertEquals("auto manage setting not false after removing policy for index $index4", false, getIndexAutoManageSetting(index3))
+            assertEquals("read only setting changed after removing policy for index $index4", null, getIndexReadOnlySetting(index3))
+            assertEquals("read only allow delete setting changed after removing policy for index $index4", null, getIndexReadOnlyAllowDeleteSetting(index3))
         }
+
+        // otherwise, test cleanup cannot delete this index
+        updateIndexSetting(index1, IndexMetadata.SETTING_READ_ONLY, "false")
     }
 }


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/opensearch-project/index-management/issues/171

*Description of changes:*
Allow removing policies from read only indices. Today one can add policies to read only indices but cannot remove it. The fix will allow one to remove the policies even on readonly indices.

*CheckList:*
- [X ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/index-management/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
