### PR TITLE
In explain API not showing the total count to all users

### DIFF
--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/transport/action/explain/TransportExplainAction.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/transport/action/explain/TransportExplainAction.kt
@@ -353,6 +353,7 @@ class TransportExplainAction @Inject constructor(
                     override fun onFailure(e: Exception) {
                         when (e is OpenSearchSecurityException) {
                             true -> {
+                                totalManagedIndices -= 1
                                 if (current < indexNames.count() - 1) {
                                     // do nothing - skip the index and go to next one
                                     filter(current + 1, filteredIndices, filteredMetadata, filteredPolicies, enabledStatus)


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
IndexManagement managed indices explain API at the moment show all matching managed indices count to all users, instead just showing the count that users can actually allowed to see.

e.g there are 3 managed indices "a", "b", "c" and user jane is allowed to see only "a"
the output of current explain API looks like 
```
{
   "a": {},
   "total_managed_indices": 3
}
```

after the fix it will look like
```
{
   "a": {},
   "total_managed_indices": 1
}
```


*CheckList:*
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/index-management/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
