### PR TITLE
Removes AwaitsFix annotation from MetadataRegressionIT tests

### DIFF
--- a/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/MetadataRegressionIT.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/MetadataRegressionIT.kt
@@ -221,7 +221,7 @@ class MetadataRegressionIT : IndexStateManagementIntegTestCase() {
             )
         }
     }
-    
+
     fun `test new node skip execution when old node exist in cluster`() {
         Assume.assumeTrue(isMixedNodeRegressionTest)
 

--- a/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/MetadataRegressionIT.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/MetadataRegressionIT.kt
@@ -66,7 +66,6 @@ class MetadataRegressionIT : IndexStateManagementIntegTestCase() {
         updateIndexStateManagementJitterSetting(null)
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/opensearch-project/index-management/issues/176")
     fun `test move metadata service`() {
         updateClusterSetting(ManagedIndexSettings.METADATA_SERVICE_ENABLED.key, "false")
         updateClusterSetting(ManagedIndexSettings.METADATA_SERVICE_ENABLED.key, "true")
@@ -141,7 +140,6 @@ class MetadataRegressionIT : IndexStateManagementIntegTestCase() {
         }
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/opensearch-project/index-management/issues/176")
     fun `test job can continue run from cluster state metadata`() {
         /**
          *  new version of ISM plugin can handle metadata in cluster state
@@ -223,8 +221,7 @@ class MetadataRegressionIT : IndexStateManagementIntegTestCase() {
             )
         }
     }
-
-    @AwaitsFix(bugUrl = "https://github.com/opensearch-project/index-management/issues/176")
+    
     fun `test new node skip execution when old node exist in cluster`() {
         Assume.assumeTrue(isMixedNodeRegressionTest)
 


### PR DESCRIPTION
Signed-off-by: Robert Downs <downsrob@amazon.com>

*Issue #, if available:*
https://github.com/opensearch-project/index-management/issues/176
*Description of changes:*
Removes AwaitsFix annotation from MetadataRegressionIT tests as the upstream bug causing these failures was fixed.
*CheckList:*
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/index-management/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
