### PR TITLE
Implement ReadOnlyAction using new interface

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -308,7 +308,6 @@ integTest {
     exclude 'org/opensearch/indexmanagement/indexstatemanagement/action/IndexStateManagementHistoryIT.class'
     exclude 'org/opensearch/indexmanagement/indexstatemanagement/action/NotificationActionIT.class'
     exclude 'org/opensearch/indexmanagement/indexstatemanagement/action/OpenActionIT.class'
-    exclude 'org/opensearch/indexmanagement/indexstatemanagement/action/ReadOnlyActionIT.class'
     exclude 'org/opensearch/indexmanagement/indexstatemanagement/action/ReadWriteActionIT.class'
     exclude 'org/opensearch/indexmanagement/indexstatemanagement/action/ReplicaCountActionIT.class'
     exclude 'org/opensearch/indexmanagement/indexstatemanagement/action/RolloverActionIT.class'

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/ISMActionsParser.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/ISMActionsParser.kt
@@ -9,6 +9,7 @@ import org.opensearch.common.io.stream.StreamInput
 import org.opensearch.common.xcontent.XContentParser
 import org.opensearch.common.xcontent.XContentParserUtils
 import org.opensearch.indexmanagement.indexstatemanagement.action.DeleteActionParser
+import org.opensearch.indexmanagement.indexstatemanagement.action.ReadOnlyActionParser
 import org.opensearch.indexmanagement.spi.indexstatemanagement.Action
 import org.opensearch.indexmanagement.spi.indexstatemanagement.ActionParser
 import org.opensearch.indexmanagement.spi.indexstatemanagement.model.ActionRetry
@@ -22,7 +23,8 @@ class ISMActionsParser private constructor() {
 
     // TODO: Add other action parsers as they are implemented
     val parsers = mutableListOf<ActionParser>(
-        DeleteActionParser()
+        DeleteActionParser(),
+        ReadOnlyActionParser()
     )
 
     fun addParser(parser: ActionParser) {

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/action/ReadOnlyAction.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/action/ReadOnlyAction.kt
@@ -5,6 +5,7 @@
 
 package org.opensearch.indexmanagement.indexstatemanagement.action
 
+import org.opensearch.indexmanagement.indexstatemanagement.step.readonly.SetReadOnlyStep
 import org.opensearch.indexmanagement.spi.indexstatemanagement.Action
 import org.opensearch.indexmanagement.spi.indexstatemanagement.Step
 import org.opensearch.indexmanagement.spi.indexstatemanagement.model.StepContext
@@ -16,12 +17,12 @@ class ReadOnlyAction(
     companion object {
         const val name = "read_only"
     }
+    private val setReadOnlyStep = SetReadOnlyStep()
+    private val steps = listOf(setReadOnlyStep)
 
     override fun getStepToExecute(context: StepContext): Step {
-        TODO("Not yet implemented")
+        return setReadOnlyStep
     }
 
-    override fun getSteps(): List<Step> {
-        TODO("Not yet implemented")
-    }
+    override fun getSteps(): List<Step> = steps
 }

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/action/ReadOnlyActionParser.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/action/ReadOnlyActionParser.kt
@@ -7,19 +7,24 @@ package org.opensearch.indexmanagement.indexstatemanagement.action
 
 import org.opensearch.common.io.stream.StreamInput
 import org.opensearch.common.xcontent.XContentParser
+import org.opensearch.common.xcontent.XContentParserUtils.ensureExpectedToken
 import org.opensearch.indexmanagement.spi.indexstatemanagement.Action
 import org.opensearch.indexmanagement.spi.indexstatemanagement.ActionParser
 
 class ReadOnlyActionParser : ActionParser() {
     override fun fromStreamInput(sin: StreamInput): Action {
-        TODO("Not yet implemented")
+        val index = sin.readInt()
+        return ReadOnlyAction(index)
     }
 
     override fun fromXContent(xcp: XContentParser, index: Int): Action {
-        TODO("Not yet implemented")
+        ensureExpectedToken(XContentParser.Token.START_OBJECT, xcp.currentToken(), xcp)
+        ensureExpectedToken(XContentParser.Token.END_OBJECT, xcp.nextToken(), xcp)
+
+        return ReadOnlyAction(index)
     }
 
     override fun getActionType(): String {
-        TODO("Not yet implemented")
+        return ReadOnlyAction.name
     }
 }

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/readonly/SetReadOnlyStep.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/readonly/SetReadOnlyStep.kt
@@ -5,25 +5,75 @@
 
 package org.opensearch.indexmanagement.indexstatemanagement.step.readonly
 
+import org.apache.logging.log4j.LogManager
+import org.opensearch.ExceptionsHelper
+import org.opensearch.action.admin.indices.settings.put.UpdateSettingsRequest
+import org.opensearch.action.support.master.AcknowledgedResponse
+import org.opensearch.cluster.metadata.IndexMetadata.SETTING_BLOCKS_WRITE
+import org.opensearch.common.settings.Settings
+import org.opensearch.indexmanagement.opensearchapi.suspendUntil
 import org.opensearch.indexmanagement.spi.indexstatemanagement.Step
 import org.opensearch.indexmanagement.spi.indexstatemanagement.model.ManagedIndexMetaData
+import org.opensearch.indexmanagement.spi.indexstatemanagement.model.StepMetaData
+import org.opensearch.transport.RemoteTransportException
 
 class SetReadOnlyStep : Step(name) {
+
+    private val logger = LogManager.getLogger(javaClass)
+    private var stepStatus = StepStatus.STARTING
+    private var info: Map<String, Any>? = null
+
     override suspend fun execute(): Step {
-        TODO("Not yet implemented")
+        val context = this.context ?: return this
+        val indexName = context.metadata.index
+        try {
+            val updateSettingsRequest = UpdateSettingsRequest()
+                .indices(indexName)
+                .settings(Settings.builder().put(SETTING_BLOCKS_WRITE, true))
+            val response: AcknowledgedResponse = context.client.admin().indices()
+                .suspendUntil { updateSettings(updateSettingsRequest, it) }
+
+            if (response.isAcknowledged) {
+                stepStatus = StepStatus.COMPLETED
+                info = mapOf("message" to getSuccessMessage(indexName))
+            } else {
+                val message = getFailedMessage(indexName)
+                logger.warn(message)
+                stepStatus = StepStatus.FAILED
+                info = mapOf("message" to message)
+            }
+        } catch (e: RemoteTransportException) {
+            handleException(indexName, ExceptionsHelper.unwrapCause(e) as Exception)
+        } catch (e: Exception) {
+            handleException(indexName, e)
+        }
+
+        return this
+    }
+
+    private fun handleException(indexName: String, e: Exception) {
+        val message = getFailedMessage(indexName)
+        logger.error(message, e)
+        stepStatus = StepStatus.FAILED
+        val mutableInfo = mutableMapOf("message" to message)
+        val errorMessage = e.message
+        if (errorMessage != null) mutableInfo["cause"] = errorMessage
+        info = mutableInfo.toMap()
     }
 
     override fun getUpdatedManagedIndexMetadata(currentMetadata: ManagedIndexMetaData): ManagedIndexMetaData {
-        TODO("Not yet implemented")
+        return currentMetadata.copy(
+            stepMetaData = StepMetaData(name, getStepStartTime(currentMetadata).toEpochMilli(), stepStatus),
+            transitionTo = null,
+            info = info
+        )
     }
 
-    override fun isIdempotent(): Boolean {
-        TODO("Not yet implemented")
-    }
+    override fun isIdempotent(): Boolean = true
 
     companion object {
         const val name = "set_read_only"
-        // TODO: fixme
-        fun getSuccessMessage(indexName: String) = ""
+        fun getFailedMessage(index: String) = "Failed to set index to read-only [index=$index]"
+        fun getSuccessMessage(index: String) = "Successfully set index to read-only [index=$index]"
     }
 }

--- a/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/model/ActionTests.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/model/ActionTests.kt
@@ -18,6 +18,7 @@ import org.opensearch.indexmanagement.indexstatemanagement.randomAllocationActio
 import org.opensearch.indexmanagement.indexstatemanagement.randomForceMergeActionConfig
 import org.opensearch.indexmanagement.indexstatemanagement.randomIndexPriorityActionConfig
 import org.opensearch.indexmanagement.indexstatemanagement.randomNotificationActionConfig
+import org.opensearch.indexmanagement.indexstatemanagement.randomReadOnlyActionConfig
 import org.opensearch.indexmanagement.indexstatemanagement.randomReplicaCountActionConfig
 import org.opensearch.indexmanagement.indexstatemanagement.randomRolloverActionConfig
 import org.opensearch.indexmanagement.indexstatemanagement.randomSnapshotActionConfig
@@ -72,6 +73,10 @@ class ActionTests : OpenSearchTestCase() {
         assertFailsWith(IllegalArgumentException::class, "Expected IllegalArgumentException for empty parameters") {
             randomAllocationActionConfig()
         }
+    }
+
+    fun `test set read only action round trip`() {
+        roundTripAction(randomReadOnlyActionConfig())
     }
 
     // TODO: fixme - enable the test

--- a/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/model/XContentTests.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/model/XContentTests.kt
@@ -95,12 +95,12 @@ class XContentTests : OpenSearchTestCase() {
         assertEquals("Round tripping RolloverActionConfig doesn't work", rolloverActionConfig, parsedRolloverActionConfig)
     }
 
-    private fun `test read_only action config parsing`() {
-        val readOnlyActionConfig = randomReadOnlyActionConfig()
+    fun `test read_only action config parsing`() {
+        val readOnlyAction = randomReadOnlyActionConfig()
 
-        val readOnlyActionConfigString = readOnlyActionConfig.toJsonString()
-        val parsedReadOnlyActionConfig = ISMActionsParser.instance.parse(parser(readOnlyActionConfigString), 0)
-        assertEquals("Round tripping ReadOnlyActionConfig doesn't work", readOnlyActionConfig, parsedReadOnlyActionConfig)
+        val readOnlyActionString = readOnlyAction.toJsonString()
+        val parsedReadOnlyAction = ISMActionsParser.instance.parse(parser(readOnlyActionString), 0)
+        assertEquals("Round tripping ReadOnlyAction doesn't work", readOnlyAction.convertToMap(), parsedReadOnlyAction.convertToMap())
     }
 
     private fun `test read_write action config parsing`() {

--- a/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/SetReadOnlyStepTests.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/SetReadOnlyStepTests.kt
@@ -5,22 +5,39 @@
 
 package org.opensearch.indexmanagement.indexstatemanagement.step
 
+import com.nhaarman.mockitokotlin2.any
+import com.nhaarman.mockitokotlin2.doAnswer
+import com.nhaarman.mockitokotlin2.doReturn
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.whenever
+import kotlinx.coroutines.runBlocking
+import org.opensearch.action.ActionListener
+import org.opensearch.action.support.master.AcknowledgedResponse
+import org.opensearch.client.AdminClient
+import org.opensearch.client.Client
+import org.opensearch.client.IndicesAdminClient
+import org.opensearch.cluster.service.ClusterService
+import org.opensearch.indexmanagement.indexstatemanagement.step.readonly.SetReadOnlyStep
+import org.opensearch.indexmanagement.spi.indexstatemanagement.Step
+import org.opensearch.indexmanagement.spi.indexstatemanagement.model.ManagedIndexMetaData
+import org.opensearch.indexmanagement.spi.indexstatemanagement.model.StepContext
 import org.opensearch.test.OpenSearchTestCase
+import org.opensearch.transport.RemoteTransportException
 
 class SetReadOnlyStepTests : OpenSearchTestCase() {
 
-    /*private val clusterService: ClusterService = mock()
+    private val clusterService: ClusterService = mock()
 
     fun `test read only step sets step status to failed when not acknowledged`() {
         val setReadOnlyResponse = AcknowledgedResponse(false)
         val client = getClient(getAdminClient(getIndicesAdminClient(setReadOnlyResponse, null)))
 
         runBlocking {
-            val readOnlyActionConfig = ReadOnlyActionConfig(0)
             val managedIndexMetaData = ManagedIndexMetaData("test", "indexUuid", "policy_id", null, null, null, null, null, null, null, null, null, null)
-            val setReadOnlyStep = SetReadOnlyStep(clusterService, client, readOnlyActionConfig, managedIndexMetaData)
-            setReadOnlyStep.execute()
-            val updatedManagedIndexMetaData = setReadOnlyStep.getUpdatedManagedIndexMetaData(managedIndexMetaData)
+            val setReadOnlyStep = SetReadOnlyStep()
+            val context = StepContext(managedIndexMetaData, clusterService, client, null, null)
+            setReadOnlyStep.preExecute(logger, context).execute()
+            val updatedManagedIndexMetaData = setReadOnlyStep.getUpdatedManagedIndexMetadata(managedIndexMetaData)
             assertEquals("Step status is not FAILED", Step.StepStatus.FAILED, updatedManagedIndexMetaData.stepMetaData?.stepStatus)
         }
     }
@@ -30,11 +47,11 @@ class SetReadOnlyStepTests : OpenSearchTestCase() {
         val client = getClient(getAdminClient(getIndicesAdminClient(null, exception)))
 
         runBlocking {
-            val readOnlyActionConfig = ReadOnlyActionConfig(0)
             val managedIndexMetaData = ManagedIndexMetaData("test", "indexUuid", "policy_id", null, null, null, null, null, null, null, null, null, null)
-            val setReadOnlyStep = SetReadOnlyStep(clusterService, client, readOnlyActionConfig, managedIndexMetaData)
-            setReadOnlyStep.execute()
-            val updatedManagedIndexMetaData = setReadOnlyStep.getUpdatedManagedIndexMetaData(managedIndexMetaData)
+            val setReadOnlyStep = SetReadOnlyStep()
+            val context = StepContext(managedIndexMetaData, clusterService, client, null, null)
+            setReadOnlyStep.preExecute(logger, context).execute()
+            val updatedManagedIndexMetaData = setReadOnlyStep.getUpdatedManagedIndexMetadata(managedIndexMetaData)
             assertEquals("Step status is not FAILED", Step.StepStatus.FAILED, updatedManagedIndexMetaData.stepMetaData?.stepStatus)
         }
     }
@@ -44,11 +61,11 @@ class SetReadOnlyStepTests : OpenSearchTestCase() {
         val client = getClient(getAdminClient(getIndicesAdminClient(null, exception)))
 
         runBlocking {
-            val readOnlyActionConfig = ReadOnlyActionConfig(0)
             val managedIndexMetaData = ManagedIndexMetaData("test", "indexUuid", "policy_id", null, null, null, null, null, null, null, null, null, null)
-            val setReadOnlyStep = SetReadOnlyStep(clusterService, client, readOnlyActionConfig, managedIndexMetaData)
-            setReadOnlyStep.execute()
-            val updatedManagedIndexMetaData = setReadOnlyStep.getUpdatedManagedIndexMetaData(managedIndexMetaData)
+            val setReadOnlyStep = SetReadOnlyStep()
+            val context = StepContext(managedIndexMetaData, clusterService, client, null, null)
+            setReadOnlyStep.preExecute(logger, context).execute()
+            val updatedManagedIndexMetaData = setReadOnlyStep.getUpdatedManagedIndexMetadata(managedIndexMetaData)
             assertEquals("Step status is not FAILED", Step.StepStatus.FAILED, updatedManagedIndexMetaData.stepMetaData?.stepStatus)
             assertEquals("Did not get cause from nested exception", "nested", updatedManagedIndexMetaData.info!!["cause"])
         }
@@ -65,5 +82,5 @@ class SetReadOnlyStepTests : OpenSearchTestCase() {
                 else listener.onFailure(exception)
             }.whenever(this.mock).updateSettings(any(), any())
         }
-    }*/
+    }
 }


### PR DESCRIPTION
Signed-off-by: Robert Downs <downsrob@amazon.com>

*Issue #, if available:*
NA

*Description of changes:*
Implement ReadOnlyAction using new interface

*CheckList:*
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/index-management/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
