### PR TITLE
Fixes test deleting a transform that doesn't exist (#198)

### DIFF
--- a/src/test/kotlin/org/opensearch/indexmanagement/transform/resthandler/RestDeleteTransformActionIT.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/transform/resthandler/RestDeleteTransformActionIT.kt
@@ -81,7 +81,7 @@ class RestDeleteTransformActionIT : TransformRestTestCase() {
     @Throws(Exception::class)
     fun `test deleting a transform that doesn't exist and config index doesn't exist`() {
         try {
-            deleteIndex(INDEX_MANAGEMENT_INDEX)
+            if (indexExists(INDEX_MANAGEMENT_INDEX)) deleteIndex(INDEX_MANAGEMENT_INDEX)
             val res = client().makeRequest("DELETE", "$TRANSFORM_BASE_URI/foobarbaz")
             fail("expected 404 ResponseException: ${res.asMap()}")
         } catch (e: ResponseException) {


### PR DESCRIPTION
Signed-off-by: Robert Downs <downsrob@amazon.com>

Backport of https://github.com/opensearch-project/index-management/pull/198 to 1.x
*Issue #, if available:*
https://github.com/opensearch-project/index-management/issues/197
*Description of changes:*
Fixes the 'RestDeleteTransformActionIT.test deleting a transform that doesn't exist and config index doesn't exist' test which always failed when the index management system index is not present at the start of the test. This wasn't noticed before, as the system index is often present at the start of the test when the entire test suite is run.

For additional context, this failing test was likely copied from [this analogous rollups test](https://github.com/opensearch-project/index-management/blob/70b39ea763090c93f776016f95e8d0fc7ab795e2/src/test/kotlin/org/opensearch/indexmanagement/rollup/resthandler/RestDeleteRollupActionIT.kt#L58-L67), which passes because rollups return NOT_FOUND when a rollup/ism index doesn't exist, whereas transforms return BAD_REQUEST. Additional sharing of code between the ISM sub-plugins may help prevent this issue in the future.

*CheckList:*
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/index-management/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
