### PR TITLE
Adds test and build workflow for mac and windows

### DIFF
--- a/.github/workflows/test-and-build-workflow.yml
+++ b/.github/workflows/test-and-build-workflow.yml
@@ -65,7 +65,7 @@ jobs:
         run: subst 'X:' .
       - name: Build with Gradle
         working-directory: 'X:'
-        run: ./gradlew.bat build -D"opensearch.version=1.2.0-SNAPSHOT" -x integTest -x jacocoTestReport
+        run: ./gradlew.bat build -D"opensearch.version=1.3.0-SNAPSHOT" -x integTest -x jacocoTestReport
         env:
           _JAVA_OPTIONS: -Xmx4096M
 #      - name: Upload failed logs
@@ -99,7 +99,7 @@ jobs:
       - name: Checkout Branch
         uses: actions/checkout@v2
       - name: Build with Gradle
-        run: ./gradlew build -Dopensearch.version=1.2.0-SNAPSHOT -x integTest -x jacocoTestReport
+        run: ./gradlew build -Dopensearch.version=1.3.0-SNAPSHOT -x integTest -x jacocoTestReport
 #      - name: Upload failed logs
 #        uses: actions/upload-artifact@v2
 #        if: failure()

--- a/.github/workflows/test-and-build-workflow.yml
+++ b/.github/workflows/test-and-build-workflow.yml
@@ -1,5 +1,5 @@
 name: Test and Build Workflow
-# This workflow is triggered on pull requests to main or a opendistro release branch
+# This workflow is triggered on pull requests to main or an opendistro release branch
 on:
   pull_request:
     branches:
@@ -7,49 +7,27 @@ on:
   push:
     branches:
       - "*"
-
 jobs:
-  linux-build:
+  build:
     # Job name
     name: Build Index Management
-    # This job runs on Linux
-    runs-on: ubuntu-latest
-    steps:
-      # This step uses the setup-java Github action: https://github.com/actions/setup-java
-      - name: Set Up JDK 14
-        uses: actions/setup-java@v1
-        with:
-          java-version: 14
-      # build index management
-      - name: Checkout Branch
-        uses: actions/checkout@v2
-      - name: Build with Gradle
-        run: ./gradlew build -Dopensearch.version=1.3.0-SNAPSHOT
-      - name: Upload failed logs
-        uses: actions/upload-artifact@v2
-        if: failure()
-        with:
-          name: logs
-          path: build/testclusters/integTest-*/logs/*
-      - name: Create Artifact Path
-        run: |
-          mkdir -p index-management-artifacts
-          cp ./build/distributions/*.zip index-management-artifacts
-      - name: Uploads coverage
-        uses: codecov/codecov-action@v1
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-      # This step uses the upload-artifact Github action: https://github.com/actions/upload-artifact
-      - name: Upload Artifacts
-        uses: actions/upload-artifact@v1
-        with:
-          name: index-management-plugin-ubuntu
-          path: index-management-artifacts
-  windows-build:
-    # Job name
-    name: Build Index Management
-    # This job runs on Windows
-    runs-on: windows-latest
+    env:
+      BUILD_ARGS: -D"opensearch.version=1.3.0-SNAPSHOT" ${{ matrix.os_build_args }}
+      WORKING_DIR: ${{ matrix.working_directory }}.
+    strategy:
+      # This setting says that all jobs should finish, even if one fails
+      fail-fast: false
+      # This starts three jobs, with
+      matrix:
+        include:
+          - os: ubuntu-latest
+          - os: windows-latest
+            os_build_args: -x integTest -x jacocoTestReport
+            working_directory: X:\
+            os_java_options: -Xmx4096M
+          - os: macos-latest
+            os_build_args: -x integTest -x jacocoTestReport
+    runs-on: ${{ matrix.os }}
     steps:
       # This step uses the setup-java Github action: https://github.com/actions/setup-java
       - name: Set Up JDK 14
@@ -62,57 +40,31 @@ jobs:
       # This is a hack, but this step creates a link to the X: mounted drive, which makes the path
       # short enough to work on Windows
       - name: Shorten Path
+        if: ${{ matrix.os == 'windows-latest' }}
         run: subst 'X:' .
       - name: Build with Gradle
-        working-directory: 'X:'
-        run: ./gradlew.bat build -D"opensearch.version=1.3.0-SNAPSHOT" -x integTest -x jacocoTestReport
+        working-directory: ${{ env.WORKING_DIR }}
+        run: ./gradlew build ${{ env.BUILD_ARGS }}
         env:
-          _JAVA_OPTIONS: -Xmx4096M
-#      - name: Upload failed logs
-#        uses: actions/upload-artifact@v2
-#        if: failure()
-#        with:
-#          name: logs
-#          path: build/testclusters/integTest-*/logs/*
+          _JAVA_OPTIONS: ${{ matrix.os_java_options }}
+      - name: Upload failed logs
+        uses: actions/upload-artifact@v2
+        if: ${{ failure() && matrix.os == 'ubuntu-latest' }}
+        with:
+          name: logs
+          path: build/testclusters/integTest-*/logs/*
       - name: Create Artifact Path
         run: |
           mkdir -p index-management-artifacts
           cp ./build/distributions/*.zip index-management-artifacts
+      - name: Uploads coverage
+        if: ${{ matrix.os == 'ubuntu-latest' }}
+        uses: codecov/codecov-action@v1
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
       # This step uses the upload-artifact Github action: https://github.com/actions/upload-artifact
       - name: Upload Artifacts
         uses: actions/upload-artifact@v1
         with:
-          name: index-management-plugin-windows
-          path: index-management-artifacts
-  mac-build:
-    # Job name
-    name: Build Index Management
-    # This job runs on Mac OS
-    runs-on: macos-latest
-    steps:
-      # This step uses the setup-java Github action: https://github.com/actions/setup-java
-      - name: Set Up JDK 14
-        uses: actions/setup-java@v1
-        with:
-          java-version: 14
-      # build index management
-      - name: Checkout Branch
-        uses: actions/checkout@v2
-      - name: Build with Gradle
-        run: ./gradlew build -Dopensearch.version=1.3.0-SNAPSHOT -x integTest -x jacocoTestReport
-#      - name: Upload failed logs
-#        uses: actions/upload-artifact@v2
-#        if: failure()
-#        with:
-#          name: logs
-#          path: build/testclusters/integTest-*/logs/*
-      - name: Create Artifact Path
-        run: |
-          mkdir -p index-management-artifacts
-          cp ./build/distributions/*.zip index-management-artifacts
-      # This step uses the upload-artifact Github action: https://github.com/actions/upload-artifact
-      - name: Upload Artifacts
-        uses: actions/upload-artifact@v1
-        with:
-          name: index-management-plugin-mac
+          name: index-management-plugin-${{ matrix.os }}
           path: index-management-artifacts

--- a/.github/workflows/test-and-build-workflow.yml
+++ b/.github/workflows/test-and-build-workflow.yml
@@ -60,7 +60,7 @@ jobs:
       - name: Checkout Branch
         uses: actions/checkout@v2
       - name: Build with Gradle
-        run: gradlew build -Dopensearch.version=1.2.0-SNAPSHOT
+        run: ./gradlew.bat build -Dopensearch.version=1.2.0-SNAPSHOT
       - name: Upload failed logs
         uses: actions/upload-artifact@v2
         if: failure()

--- a/.github/workflows/test-and-build-workflow.yml
+++ b/.github/workflows/test-and-build-workflow.yml
@@ -60,7 +60,7 @@ jobs:
       - name: Checkout Branch
         uses: actions/checkout@v2
       - name: Build with Gradle
-        run: ./gradlew.bat build -Dopensearch.version=1.2.0-SNAPSHOT
+        run: ./gradlew.bat build -D"opensearch.version=1.2.0-SNAPSHOT"
       - name: Upload failed logs
         uses: actions/upload-artifact@v2
         if: failure()

--- a/.github/workflows/test-and-build-workflow.yml
+++ b/.github/workflows/test-and-build-workflow.yml
@@ -56,15 +56,14 @@ jobs:
         uses: actions/setup-java@v1
         with:
           java-version: 14
-      # This step creates a link to the X: mounted drive, which makes the path short enough to work on windows
-      - name: Shorten Path
-        run: subst 'X:' .
-      - name: Go to Shorter Path
-        run: cd 'X:'
       # build index management
       - name: Checkout Branch
         uses: actions/checkout@v2
+      # This step creates a link to the X: mounted drive, which makes the path short enough to work on windows
+      - name: Shorten Path
+        run: subst 'X:' .
       - name: Build with Gradle
+        working-directory: 'X:'
         run: ./gradlew.bat build -D"opensearch.version=1.2.0-SNAPSHOT"
         env:
           _JAVA_OPTIONS: -Xmx4096M

--- a/.github/workflows/test-and-build-workflow.yml
+++ b/.github/workflows/test-and-build-workflow.yml
@@ -9,7 +9,7 @@ on:
       - "*"
 
 jobs:
-  build:
+  linux-build:
     # Job name
     name: Build Index Management
     # This job runs on Linux
@@ -35,6 +35,42 @@ jobs:
         run: |
           mkdir -p index-management-artifacts
           cp ./build/distributions/*.zip index-management-artifacts        
+      - name: Uploads coverage
+        uses: codecov/codecov-action@v1
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+      # This step uses the upload-artifact Github action: https://github.com/actions/upload-artifact
+      - name: Upload Artifacts
+        uses: actions/upload-artifact@v1
+        with:
+          name: index-management-plugin
+          path: index-management-artifacts
+  windows-build:
+    # Job name
+    name: Build Index Management
+    # This job runs on Windows
+    runs-on: windows-latest
+    steps:
+      # This step uses the setup-java Github action: https://github.com/actions/setup-java
+      - name: Set Up JDK 14
+        uses: actions/setup-java@v1
+        with:
+          java-version: 14
+      # build index management
+      - name: Checkout Branch
+        uses: actions/checkout@v2
+      - name: Build with Gradle
+        run: ./gradlew build -Dopensearch.version=1.2.0-SNAPSHOT
+      - name: Upload failed logs
+        uses: actions/upload-artifact@v2
+        if: failure()
+        with:
+          name: logs
+          path: build/testclusters/integTest-*/logs/*
+      - name: Create Artifact Path
+        run: |
+          mkdir -p index-management-artifacts
+          cp ./build/distributions/*.zip index-management-artifacts
       - name: Uploads coverage
         uses: codecov/codecov-action@v1
         with:

--- a/.github/workflows/test-and-build-workflow.yml
+++ b/.github/workflows/test-and-build-workflow.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Create Artifact Path
         run: |
           mkdir -p index-management-artifacts
-          cp ./build/distributions/*.zip index-management-artifacts        
+          cp ./build/distributions/*.zip index-management-artifacts
       - name: Uploads coverage
         uses: codecov/codecov-action@v1
         with:
@@ -59,20 +59,45 @@ jobs:
       # build index management
       - name: Checkout Branch
         uses: actions/checkout@v2
-      # This step creates a link to the X: mounted drive, which makes the path short enough to work on windows
+      # This is a hack, but this step creates a link to the X: mounted drive, which makes the path
+      # short enough to work on Windows
       - name: Shorten Path
         run: subst 'X:' .
       - name: Build with Gradle
         working-directory: 'X:'
-        run: ./gradlew.bat build -D"opensearch.version=1.2.0-SNAPSHOT"
+        run: ./gradlew.bat build -D"opensearch.version=1.2.0-SNAPSHOT" -x integTest -x jacocoTestReport
         env:
           _JAVA_OPTIONS: -Xmx4096M
-      - name: Upload failed logs
-        uses: actions/upload-artifact@v2
-        if: failure()
+      - name: Create Artifact Path
+        run: |
+          mkdir -p index-management-artifacts
+          cp ./build/distributions/*.zip index-management-artifacts
+      - name: Uploads coverage
+        uses: codecov/codecov-action@v1
         with:
-          name: logs
-          path: build/testclusters/integTest-*/logs/*
+          token: ${{ secrets.CODECOV_TOKEN }}
+      # This step uses the upload-artifact Github action: https://github.com/actions/upload-artifact
+      - name: Upload Artifacts
+        uses: actions/upload-artifact@v1
+        with:
+          name: index-management-plugin
+          path: index-management-artifacts
+  mac-build:
+    # Job name
+    name: Build Index Management
+    # This job runs on Windows
+    runs-on: windows-latest
+    steps:
+      # This step uses the setup-java Github action: https://github.com/actions/setup-java
+      - name: Set Up JDK 14
+        uses: actions/setup-java@v1
+        with:
+          java-version: 14
+      # build index management
+      - name: Checkout Branch
+        uses: actions/checkout@v2
+      - name: Build with Gradle
+        run: ./gradlew.bat build -Dopensearch.version=1.2.0-SNAPSHOT -x integTest -x jacocoTestReport
       - name: Create Artifact Path
         run: |
           mkdir -p index-management-artifacts

--- a/.github/workflows/test-and-build-workflow.yml
+++ b/.github/workflows/test-and-build-workflow.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Upload Artifacts
         uses: actions/upload-artifact@v1
         with:
-          name: index-management-plugin
+          name: index-management-plugin-ubuntu
           path: index-management-artifacts
   windows-build:
     # Job name
@@ -68,19 +68,21 @@ jobs:
         run: ./gradlew.bat build -D"opensearch.version=1.2.0-SNAPSHOT" -x integTest -x jacocoTestReport
         env:
           _JAVA_OPTIONS: -Xmx4096M
+#      - name: Upload failed logs
+#        uses: actions/upload-artifact@v2
+#        if: failure()
+#        with:
+#          name: logs
+#          path: build/testclusters/integTest-*/logs/*
       - name: Create Artifact Path
         run: |
           mkdir -p index-management-artifacts
           cp ./build/distributions/*.zip index-management-artifacts
-      - name: Uploads coverage
-        uses: codecov/codecov-action@v1
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
       # This step uses the upload-artifact Github action: https://github.com/actions/upload-artifact
       - name: Upload Artifacts
         uses: actions/upload-artifact@v1
         with:
-          name: index-management-plugin
+          name: index-management-plugin-windows
           path: index-management-artifacts
   mac-build:
     # Job name
@@ -98,17 +100,19 @@ jobs:
         uses: actions/checkout@v2
       - name: Build with Gradle
         run: ./gradlew build -Dopensearch.version=1.2.0-SNAPSHOT -x integTest -x jacocoTestReport
+#      - name: Upload failed logs
+#        uses: actions/upload-artifact@v2
+#        if: failure()
+#        with:
+#          name: logs
+#          path: build/testclusters/integTest-*/logs/*
       - name: Create Artifact Path
         run: |
           mkdir -p index-management-artifacts
           cp ./build/distributions/*.zip index-management-artifacts
-      - name: Uploads coverage
-        uses: codecov/codecov-action@v1
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
       # This step uses the upload-artifact Github action: https://github.com/actions/upload-artifact
       - name: Upload Artifacts
         uses: actions/upload-artifact@v1
         with:
-          name: index-management-plugin
+          name: index-management-plugin-mac
           path: index-management-artifacts

--- a/.github/workflows/test-and-build-workflow.yml
+++ b/.github/workflows/test-and-build-workflow.yml
@@ -60,7 +60,7 @@ jobs:
       - name: Checkout Branch
         uses: actions/checkout@v2
       - name: Build with Gradle
-        run: ./gradlew build -Dopensearch.version=1.2.0-SNAPSHOT
+        run: gradlew build -Dopensearch.version=1.2.0-SNAPSHOT
       - name: Upload failed logs
         uses: actions/upload-artifact@v2
         if: failure()

--- a/.github/workflows/test-and-build-workflow.yml
+++ b/.github/workflows/test-and-build-workflow.yml
@@ -97,7 +97,7 @@ jobs:
       - name: Checkout Branch
         uses: actions/checkout@v2
       - name: Build with Gradle
-        run: ./gradlew.bat build -Dopensearch.version=1.2.0-SNAPSHOT -x integTest -x jacocoTestReport
+        run: ./gradlew build -Dopensearch.version=1.2.0-SNAPSHOT -x integTest -x jacocoTestReport
       - name: Create Artifact Path
         run: |
           mkdir -p index-management-artifacts

--- a/.github/workflows/test-and-build-workflow.yml
+++ b/.github/workflows/test-and-build-workflow.yml
@@ -7,6 +7,7 @@ on:
   push:
     branches:
       - "*"
+
 jobs:
   build:
     # Job name
@@ -17,7 +18,7 @@ jobs:
     strategy:
       # This setting says that all jobs should finish, even if one fails
       fail-fast: false
-      # This starts three jobs, with
+      # This starts three jobs, setting these environment variables uniquely for the different jobs
       matrix:
         include:
           - os: ubuntu-latest

--- a/.github/workflows/test-and-build-workflow.yml
+++ b/.github/workflows/test-and-build-workflow.yml
@@ -1,5 +1,4 @@
 name: Test and Build Workflow
-# This workflow is triggered on pull requests to main or an opendistro release branch
 on:
   pull_request:
     branches:

--- a/.github/workflows/test-and-build-workflow.yml
+++ b/.github/workflows/test-and-build-workflow.yml
@@ -56,11 +56,18 @@ jobs:
         uses: actions/setup-java@v1
         with:
           java-version: 14
+      # This step creates a link to the X: mounted drive, which makes the path short enough to work on windows
+      - name: Shorten Path
+        run: subst 'X:' .
+      - name: Go to Shorter Path
+        run: cd 'X:'
       # build index management
       - name: Checkout Branch
         uses: actions/checkout@v2
       - name: Build with Gradle
         run: ./gradlew.bat build -D"opensearch.version=1.2.0-SNAPSHOT"
+        env:
+          _JAVA_OPTIONS: -Xmx4096M
       - name: Upload failed logs
         uses: actions/upload-artifact@v2
         if: failure()

--- a/.github/workflows/test-and-build-workflow.yml
+++ b/.github/workflows/test-and-build-workflow.yml
@@ -85,8 +85,8 @@ jobs:
   mac-build:
     # Job name
     name: Build Index Management
-    # This job runs on Windows
-    runs-on: windows-latest
+    # This job runs on Mac OS
+    runs-on: macos-latest
     steps:
       # This step uses the setup-java Github action: https://github.com/actions/setup-java
       - name: Set Up JDK 14


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/opensearch-project/index-management/issues/173 https://github.com/opensearch-project/index-management/issues/172
*Description of changes:*

- Adds windows and mac build tasks to the test and build workflow to run as part of github CI. As there currently are no min distributions for mac or windows, plugins are blocked on running integration tests on mac or windows machines. While waiting for the min distribution, integration tests are disabled, but unit tests and build tasks are run. 
- Artifacts are uploaded for each build. Though the artifacts differ very little, with just different line ending for windows, and different manifests documenting the build OS, they may be useful for debugging a build failure on the mac or windows distribution.

*CheckList:*
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/index-management/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
