### PR TITLE
Adds default action retries

### DIFF
--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/model/action/ActionConfig.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/model/action/ActionConfig.kt
@@ -28,9 +28,7 @@ abstract class ActionConfig(
 ) : ToXContentFragment, Writeable {
 
     var configTimeout: ActionTimeout? = null
-        private set
     var configRetry: ActionRetry? = null
-        private set
 
     override fun toXContent(builder: XContentBuilder, params: ToXContent.Params): XContentBuilder {
         configTimeout?.toXContent(builder, params)
@@ -76,6 +74,8 @@ abstract class ActionConfig(
     }
 
     companion object {
+        private const val DEFAULT_RETRIES = 3L
+
         // TODO clean up for actionIndex
         @JvmStatic
         @Throws(IOException::class)
@@ -115,7 +115,7 @@ abstract class ActionConfig(
         fun parse(xcp: XContentParser, index: Int): ActionConfig {
             var actionConfig: ActionConfig? = null
             var timeout: ActionTimeout? = null
-            var retry: ActionRetry? = null
+            var retry: ActionRetry? = ActionRetry(DEFAULT_RETRIES)
 
             ensureExpectedToken(Token.START_OBJECT, xcp.currentToken(), xcp)
             while (xcp.nextToken() != Token.END_OBJECT) {

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/model/action/ActionRetry.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/model/action/ActionRetry.kt
@@ -28,7 +28,7 @@ data class ActionRetry(
     val delay: TimeValue = TimeValue.timeValueMinutes(1)
 ) : ToXContentFragment, Writeable {
 
-    init { require(count > 0) { "Count for ActionRetry must be greater than 0" } }
+    init { require(count >= 0) { "Count for ActionRetry must be a non-negative number" } }
 
     override fun toXContent(builder: XContentBuilder, params: ToXContent.Params): XContentBuilder {
         builder

--- a/src/test/kotlin/org/opensearch/indexmanagement/ODFERestTestCase.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/ODFERestTestCase.kt
@@ -98,6 +98,10 @@ abstract class ODFERestTestCase : OpenSearchRestTestCase() {
 
     @Throws(IOException::class)
     open fun wipeAllODFEIndices() {
+        // Delete all data stream indices
+        client().performRequest(Request("DELETE", "/_data_stream/*"))
+
+        // Delete all indices
         val response = client().performRequest(Request("GET", "/_cat/indices?format=json&expand_wildcards=all"))
 
         val xContentType = XContentType.fromMediaTypeOrFormat(response.entity.contentType.value)

--- a/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/action/RolloverActionIT.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/action/RolloverActionIT.kt
@@ -17,6 +17,7 @@ import org.opensearch.indexmanagement.indexstatemanagement.IndexStateManagementR
 import org.opensearch.indexmanagement.indexstatemanagement.model.ISMTemplate
 import org.opensearch.indexmanagement.indexstatemanagement.model.Policy
 import org.opensearch.indexmanagement.indexstatemanagement.model.State
+import org.opensearch.indexmanagement.indexstatemanagement.model.action.ActionRetry
 import org.opensearch.indexmanagement.indexstatemanagement.model.action.RolloverActionConfig
 import org.opensearch.indexmanagement.indexstatemanagement.randomErrorNotification
 import org.opensearch.indexmanagement.indexstatemanagement.resthandler.RestRetryFailedManagedIndexAction
@@ -277,6 +278,7 @@ class RolloverActionIT : IndexStateManagementRestTestCase() {
         val alias1 = "x"
         val policyID = "${testIndexName}_precheck"
         val actionConfig = RolloverActionConfig(null, 3, TimeValue.timeValueDays(2), 0)
+        actionConfig.configRetry = ActionRetry(0)
         val states = listOf(State(name = "RolloverAction", actions = listOf(actionConfig), transitions = listOf()))
         val policy = Policy(
             id = policyID,

--- a/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/model/ActionConfigTests.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/model/ActionConfigTests.kt
@@ -38,9 +38,9 @@ class ActionConfigTests : OpenSearchTestCase() {
         }
     }
 
-    fun `test action retry count of zero fails`() {
+    fun `test action retry count of -1 fails`() {
         assertFailsWith(IllegalArgumentException::class, "Expected IllegalArgumentException for retry count less than 1") {
-            ActionRetry(count = 0)
+            ActionRetry(count = -1)
         }
     }
 

--- a/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/resthandler/RestRetryFailedManagedIndexActionIT.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/resthandler/RestRetryFailedManagedIndexActionIT.kt
@@ -8,6 +8,7 @@ package org.opensearch.indexmanagement.indexstatemanagement.resthandler
 import org.opensearch.client.ResponseException
 import org.opensearch.indexmanagement.indexstatemanagement.IndexStateManagementRestTestCase
 import org.opensearch.indexmanagement.indexstatemanagement.model.ManagedIndexMetaData
+import org.opensearch.indexmanagement.indexstatemanagement.model.action.ActionRetry
 import org.opensearch.indexmanagement.indexstatemanagement.model.action.AllocationActionConfig
 import org.opensearch.indexmanagement.indexstatemanagement.model.managedindexmetadata.ActionMetaData
 import org.opensearch.indexmanagement.indexstatemanagement.randomForceMergeActionConfig
@@ -208,10 +209,12 @@ class RestRetryFailedManagedIndexActionIT : IndexStateManagementRestTestCase() {
 
     fun `test index failed`() {
         val indexName = "${testIndexName}_blueberry"
+        val config = AllocationActionConfig(require = mapOf("..//" to "value"), exclude = emptyMap(), include = emptyMap(), index = 0)
+        config.configRetry = ActionRetry(0)
         val states = listOf(
             randomState().copy(
                 transitions = listOf(),
-                actions = listOf(AllocationActionConfig(require = mapOf("..//" to "value"), exclude = emptyMap(), include = emptyMap(), index = 0))
+                actions = listOf(config)
             )
         )
         val invalidPolicy = randomPolicy().copy(
@@ -251,7 +254,9 @@ class RestRetryFailedManagedIndexActionIT : IndexStateManagementRestTestCase() {
     fun `test reset action start time`() {
         val indexName = "${testIndexName}_drewberry"
         val policyID = "${testIndexName}_policy_1"
-        val policy = randomPolicy(states = listOf(randomState(actions = listOf(randomForceMergeActionConfig(maxNumSegments = 1)))))
+        val config = randomForceMergeActionConfig(maxNumSegments = 1)
+        config.configRetry = ActionRetry(0)
+        val policy = randomPolicy(states = listOf(randomState(actions = listOf(config))))
         createPolicy(policy, policyId = policyID)
         createIndex(indexName, policyID)
 


### PR DESCRIPTION
Signed-off-by: Drew Baugher <46505179+dbbaughe@users.noreply.github.com>

*Description of changes:*
Adds default retries of 3 to all ISM actions.
Reduces the required retry number to >= 0 instead of > 0 to allow users to choose 0 retries if they want that.
Fixes some tests that failed because of the change which were relying on the job failing.
Fixes a flaky test that tried deleting data stream backed indices using the wipeAllODFEIndices method, it'll first delete data stream backed indices before the next call for other indices.

*CheckList:*
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/index-management/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
