### PR TITLE
Adds min primary shard size rollover condition to the ISM rollover ac…

### DIFF
--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/model/action/RolloverActionConfig.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/model/action/RolloverActionConfig.kt
@@ -28,12 +28,15 @@ data class RolloverActionConfig(
     val minSize: ByteSizeValue?,
     val minDocs: Long?,
     val minAge: TimeValue?,
+    val minPrimaryShardSize: ByteSizeValue?,
     val index: Int
 ) : ToXContentObject, ActionConfig(ActionType.ROLLOVER, index) {
 
     init {
         if (minSize != null) require(minSize.bytes > 0) { "RolloverActionConfig minSize value must be greater than 0" }
-
+        if (minPrimaryShardSize != null) require(minPrimaryShardSize.bytes > 0) {
+            "RolloverActionConfig minPrimaryShardSize value must be greater than 0"
+        }
         if (minDocs != null) require(minDocs > 0) { "RolloverActionConfig minDocs value must be greater than 0" }
     }
 
@@ -44,6 +47,7 @@ data class RolloverActionConfig(
         if (minSize != null) builder.field(MIN_SIZE_FIELD, minSize.stringRep)
         if (minDocs != null) builder.field(MIN_DOC_COUNT_FIELD, minDocs)
         if (minAge != null) builder.field(MIN_INDEX_AGE_FIELD, minAge.stringRep)
+        if (minPrimaryShardSize != null) builder.field(MIN_PRIMARY_SHARD_SIZE_FIELD, minPrimaryShardSize.stringRep)
         return builder.endObject().endObject()
     }
 
@@ -62,6 +66,7 @@ data class RolloverActionConfig(
         minSize = sin.readOptionalWriteable(::ByteSizeValue),
         minDocs = sin.readOptionalLong(),
         minAge = sin.readOptionalTimeValue(),
+        minPrimaryShardSize = sin.readOptionalWriteable(::ByteSizeValue),
         index = sin.readInt()
     )
 
@@ -71,6 +76,7 @@ data class RolloverActionConfig(
         out.writeOptionalWriteable(minSize)
         out.writeOptionalLong(minDocs)
         out.writeOptionalTimeValue(minAge)
+        out.writeOptionalWriteable(minPrimaryShardSize)
         out.writeInt(index)
     }
 
@@ -78,6 +84,7 @@ data class RolloverActionConfig(
         const val MIN_SIZE_FIELD = "min_size"
         const val MIN_DOC_COUNT_FIELD = "min_doc_count"
         const val MIN_INDEX_AGE_FIELD = "min_index_age"
+        const val MIN_PRIMARY_SHARD_SIZE_FIELD = "min_primary_shard_size"
 
         @JvmStatic
         @Throws(IOException::class)
@@ -85,6 +92,7 @@ data class RolloverActionConfig(
             var minSize: ByteSizeValue? = null
             var minDocs: Long? = null
             var minAge: TimeValue? = null
+            var minPrimaryShardSize: ByteSizeValue? = null
 
             ensureExpectedToken(Token.START_OBJECT, xcp.currentToken(), xcp)
             while (xcp.nextToken() != Token.END_OBJECT) {
@@ -95,6 +103,7 @@ data class RolloverActionConfig(
                     MIN_SIZE_FIELD -> minSize = ByteSizeValue.parseBytesSizeValue(xcp.text(), MIN_SIZE_FIELD)
                     MIN_DOC_COUNT_FIELD -> minDocs = xcp.longValue()
                     MIN_INDEX_AGE_FIELD -> minAge = TimeValue.parseTimeValue(xcp.text(), MIN_INDEX_AGE_FIELD)
+                    MIN_PRIMARY_SHARD_SIZE_FIELD -> minPrimaryShardSize = ByteSizeValue.parseBytesSizeValue(xcp.text(), MIN_PRIMARY_SHARD_SIZE_FIELD)
                     else -> throw IllegalArgumentException("Invalid field: [$fieldName] found in RolloverActionConfig.")
                 }
             }
@@ -103,6 +112,7 @@ data class RolloverActionConfig(
                 minSize = minSize,
                 minDocs = minDocs,
                 minAge = minAge,
+                minPrimaryShardSize = minPrimaryShardSize,
                 index = index
             )
         }

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/util/ManagedIndexUtils.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/util/ManagedIndexUtils.kt
@@ -251,15 +251,17 @@ fun Transition.evaluateConditions(
 
 fun Transition.hasStatsConditions(): Boolean = this.conditions?.docCount != null || this.conditions?.size != null
 
-@Suppress("ReturnCount")
+@Suppress("ReturnCount", "ComplexMethod", "ComplexCondition")
 fun RolloverActionConfig.evaluateConditions(
     indexAgeTimeValue: TimeValue,
     numDocs: Long,
-    indexSize: ByteSizeValue
+    indexSize: ByteSizeValue,
+    primaryShardSize: ByteSizeValue
 ): Boolean {
     if (this.minDocs == null &&
         this.minAge == null &&
-        this.minSize == null
+        this.minSize == null &&
+        this.minPrimaryShardSize == null
     ) {
         // If no conditions specified we default to true
         return true
@@ -277,7 +279,11 @@ fun RolloverActionConfig.evaluateConditions(
         if (this.minSize <= indexSize) return true
     }
 
-    // return false if non of the conditions were true.
+    if (this.minPrimaryShardSize != null) {
+        if (this.minPrimaryShardSize <= primaryShardSize) return true
+    }
+
+    // return false if none of the conditions were true.
     return false
 }
 

--- a/src/main/resources/mappings/opendistro-ism-config.json
+++ b/src/main/resources/mappings/opendistro-ism-config.json
@@ -1,6 +1,6 @@
 {
   "_meta" : {
-    "schema_version": 12
+    "schema_version": 13
   },
   "dynamic": "strict",
   "properties": {
@@ -210,6 +210,9 @@
                       "type": "keyword"
                     },
                     "min_doc_count": {
+                      "type": "keyword"
+                    },
+                    "min_primary_shard_size": {
                       "type": "keyword"
                     }
                   }

--- a/src/test/kotlin/org/opensearch/indexmanagement/IndexManagementRestTestCase.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/IndexManagementRestTestCase.kt
@@ -29,7 +29,7 @@ import javax.management.remote.JMXServiceURL
 
 abstract class IndexManagementRestTestCase : ODFERestTestCase() {
 
-    val configSchemaVersion = 12
+    val configSchemaVersion = 13
     val historySchemaVersion = 3
 
     // Having issues with tests leaking into other tests and mappings being incorrect and they are not caught by any pending task wait check as

--- a/src/test/kotlin/org/opensearch/indexmanagement/IndexManagementRestTestCase.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/IndexManagementRestTestCase.kt
@@ -13,13 +13,11 @@ import org.junit.rules.DisableOnDebug
 import org.opensearch.client.Request
 import org.opensearch.client.RequestOptions
 import org.opensearch.client.Response
-import org.opensearch.client.ResponseListener
 import org.opensearch.client.RestClient
 import org.opensearch.common.Strings
 import org.opensearch.common.settings.Settings
 import org.opensearch.indexmanagement.indexstatemanagement.util.INDEX_HIDDEN
 import org.opensearch.rest.RestStatus
-import java.lang.Exception
 import java.nio.file.Files
 import java.nio.file.Path
 import javax.management.MBeanServerInvocationHandler
@@ -114,14 +112,7 @@ abstract class IndexManagementRestTestCase : ODFERestTestCase() {
         for (i in 1..docCount) {
             val request = Request("POST", endpoint)
             request.setJsonEntity(jsonString)
-            client().performRequestAsync(
-                request,
-                object : ResponseListener {
-                    override fun onSuccess(r: Response) {}
-
-                    override fun onFailure(e: Exception) { throw e }
-                }
-            )
+            client().performRequest(request)
 
             Thread.sleep(delay)
         }

--- a/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/TestHelpers.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/TestHelpers.kt
@@ -117,12 +117,14 @@ fun randomDeleteActionConfig(): DeleteActionConfig {
 fun randomRolloverActionConfig(
     minSize: ByteSizeValue = randomByteSizeValue(),
     minDocs: Long = OpenSearchRestTestCase.randomLongBetween(1, 1000),
-    minAge: TimeValue = randomTimeValueObject()
+    minAge: TimeValue = randomTimeValueObject(),
+    minPrimaryShardSize: ByteSizeValue = randomByteSizeValue()
 ): RolloverActionConfig {
     return RolloverActionConfig(
         minSize = minSize,
         minDocs = minDocs,
         minAge = minAge,
+        minPrimaryShardSize = minPrimaryShardSize,
         index = 0
     )
 }

--- a/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/action/RolloverActionIT.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/action/RolloverActionIT.kt
@@ -10,6 +10,7 @@ import org.apache.http.entity.StringEntity
 import org.hamcrest.core.Is.isA
 import org.junit.Assert
 import org.opensearch.cluster.metadata.DataStream
+import org.opensearch.common.settings.Settings
 import org.opensearch.common.unit.ByteSizeUnit
 import org.opensearch.common.unit.ByteSizeValue
 import org.opensearch.common.unit.TimeValue
@@ -28,6 +29,7 @@ import org.opensearch.indexmanagement.makeRequest
 import org.opensearch.indexmanagement.waitFor
 import org.opensearch.rest.RestRequest
 import org.opensearch.rest.RestStatus
+import org.opensearch.test.OpenSearchTestCase
 import java.time.Instant
 import java.time.temporal.ChronoUnit
 import java.util.Locale
@@ -42,7 +44,7 @@ class RolloverActionIT : IndexStateManagementRestTestCase() {
         val indexNameBase = "${testIndexName}_index"
         val firstIndex = "$indexNameBase-1"
         val policyID = "${testIndexName}_testPolicyName_1"
-        val actionConfig = RolloverActionConfig(null, null, null, 0)
+        val actionConfig = RolloverActionConfig(null, null, null, null, 0)
         val states = listOf(State(name = "RolloverAction", actions = listOf(actionConfig), transitions = listOf()))
         val policy = Policy(
             id = policyID,
@@ -96,7 +98,7 @@ class RolloverActionIT : IndexStateManagementRestTestCase() {
         )
 
         val policyID = "${testIndexName}_bwc"
-        val actionConfig = RolloverActionConfig(null, null, null, 0)
+        val actionConfig = RolloverActionConfig(null, null, null, null, 0)
         val states = listOf(State(name = "RolloverAction", actions = listOf(actionConfig), transitions = listOf()))
         val policy = Policy(
             id = policyID,
@@ -133,7 +135,7 @@ class RolloverActionIT : IndexStateManagementRestTestCase() {
         val indexNameBase = "${testIndexName}_index_byte"
         val firstIndex = "$indexNameBase-1"
         val policyID = "${testIndexName}_testPolicyName_byte_1"
-        val actionConfig = RolloverActionConfig(ByteSizeValue(10, ByteSizeUnit.BYTES), 1000000, null, 0)
+        val actionConfig = RolloverActionConfig(ByteSizeValue(10, ByteSizeUnit.BYTES), 1000000, null, null, 0)
         val states = listOf(State(name = "RolloverAction", actions = listOf(actionConfig), transitions = listOf()))
         val policy = Policy(
             id = policyID,
@@ -199,12 +201,118 @@ class RolloverActionIT : IndexStateManagementRestTestCase() {
     }
 
     @Suppress("UNCHECKED_CAST")
+    fun `test rollover min primary shard size`() {
+        // Setup creating index with 20 primary shards and policy that rolls over on 100kb min primary shard size
+        val aliasName = "${testIndexName}_primary_shard_alias"
+        val indexNameBase = "${testIndexName}_index_primary_shard"
+        val firstIndex = "$indexNameBase-1"
+        val policyID = "${testIndexName}_primary_shard_1"
+        val actionConfig = RolloverActionConfig(null, null, null, ByteSizeValue(100, ByteSizeUnit.KB), 0)
+        val states = listOf(State(name = "RolloverAction", actions = listOf(actionConfig), transitions = listOf()))
+        val policy = Policy(
+            id = policyID,
+            description = "$testIndexName description",
+            schemaVersion = 1L,
+            lastUpdatedTime = Instant.now().truncatedTo(ChronoUnit.MILLIS),
+            errorNotification = randomErrorNotification(),
+            defaultState = states[0].name,
+            states = states
+        )
+
+        createPolicy(policy, policyID)
+        // create index defaults
+        createIndex(
+            index = firstIndex,
+            policyID = policyID,
+            alias = aliasName,
+            replicas = "0",
+            shards = "20",
+            settings = Settings.builder().put("store.stats_refresh_interval", "1s").build()
+        )
+
+        val managedIndexConfig = getExistingManagedIndexConfig(firstIndex)
+
+        // Change the start time so the job will trigger in 2 seconds, this will trigger the first initialization of the policy
+        updateManagedIndexConfigStartTime(managedIndexConfig)
+        waitFor { assertEquals(policyID, getExplainManagedIndexMetaData(firstIndex).policyID) }
+
+        // assuming our ingestion is randomly split between the 20 primary shards
+        // then 250kb/20 gives around 12.5kb per primary shard which is below our 100kb condition
+        val KB_250 = 250_000
+        var primaryStoreSizeBytes = 0
+        var count = 0
+        // Ingest data into the test index until the total size of the index is greater than our min primary size condition
+        while (primaryStoreSizeBytes < KB_250) {
+            // this count should never get as high as 10... if it does just fail the test
+            if (count++ > 10) fail("Something is wrong with the data ingestion for testing rollover condition")
+            insertSampleData(index = firstIndex, docCount = 20, jsonString = "{ \"test_field\": \"${OpenSearchTestCase.randomAlphaOfLength(7000)}\" }", delay = 0)
+            flush(firstIndex, true)
+            forceMerge(firstIndex, "1")
+            val catIndex = (cat("indices/$firstIndex?format=json&bytes=b") as List<Map<String, Any>>).find { it["index"] == firstIndex }
+            assertNotNull("Did not find index in cat response", catIndex)
+            primaryStoreSizeBytes = (catIndex!!["pri.store.size"] as String).toInt()
+        }
+
+        // Need to speed up to second execution where it will trigger the first execution of the action
+        // Confirm index is waiting to meet the rollover condition
+        updateManagedIndexConfigStartTime(managedIndexConfig)
+        waitFor {
+            val info = getExplainManagedIndexMetaData(firstIndex).info as Map<String, Any?>
+            assertEquals(
+                "Index rollover before it met the condition.",
+                AttemptRolloverStep.getPendingMessage(firstIndex), info["message"]
+            )
+            val conditions = info["conditions"] as Map<String, Any?>
+            assertEquals(
+                "Did not have exclusively min primary shard size condition",
+                setOf(RolloverActionConfig.MIN_PRIMARY_SHARD_SIZE_FIELD), conditions.keys
+            )
+            val minPrimarySize = conditions[RolloverActionConfig.MIN_PRIMARY_SHARD_SIZE_FIELD] as Map<String, Any?>
+            assertEquals("Did not have min size condition", "100kb", minPrimarySize["condition"])
+            assertThat("Did not have min size current", minPrimarySize["current"], isA(String::class.java))
+        }
+
+        val KB_150 = 150_000
+        var primaryShardSizeBytes = 0
+        count = 0
+        // Ingest data into the test index using custom routing so it always goes to a single shard until the size of the
+        // primary shard is over 150kb
+        while (primaryShardSizeBytes < KB_150) {
+            // this count should never get as high as 10... if it does just fail the test
+            if (count++ > 10) fail("Something is wrong with the data ingestion for testing rollover condition")
+            insertSampleData(index = firstIndex, docCount = 20, delay = 0, jsonString = "{ \"test_field\": \"${OpenSearchTestCase.randomAlphaOfLength(7000)}\" }", routing = "custom_routing")
+            flush(firstIndex, true)
+            forceMerge(firstIndex, "1")
+            val primaryShards = (cat("shards/$firstIndex?format=json&bytes=b") as List<Map<String, Any>>).filter { it["prirep"] == "p" }
+            val primaryShardsOver100KB = primaryShards.filter { (it["store"] as String).toInt() > 100000 }
+            assertTrue("Found multiple shards over 100kb", primaryShardsOver100KB.size == 1)
+            primaryShardSizeBytes = primaryShards.maxOf { (it["store"] as String).toInt() }
+        }
+
+        // Speed up to third execution
+        updateManagedIndexConfigStartTime(managedIndexConfig)
+        waitFor {
+            val info = getExplainManagedIndexMetaData(firstIndex).info as Map<String, Any?>
+            assertEquals("Index did not rollover", AttemptRolloverStep.getSuccessMessage(firstIndex), info["message"])
+            val conditions = info["conditions"] as Map<String, Any?>
+            assertEquals(
+                "Did not have exclusively min primary shard size conditions",
+                setOf(RolloverActionConfig.MIN_PRIMARY_SHARD_SIZE_FIELD), conditions.keys
+            )
+            val minPrimaryShardSize = conditions[RolloverActionConfig.MIN_PRIMARY_SHARD_SIZE_FIELD] as Map<String, Any?>
+            assertEquals("Did not have min primary shard size condition", "100kb", minPrimaryShardSize["condition"])
+            assertThat("Did not have min primary shard size current", minPrimaryShardSize["current"], isA(String::class.java))
+        }
+        assertTrue("New rollover index does not exist.", indexExists("$indexNameBase-000002"))
+    }
+
+    @Suppress("UNCHECKED_CAST")
     fun `test rollover multi condition doc size`() {
         val aliasName = "${testIndexName}_doc_alias"
         val indexNameBase = "${testIndexName}_index_doc"
         val firstIndex = "$indexNameBase-1"
         val policyID = "${testIndexName}_testPolicyName_doc_1"
-        val actionConfig = RolloverActionConfig(null, 3, TimeValue.timeValueDays(2), 0)
+        val actionConfig = RolloverActionConfig(null, 3, TimeValue.timeValueDays(2), null, 0)
         val states = listOf(State(name = "RolloverAction", actions = listOf(actionConfig), transitions = listOf()))
         val policy = Policy(
             id = policyID,
@@ -277,7 +385,7 @@ class RolloverActionIT : IndexStateManagementRestTestCase() {
         val index2 = "index-2"
         val alias1 = "x"
         val policyID = "${testIndexName}_precheck"
-        val actionConfig = RolloverActionConfig(null, 3, TimeValue.timeValueDays(2), 0)
+        val actionConfig = RolloverActionConfig(null, 3, TimeValue.timeValueDays(2), null, 0)
         actionConfig.configRetry = ActionRetry(0)
         val states = listOf(State(name = "RolloverAction", actions = listOf(actionConfig), transitions = listOf()))
         val policy = Policy(
@@ -336,7 +444,7 @@ class RolloverActionIT : IndexStateManagementRestTestCase() {
         val policyID = "${testIndexName}_rollover_policy"
 
         // Create the rollover policy
-        val rolloverActionConfig = RolloverActionConfig(null, null, null, 0)
+        val rolloverActionConfig = RolloverActionConfig(null, null, null, null, 0)
         val states = listOf(State(name = "default", actions = listOf(rolloverActionConfig), transitions = listOf()))
         val policy = Policy(
             id = policyID,
@@ -392,7 +500,7 @@ class RolloverActionIT : IndexStateManagementRestTestCase() {
         val policyID = "${testIndexName}_rollover_policy_multi"
 
         // Create the rollover policy
-        val rolloverActionConfig = RolloverActionConfig(null, 3, TimeValue.timeValueDays(2), 0)
+        val rolloverActionConfig = RolloverActionConfig(null, 3, TimeValue.timeValueDays(2), null, 0)
         val states = listOf(State(name = "default", actions = listOf(rolloverActionConfig), transitions = listOf()))
         val policy = Policy(
             id = policyID,
@@ -485,7 +593,7 @@ class RolloverActionIT : IndexStateManagementRestTestCase() {
         val indexNameBase = "${testIndexName}_index"
         val firstIndex = "$indexNameBase-1"
         val policyID = "${testIndexName}_testPolicyName_1"
-        val actionConfig = RolloverActionConfig(null, null, null, 0)
+        val actionConfig = RolloverActionConfig(null, null, null, null, 0)
         val states = listOf(State(name = "RolloverAction", actions = listOf(actionConfig), transitions = listOf()))
         val policy = Policy(
             id = policyID,

--- a/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/coordinator/ManagedIndexCoordinatorIT.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/coordinator/ManagedIndexCoordinatorIT.kt
@@ -165,7 +165,7 @@ class ManagedIndexCoordinatorIT : IndexStateManagementRestTestCase() {
         val policyID = "test_policy_1"
 
         // Create a policy with one State that performs rollover
-        val rolloverActionConfig = RolloverActionConfig(index = 0, minDocs = 5, minAge = null, minSize = null)
+        val rolloverActionConfig = RolloverActionConfig(index = 0, minDocs = 5, minAge = null, minSize = null, minPrimaryShardSize = null)
         val states =
             listOf(State(name = "RolloverState", actions = listOf(rolloverActionConfig), transitions = listOf()))
         val policy = Policy(

--- a/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/resthandler/RestChangePolicyActionIT.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/resthandler/RestChangePolicyActionIT.kt
@@ -551,7 +551,7 @@ class RestChangePolicyActionIT : IndexStateManagementRestTestCase() {
 
     fun `test allowing change policy to happen in middle of state if same state structure`() {
         // Creates a policy that has one state with rollover
-        val actionConfig = RolloverActionConfig(index = 0, minDocs = 100_000_000, minAge = null, minSize = null)
+        val actionConfig = RolloverActionConfig(index = 0, minDocs = 100_000_000, minAge = null, minSize = null, minPrimaryShardSize = null)
         val stateWithReadOnlyAction = randomState(actions = listOf(actionConfig))
         val randomPolicy = randomPolicy(states = listOf(stateWithReadOnlyAction))
         val policy = createPolicy(randomPolicy)

--- a/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/util/ManagedIndexUtilsTests.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/util/ManagedIndexUtilsTests.kt
@@ -143,89 +143,112 @@ class ManagedIndexUtilsTests : OpenSearchTestCase() {
     }
 
     fun `test rollover action config evaluate conditions`() {
-        val noConditionsConfig = RolloverActionConfig(minSize = null, minDocs = null, minAge = null, index = 0)
+        val noConditionsConfig = RolloverActionConfig(minSize = null, minDocs = null, minAge = null, minPrimaryShardSize = null, index = 0)
         assertTrue(
             "No conditions should always pass",
             noConditionsConfig
-                .evaluateConditions(indexAgeTimeValue = TimeValue.timeValueMillis(0), numDocs = 0, indexSize = ByteSizeValue(0))
+                .evaluateConditions(indexAgeTimeValue = TimeValue.timeValueMillis(0), numDocs = 0, indexSize = ByteSizeValue.ZERO, primaryShardSize = ByteSizeValue.ZERO)
         )
         assertTrue(
             "No conditions should always pass",
             noConditionsConfig
-                .evaluateConditions(indexAgeTimeValue = TimeValue.timeValueMillis(100), numDocs = 5, indexSize = ByteSizeValue(5))
+                .evaluateConditions(indexAgeTimeValue = TimeValue.timeValueMillis(100), numDocs = 5, indexSize = ByteSizeValue(5), primaryShardSize = ByteSizeValue(5))
         )
         assertTrue(
             "No conditions should always pass",
             noConditionsConfig
-                .evaluateConditions(indexAgeTimeValue = TimeValue.timeValueMillis(6000), numDocs = 5, indexSize = ByteSizeValue(5))
+                .evaluateConditions(indexAgeTimeValue = TimeValue.timeValueMillis(6000), numDocs = 5, indexSize = ByteSizeValue(5), primaryShardSize = ByteSizeValue(5))
         )
 
-        val minSizeConfig = RolloverActionConfig(minSize = ByteSizeValue(5), minDocs = null, minAge = null, index = 0)
+        val minSizeConfig = RolloverActionConfig(minSize = ByteSizeValue(5), minDocs = null, minAge = null, minPrimaryShardSize = null, index = 0)
         assertFalse(
             "Less bytes should not pass",
             minSizeConfig
-                .evaluateConditions(indexAgeTimeValue = TimeValue.timeValueMillis(1000), numDocs = 0, indexSize = ByteSizeValue.ZERO)
+                .evaluateConditions(indexAgeTimeValue = TimeValue.timeValueMillis(1000), numDocs = 0, indexSize = ByteSizeValue.ZERO, primaryShardSize = ByteSizeValue.ZERO)
         )
         assertTrue(
             "Equal bytes should pass",
             minSizeConfig
-                .evaluateConditions(indexAgeTimeValue = TimeValue.timeValueMillis(1000), numDocs = 0, indexSize = ByteSizeValue(5))
+                .evaluateConditions(indexAgeTimeValue = TimeValue.timeValueMillis(1000), numDocs = 0, indexSize = ByteSizeValue(5), primaryShardSize = ByteSizeValue(5))
         )
         assertTrue(
             "More bytes should pass",
             minSizeConfig
-                .evaluateConditions(indexAgeTimeValue = TimeValue.timeValueMillis(1000), numDocs = 0, indexSize = ByteSizeValue(10))
+                .evaluateConditions(indexAgeTimeValue = TimeValue.timeValueMillis(1000), numDocs = 0, indexSize = ByteSizeValue(10), primaryShardSize = ByteSizeValue(10))
         )
 
-        val minDocsConfig = RolloverActionConfig(minSize = null, minDocs = 5, minAge = null, index = 0)
+        val minPrimarySizeConfig = RolloverActionConfig(minSize = null, minDocs = null, minAge = null, minPrimaryShardSize = ByteSizeValue(5), index = 0)
+        assertFalse(
+            "Less primary bytes should not pass",
+            minPrimarySizeConfig
+                .evaluateConditions(indexAgeTimeValue = TimeValue.timeValueMillis(1000), numDocs = 0, indexSize = ByteSizeValue.ZERO, primaryShardSize = ByteSizeValue.ZERO)
+        )
+        assertTrue(
+            "Equal primary bytes should pass",
+            minPrimarySizeConfig
+                .evaluateConditions(indexAgeTimeValue = TimeValue.timeValueMillis(1000), numDocs = 0, indexSize = ByteSizeValue(5), primaryShardSize = ByteSizeValue(5))
+        )
+        assertTrue(
+            "More primary bytes should pass",
+            minPrimarySizeConfig
+                .evaluateConditions(indexAgeTimeValue = TimeValue.timeValueMillis(1000), numDocs = 0, indexSize = ByteSizeValue(10), primaryShardSize = ByteSizeValue(10))
+        )
+
+        val minDocsConfig = RolloverActionConfig(minSize = null, minDocs = 5, minAge = null, minPrimaryShardSize = null, index = 0)
         assertFalse(
             "Less docs should not pass",
             minDocsConfig
-                .evaluateConditions(indexAgeTimeValue = TimeValue.timeValueMillis(1000), numDocs = 0, indexSize = ByteSizeValue.ZERO)
+                .evaluateConditions(indexAgeTimeValue = TimeValue.timeValueMillis(1000), numDocs = 0, indexSize = ByteSizeValue.ZERO, primaryShardSize = ByteSizeValue.ZERO)
         )
         assertTrue(
             "Equal docs should pass",
             minDocsConfig
-                .evaluateConditions(indexAgeTimeValue = TimeValue.timeValueMillis(1000), numDocs = 5, indexSize = ByteSizeValue.ZERO)
+                .evaluateConditions(indexAgeTimeValue = TimeValue.timeValueMillis(1000), numDocs = 5, indexSize = ByteSizeValue.ZERO, primaryShardSize = ByteSizeValue.ZERO)
         )
         assertTrue(
             "More docs should pass",
             minDocsConfig
-                .evaluateConditions(indexAgeTimeValue = TimeValue.timeValueMillis(1000), numDocs = 10, indexSize = ByteSizeValue.ZERO)
+                .evaluateConditions(indexAgeTimeValue = TimeValue.timeValueMillis(1000), numDocs = 10, indexSize = ByteSizeValue.ZERO, primaryShardSize = ByteSizeValue.ZERO)
         )
 
-        val minAgeConfig = RolloverActionConfig(minSize = null, minDocs = null, minAge = TimeValue.timeValueSeconds(5), index = 0)
+        val minAgeConfig = RolloverActionConfig(minSize = null, minDocs = null, minAge = TimeValue.timeValueSeconds(5), minPrimaryShardSize = null, index = 0)
         assertFalse(
             "Index age that is too young should not pass",
             minAgeConfig
-                .evaluateConditions(indexAgeTimeValue = TimeValue.timeValueMillis(1000), numDocs = 0, indexSize = ByteSizeValue.ZERO)
+                .evaluateConditions(indexAgeTimeValue = TimeValue.timeValueMillis(1000), numDocs = 0, indexSize = ByteSizeValue.ZERO, primaryShardSize = ByteSizeValue.ZERO)
         )
         assertTrue(
             "Index age that is older should pass",
             minAgeConfig
-                .evaluateConditions(indexAgeTimeValue = TimeValue.timeValueMillis(10000), numDocs = 0, indexSize = ByteSizeValue.ZERO)
+                .evaluateConditions(indexAgeTimeValue = TimeValue.timeValueMillis(10000), numDocs = 0, indexSize = ByteSizeValue.ZERO, primaryShardSize = ByteSizeValue.ZERO)
         )
 
-        val multiConfig = RolloverActionConfig(minSize = ByteSizeValue(1), minDocs = 1, minAge = TimeValue.timeValueSeconds(5), index = 0)
+        val multiConfig = RolloverActionConfig(minSize = ByteSizeValue(1), minDocs = 1, minAge = TimeValue.timeValueSeconds(5), minPrimaryShardSize = ByteSizeValue(1), index = 0)
         assertFalse(
             "No conditions met should not pass",
             multiConfig
-                .evaluateConditions(indexAgeTimeValue = TimeValue.timeValueMillis(0), numDocs = 0, indexSize = ByteSizeValue.ZERO)
+                .evaluateConditions(indexAgeTimeValue = TimeValue.timeValueMillis(0), numDocs = 0, indexSize = ByteSizeValue.ZERO, primaryShardSize = ByteSizeValue.ZERO)
         )
         assertTrue(
             "Multi condition, age should pass",
             multiConfig
-                .evaluateConditions(indexAgeTimeValue = TimeValue.timeValueMillis(10000), numDocs = 0, indexSize = ByteSizeValue.ZERO)
+                .evaluateConditions(indexAgeTimeValue = TimeValue.timeValueMillis(10000), numDocs = 0, indexSize = ByteSizeValue.ZERO, primaryShardSize = ByteSizeValue.ZERO)
         )
         assertTrue(
             "Multi condition, docs should pass",
             multiConfig
-                .evaluateConditions(indexAgeTimeValue = TimeValue.timeValueMillis(0), numDocs = 2, indexSize = ByteSizeValue.ZERO)
+                .evaluateConditions(indexAgeTimeValue = TimeValue.timeValueMillis(0), numDocs = 2, indexSize = ByteSizeValue.ZERO, primaryShardSize = ByteSizeValue.ZERO)
         )
         assertTrue(
             "Multi condition, size should pass",
             multiConfig
-                .evaluateConditions(indexAgeTimeValue = TimeValue.timeValueMillis(0), numDocs = 0, indexSize = ByteSizeValue(2))
+                .evaluateConditions(indexAgeTimeValue = TimeValue.timeValueMillis(0), numDocs = 0, indexSize = ByteSizeValue(2), primaryShardSize = ByteSizeValue.ZERO)
+        )
+
+        assertTrue(
+            "Multi condition, primary size should pass",
+            multiConfig
+                .evaluateConditions(indexAgeTimeValue = TimeValue.timeValueMillis(0), numDocs = 0, indexSize = ByteSizeValue.ZERO, primaryShardSize = ByteSizeValue(2))
         )
     }
 

--- a/src/test/resources/mappings/cached-opendistro-ism-config.json
+++ b/src/test/resources/mappings/cached-opendistro-ism-config.json
@@ -1,6 +1,6 @@
 {
   "_meta" : {
-    "schema_version": 12
+    "schema_version": 13
   },
   "dynamic": "strict",
   "properties": {
@@ -210,6 +210,9 @@
                       "type": "keyword"
                     },
                     "min_doc_count": {
+                      "type": "keyword"
+                    },
+                    "min_primary_shard_size": {
                       "type": "keyword"
                     }
                   }


### PR DESCRIPTION
…tion

Signed-off-by: Drew Baugher <46505179+dbbaughe@users.noreply.github.com>

*Issue #, if available:*
https://github.com/opensearch-project/index-management/issues/213

*Description of changes:*
* Adds min_primary_shard_size as a rollover condition to ISM rollover action.
* It will evaluate to true when there is a single primary shard in the index that has a greater size than the condition.
* Kept the prefix as min instead of max to be aligned with the other conditions we have in rollover, although it is odd that our conditions are differently named than the native rollover API conditions.

*CheckList:*
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/index-management/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
