### PR TITLE
Adds 1.2.0.0 release notes

### DIFF
--- a/release-notes/opensearch-index-management.release-notes-1.2.0.0.md
+++ b/release-notes/opensearch-index-management.release-notes-1.2.0.0.md
@@ -1,0 +1,31 @@
+## Version 1.2.0.0 2021-11-05
+
+Compatible with OpenSearch 1.2.0
+
+### Enhancements
+
+* Making snapshot name to scripted input in template ([#77](https://github.com/opensearch-project/index-management/pull/77))
+* Adds setting to search all rollup jobs on a target index ([#165](https://github.com/opensearch-project/index-management/pull/165))
+* Adds cluster setting to configure index state management jitter ([#153](https://github.com/opensearch-project/index-management/pull/153))
+* Allows out of band rollovers on an index without causing ISM to fail ([#180](https://github.com/opensearch-project/index-management/pull/180))
+
+### Bug Fixes
+
+* Adds implementation for the delay feature in rollup jobs ([#147](https://github.com/opensearch-project/index-management/pull/147))
+* Remove policy API on read only indices ([#182](https://github.com/opensearch-project/index-management/pull/182))
+* In explain API not showing the total count to all users ([#185](https://github.com/opensearch-project/index-management/pull/185))
+
+### Infrastructure
+
+* Uses published daily snapshot dependencies ([#141](https://github.com/opensearch-project/index-management/pull/141))
+* Removes default integtest.sh ([#148](https://github.com/opensearch-project/index-management/pull/148))
+* Adds mavenLocal back to repositories ([#158](https://github.com/opensearch-project/index-management/pull/158))
+
+### Documentation
+
+* Automatically provides license header for new files ([#142](https://github.com/opensearch-project/index-management/pull/142))
+
+### Maintenance
+
+* Updates index management version to 1.2 ([#157](https://github.com/opensearch-project/index-management/pull/157))
+* Updates testCompile mockito version, adds AwaitsFix annotation to MetadataRegressionIT tests ([#168](https://github.com/opensearch-project/index-management/pull/168))


### PR DESCRIPTION
Signed-off-by: Robert Downs <downsrob@amazon.com>

*Issue #, if available:*

*Description of changes:*
Cherry picks 1.2.0.0 release notes to 1.x branch to prepare for 1.2 cut.

*CheckList:*
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/index-management/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
