### PR TITLE
Implements RolloverAction with new interface, fixes default action retry commit

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -310,7 +310,6 @@ integTest {
     exclude 'org/opensearch/indexmanagement/indexstatemanagement/action/ReadOnlyActionIT.class'
     exclude 'org/opensearch/indexmanagement/indexstatemanagement/action/ReadWriteActionIT.class'
     exclude 'org/opensearch/indexmanagement/indexstatemanagement/action/ReplicaCountActionIT.class'
-    exclude 'org/opensearch/indexmanagement/indexstatemanagement/action/RolloverActionIT.class'
     exclude 'org/opensearch/indexmanagement/indexstatemanagement/action/RollupActionIT.class'
     exclude 'org/opensearch/indexmanagement/indexstatemanagement/action/SnapshotActionIT.class'
     exclude 'org/opensearch/indexmanagement/indexstatemanagement/action/TransitionActionIT.class'

--- a/spi/src/main/kotlin/org.opensearch.indexmanagement.spi/indexstatemanagement/Action.kt
+++ b/spi/src/main/kotlin/org.opensearch.indexmanagement.spi/indexstatemanagement/Action.kt
@@ -20,7 +20,7 @@ abstract class Action(
 ) : ToXContentObject, Writeable {
 
     var configTimeout: ActionTimeout? = null
-    var configRetry: ActionRetry? = null
+    var configRetry: ActionRetry? = ActionRetry(DEFAULT_RETRIES)
 
     final override fun toXContent(builder: XContentBuilder, params: ToXContent.Params): XContentBuilder {
         builder.startObject()
@@ -67,4 +67,8 @@ abstract class Action(
     final fun isLastStep(stepName: String): Boolean = getSteps().last().name == stepName
 
     final fun isFirstStep(stepName: String): Boolean = getSteps().first().name == stepName
+
+    companion object {
+        const val DEFAULT_RETRIES = 3L
+    }
 }

--- a/spi/src/main/kotlin/org.opensearch.indexmanagement.spi/indexstatemanagement/model/ActionRetry.kt
+++ b/spi/src/main/kotlin/org.opensearch.indexmanagement.spi/indexstatemanagement/model/ActionRetry.kt
@@ -26,7 +26,7 @@ data class ActionRetry(
     val delay: TimeValue = TimeValue.timeValueMinutes(1)
 ) : ToXContentFragment, Writeable {
 
-    init { require(count > 0) { "Count for ActionRetry must be greater than 0" } }
+    init { require(count >= 0) { "Count for ActionRetry must be a non-negative number" } }
 
     override fun toXContent(builder: XContentBuilder, params: ToXContent.Params): XContentBuilder {
         builder

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/ISMActionsParser.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/ISMActionsParser.kt
@@ -10,6 +10,7 @@ import org.opensearch.common.xcontent.XContentParser
 import org.opensearch.common.xcontent.XContentParserUtils
 import org.opensearch.indexmanagement.indexstatemanagement.action.CloseActionParser
 import org.opensearch.indexmanagement.indexstatemanagement.action.DeleteActionParser
+import org.opensearch.indexmanagement.indexstatemanagement.action.RolloverActionParser
 import org.opensearch.indexmanagement.spi.indexstatemanagement.Action
 import org.opensearch.indexmanagement.spi.indexstatemanagement.ActionParser
 import org.opensearch.indexmanagement.spi.indexstatemanagement.model.ActionRetry
@@ -24,7 +25,8 @@ class ISMActionsParser private constructor() {
     // TODO: Add other action parsers as they are implemented
     val parsers = mutableListOf<ActionParser>(
         CloseActionParser(),
-        DeleteActionParser()
+        DeleteActionParser(),
+        RolloverActionParser()
     )
 
     fun addParser(parser: ActionParser) {
@@ -47,7 +49,7 @@ class ISMActionsParser private constructor() {
     fun parse(xcp: XContentParser, totalActions: Int): Action {
         var action: Action? = null
         var timeout: ActionTimeout? = null
-        var retry: ActionRetry? = ActionRetry(DEFAULT_RETRIES)
+        var retry: ActionRetry? = ActionRetry(Action.DEFAULT_RETRIES)
         XContentParserUtils.ensureExpectedToken(XContentParser.Token.START_OBJECT, xcp.currentToken(), xcp)
         while (xcp.nextToken() != XContentParser.Token.END_OBJECT) {
             val type = xcp.currentName()
@@ -76,6 +78,5 @@ class ISMActionsParser private constructor() {
 
     companion object {
         val instance: ISMActionsParser by lazy { HOLDER.instance }
-        private const val DEFAULT_RETRIES = 3L
     }
 }

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/ISMActionsParser.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/ISMActionsParser.kt
@@ -47,7 +47,7 @@ class ISMActionsParser private constructor() {
     fun parse(xcp: XContentParser, totalActions: Int): Action {
         var action: Action? = null
         var timeout: ActionTimeout? = null
-        var retry: ActionRetry? = null
+        var retry: ActionRetry? = ActionRetry(DEFAULT_RETRIES)
         XContentParserUtils.ensureExpectedToken(XContentParser.Token.START_OBJECT, xcp.currentToken(), xcp)
         while (xcp.nextToken() != XContentParser.Token.END_OBJECT) {
             val type = xcp.currentName()
@@ -76,5 +76,6 @@ class ISMActionsParser private constructor() {
 
     companion object {
         val instance: ISMActionsParser by lazy { HOLDER.instance }
+        private const val DEFAULT_RETRIES = 3L
     }
 }

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/action/RolloverAction.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/action/RolloverAction.kt
@@ -5,8 +5,12 @@
 
 package org.opensearch.indexmanagement.indexstatemanagement.action
 
+import org.opensearch.common.io.stream.StreamOutput
 import org.opensearch.common.unit.ByteSizeValue
 import org.opensearch.common.unit.TimeValue
+import org.opensearch.common.xcontent.ToXContent
+import org.opensearch.common.xcontent.XContentBuilder
+import org.opensearch.indexmanagement.indexstatemanagement.step.rollover.AttemptRolloverStep
 import org.opensearch.indexmanagement.spi.indexstatemanagement.Action
 import org.opensearch.indexmanagement.spi.indexstatemanagement.Step
 import org.opensearch.indexmanagement.spi.indexstatemanagement.model.StepContext
@@ -18,12 +22,34 @@ class RolloverAction(
     index: Int
 ) : Action(name, index) {
 
-    override fun getStepToExecute(context: StepContext): Step {
-        TODO("Not yet implemented")
+    init {
+        if (minSize != null) require(minSize.bytes > 0) { "RolloverActionConfig minSize value must be greater than 0" }
+
+        if (minDocs != null) require(minDocs > 0) { "RolloverActionConfig minDocs value must be greater than 0" }
     }
 
-    override fun getSteps(): List<Step> {
-        TODO("Not yet implemented")
+    private val attemptRolloverStep = AttemptRolloverStep(this)
+    private val steps = listOf(attemptRolloverStep)
+
+    override fun getStepToExecute(context: StepContext): Step {
+        return attemptRolloverStep
+    }
+
+    override fun getSteps(): List<Step> = steps
+
+    override fun populateAction(builder: XContentBuilder, params: ToXContent.Params) {
+        builder.startObject(type)
+        if (minSize != null) builder.field(MIN_SIZE_FIELD, minSize.stringRep)
+        if (minDocs != null) builder.field(MIN_DOC_COUNT_FIELD, minDocs)
+        if (minAge != null) builder.field(MIN_INDEX_AGE_FIELD, minAge.stringRep)
+        builder.endObject()
+    }
+
+    override fun populateAction(out: StreamOutput) {
+        out.writeOptionalWriteable(minSize)
+        out.writeOptionalLong(minDocs)
+        out.writeOptionalTimeValue(minAge)
+        out.writeInt(actionIndex)
     }
 
     companion object {

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/action/RolloverAction.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/action/RolloverAction.kt
@@ -23,9 +23,9 @@ class RolloverAction(
 ) : Action(name, index) {
 
     init {
-        if (minSize != null) require(minSize.bytes > 0) { "RolloverActionConfig minSize value must be greater than 0" }
+        if (minSize != null) require(minSize.bytes > 0) { "RolloverAction minSize value must be greater than 0" }
 
-        if (minDocs != null) require(minDocs > 0) { "RolloverActionConfig minDocs value must be greater than 0" }
+        if (minDocs != null) require(minDocs > 0) { "RolloverAction minDocs value must be greater than 0" }
     }
 
     private val attemptRolloverStep = AttemptRolloverStep(this)

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/rollover/AttemptRolloverStep.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/rollover/AttemptRolloverStep.kt
@@ -5,32 +5,279 @@
 
 package org.opensearch.indexmanagement.indexstatemanagement.step.rollover
 
+import org.apache.logging.log4j.LogManager
+import org.opensearch.ExceptionsHelper
+import org.opensearch.action.admin.indices.rollover.RolloverRequest
+import org.opensearch.action.admin.indices.rollover.RolloverResponse
+import org.opensearch.action.admin.indices.stats.IndicesStatsRequest
+import org.opensearch.action.admin.indices.stats.IndicesStatsResponse
+import org.opensearch.common.unit.ByteSizeValue
+import org.opensearch.common.unit.TimeValue
+import org.opensearch.indexmanagement.indexstatemanagement.action.RolloverAction
+import org.opensearch.indexmanagement.indexstatemanagement.opensearchapi.getRolloverAlias
+import org.opensearch.indexmanagement.indexstatemanagement.opensearchapi.getRolloverSkip
+import org.opensearch.indexmanagement.indexstatemanagement.util.evaluateConditions
+import org.opensearch.indexmanagement.opensearchapi.getUsefulCauseString
+import org.opensearch.indexmanagement.opensearchapi.suspendUntil
 import org.opensearch.indexmanagement.spi.indexstatemanagement.Step
 import org.opensearch.indexmanagement.spi.indexstatemanagement.model.ManagedIndexMetaData
+import org.opensearch.indexmanagement.spi.indexstatemanagement.model.StepContext
+import org.opensearch.indexmanagement.spi.indexstatemanagement.model.StepMetaData
+import org.opensearch.rest.RestStatus
+import org.opensearch.transport.RemoteTransportException
+import java.time.Instant
 
-class AttemptRolloverStep : Step(name) {
+@Suppress("ReturnCount")
+class AttemptRolloverStep(private val action: RolloverAction) : Step(name) {
 
+    private val logger = LogManager.getLogger(javaClass)
+    private var stepStatus = StepStatus.STARTING
+    private var info: Map<String, Any>? = null
+
+    @Suppress("ComplexMethod", "LongMethod")
     override suspend fun execute(): Step {
-        TODO("Not yet implemented")
+        val context = this.context ?: return this
+        val indexName = context.metadata.index
+        val clusterService = context.clusterService
+        val skipRollover = clusterService.state().metadata.index(indexName).getRolloverSkip()
+        if (skipRollover) {
+            stepStatus = StepStatus.COMPLETED
+            info = mapOf("message" to getSkipRolloverMessage(indexName))
+            return this
+        }
+
+        val (rolloverTarget, isDataStream) = getRolloverTargetOrUpdateInfo(context)
+        // If the rolloverTarget is null, we would've already updated the failed info from getRolloverTargetOrUpdateInfo and can return early
+        rolloverTarget ?: return this
+
+        if (clusterService.state().metadata.index(indexName).rolloverInfos.containsKey(rolloverTarget)) {
+            stepStatus = StepStatus.COMPLETED
+            info = mapOf("message" to getAlreadyRolledOverMessage(indexName, rolloverTarget))
+            return this
+        }
+
+        if (!isDataStream && !preCheckIndexAlias(context, rolloverTarget)) {
+            stepStatus = StepStatus.FAILED
+            info = mapOf("message" to getFailedPreCheckMessage(indexName))
+            return this
+        }
+
+        val statsResponse = getIndexStatsOrUpdateInfo(context)
+        // If statsResponse is null we already updated failed info from getIndexStatsOrUpdateInfo and can return early
+        statsResponse ?: return this
+
+        val indexCreationDate = clusterService.state().metadata().index(indexName).creationDate
+        val indexAgeTimeValue = if (indexCreationDate == -1L) {
+            logger.warn("$indexName had an indexCreationDate=-1L, cannot use for comparison")
+            // since we cannot use for comparison, we can set it to 0 as minAge will never be <= 0
+            TimeValue.timeValueMillis(0)
+        } else {
+            TimeValue.timeValueMillis(Instant.now().toEpochMilli() - indexCreationDate)
+        }
+        val numDocs = statsResponse.primaries.docs?.count ?: 0
+        val indexSize = ByteSizeValue(statsResponse.primaries.docs?.totalSizeInBytes ?: 0)
+
+        val conditions = listOfNotNull(
+            action.minAge?.let {
+                RolloverAction.MIN_INDEX_AGE_FIELD to mapOf(
+                    "condition" to it.toString(),
+                    "current" to indexAgeTimeValue.toString(),
+                    "creationDate" to indexCreationDate
+                )
+            },
+            action.minDocs?.let {
+                RolloverAction.MIN_DOC_COUNT_FIELD to mapOf(
+                    "condition" to it,
+                    "current" to numDocs
+                )
+            },
+            action.minSize?.let {
+                RolloverAction.MIN_SIZE_FIELD to mapOf(
+                    "condition" to it.toString(),
+                    "current" to indexSize.toString()
+                )
+            }
+        ).toMap()
+
+        if (action.evaluateConditions(indexAgeTimeValue, numDocs, indexSize)) {
+            logger.info(
+                "$indexName rollover conditions evaluated to true [indexCreationDate=$indexCreationDate," +
+                    " numDocs=$numDocs, indexSize=${indexSize.bytes}]"
+            )
+            executeRollover(context, rolloverTarget, isDataStream, conditions)
+        } else {
+            stepStatus = StepStatus.CONDITION_NOT_MET
+            info = mapOf("message" to getPendingMessage(indexName), "conditions" to conditions)
+        }
+
+        return this
+    }
+
+    private fun getRolloverTargetOrUpdateInfo(context: StepContext): Pair<String?, Boolean> {
+        val indexName = context.metadata.index
+        val metadata = context.clusterService.state().metadata()
+        val indexAbstraction = metadata.indicesLookup[indexName]
+        val isDataStreamIndex = indexAbstraction?.parentDataStream != null
+
+        val rolloverTarget = when {
+            isDataStreamIndex -> indexAbstraction?.parentDataStream?.name
+            else -> metadata.index(indexName).getRolloverAlias()
+        }
+
+        if (rolloverTarget == null) {
+            val message = getFailedNoValidAliasMessage(indexName)
+            logger.warn(message)
+            stepStatus = StepStatus.FAILED
+            info = mapOf("message" to message)
+        }
+
+        return rolloverTarget to isDataStreamIndex
+    }
+
+    /**
+     * pre-condition check on managed-index's alias before rollover
+     *
+     * This will block
+     *  when managed index doesn't have alias
+     *  when managed index has alias but not the write index,
+     *      and this alias contains more than one index
+     * User can use skip rollover setting to bypass this
+     *
+     * @param alias user defined ISM rollover alias
+     */
+    private fun preCheckIndexAlias(context: StepContext, alias: String): Boolean {
+        val indexName = context.metadata.index
+        val metadata = context.clusterService.state().metadata
+        val indexAlias = metadata.index(indexName)?.aliases?.get(alias)
+        logger.debug("Index $indexName has aliases $indexAlias")
+        if (indexAlias == null) {
+            return false
+        }
+        val isWriteIndex = indexAlias.writeIndex() // this could be null
+        if (isWriteIndex != true) {
+            val aliasIndices = metadata.indicesLookup[alias]?.indices?.map { it.index }
+            logger.debug("Alias $alias contains indices $aliasIndices")
+            if (aliasIndices != null && aliasIndices.size > 1) {
+                return false
+            }
+        }
+
+        return true
+    }
+
+    private suspend fun getIndexStatsOrUpdateInfo(context: StepContext): IndicesStatsResponse? {
+        val indexName = context.metadata.index
+        try {
+            val statsRequest = IndicesStatsRequest()
+                .indices(indexName).clear().docs(true)
+            val statsResponse: IndicesStatsResponse = context.client.admin().indices().suspendUntil { stats(statsRequest, it) }
+
+            if (statsResponse.status == RestStatus.OK) {
+                return statsResponse
+            }
+
+            val message = getFailedEvaluateMessage(indexName)
+            logger.warn("$message - ${statsResponse.status}")
+            stepStatus = StepStatus.FAILED
+            info = mapOf(
+                "message" to message,
+                "shard_failures" to statsResponse.shardFailures.map { it.getUsefulCauseString() }
+            )
+        } catch (e: RemoteTransportException) {
+            handleException(indexName, ExceptionsHelper.unwrapCause(e) as Exception)
+        } catch (e: Exception) {
+            handleException(indexName, e, getFailedEvaluateMessage(indexName))
+        }
+
+        return null
+    }
+
+    @Suppress("ComplexMethod")
+    private suspend fun executeRollover(
+        context: StepContext,
+        rolloverTarget: String,
+        isDataStream: Boolean,
+        conditions: Map<String, Map<String, Any?>>
+    ) {
+        val indexName = context.metadata.index
+        try {
+            val request = RolloverRequest(rolloverTarget, null)
+            val response: RolloverResponse = context.client.admin().indices().suspendUntil { rolloverIndex(request, it) }
+
+            // Do not need to check for isRolledOver as we are not passing any conditions or dryrun=true
+            // which are the only two ways it comes back as false
+
+            // If the response is acknowledged, then the new index is created and added to one of the following index abstractions:
+            // 1. IndexAbstraction.Type.DATA_STREAM - the new index is added to the data stream indicated by the 'rolloverTarget'
+            // 2. IndexAbstraction.Type.ALIAS - the new index is added to the alias indicated by the 'rolloverTarget'
+            if (response.isAcknowledged) {
+                val message = when {
+                    isDataStream -> getSuccessDataStreamRolloverMessage(rolloverTarget, indexName)
+                    else -> getSuccessMessage(indexName)
+                }
+
+                stepStatus = StepStatus.COMPLETED
+                info = listOfNotNull(
+                    "message" to message,
+                    if (conditions.isEmpty()) null else "conditions" to conditions // don't show empty conditions object if no conditions specified
+                ).toMap()
+            } else {
+                val message = when {
+                    isDataStream -> getFailedDataStreamRolloverMessage(rolloverTarget)
+
+                    // If the alias update response was NOT acknowledged, then the new index was created but we failed to swap the alias
+                    else -> getFailedAliasUpdateMessage(indexName, response.newIndex)
+                }
+                logger.warn(message)
+                stepStatus = StepStatus.FAILED
+                info = listOfNotNull(
+                    "message" to message,
+                    if (conditions.isEmpty()) null else "conditions" to conditions // don't show empty conditions object if no conditions specified
+                ).toMap()
+            }
+        } catch (e: RemoteTransportException) {
+            handleException(indexName, ExceptionsHelper.unwrapCause(e) as Exception)
+        } catch (e: Exception) {
+            handleException(indexName, e)
+        }
     }
 
     override fun getUpdatedManagedIndexMetadata(currentMetadata: ManagedIndexMetaData): ManagedIndexMetaData {
-        TODO("Not yet implemented")
+        return currentMetadata.copy(
+            stepMetaData = StepMetaData(name, getStepStartTime(currentMetadata).toEpochMilli(), stepStatus),
+            rolledOver = if (currentMetadata.rolledOver == true) true else stepStatus == StepStatus.COMPLETED,
+            transitionTo = null,
+            info = info
+        )
     }
 
-    override fun isIdempotent(): Boolean {
-        TODO("Not yet implemented")
+    private fun handleException(indexName: String, e: Exception, message: String = getFailedMessage(indexName)) {
+        logger.error(message, e)
+        stepStatus = StepStatus.FAILED
+        val mutableInfo = mutableMapOf("message" to message)
+        val errorMessage = e.message
+        if (errorMessage != null) mutableInfo["cause"] = errorMessage
+        info = mutableInfo.toMap()
     }
 
+    override fun isIdempotent(): Boolean = false
+
+    @Suppress("TooManyFunctions")
     companion object {
         const val name = "attempt_rollover"
-        // TODO: fixme
-        fun getFailedNoValidAliasMessage(indexName: String) = ""
-        fun getPendingMessage(indexName: String) = ""
-        fun getAlreadyRolledOverMessage(indexName: String, alias: String) = ""
-        fun getSuccessDataStreamRolloverMessage(dataStreamName: String, indexName: String) = ""
-        fun getSuccessMessage(indexName: String) = ""
-        fun getFailedPreCheckMessage(indexName: String) = ""
-        fun getSkipRolloverMessage(indexName: String) = ""
+        fun getFailedMessage(index: String) = "Failed to rollover index [index=$index]"
+        fun getFailedAliasUpdateMessage(index: String, newIndex: String) =
+            "New index created, but failed to update alias [index=$index, newIndex=$newIndex]"
+        fun getFailedDataStreamRolloverMessage(dataStream: String) = "Failed to rollover data stream [data_stream=$dataStream]"
+        fun getFailedNoValidAliasMessage(index: String) = "Missing rollover_alias index setting [index=$index]"
+        fun getFailedEvaluateMessage(index: String) = "Failed to evaluate conditions for rollover [index=$index]"
+        fun getPendingMessage(index: String) = "Pending rollover of index [index=$index]"
+        fun getSuccessMessage(index: String) = "Successfully rolled over index [index=$index]"
+        fun getSuccessDataStreamRolloverMessage(dataStream: String, index: String) =
+            "Successfully rolled over data stream [data_stream=$dataStream index=$index]"
+        fun getFailedPreCheckMessage(index: String) = "Missing alias or not the write index when rollover [index=$index]"
+        fun getSkipRolloverMessage(index: String) = "Skipped rollover action for [index=$index]"
+        fun getAlreadyRolledOverMessage(index: String, alias: String) =
+            "This index has already been rolled over using this alias, treating as a success [index=$index, alias=$alias]"
     }
 }

--- a/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/model/ActionTests.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/model/ActionTests.kt
@@ -72,7 +72,7 @@ class ActionTests : OpenSearchTestCase() {
             randomAllocationActionConfig()
         }
     }
-    
+
     fun `test set read only action round trip`() {
         roundTripAction(randomReadOnlyActionConfig())
     }

--- a/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/model/ActionTests.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/model/ActionTests.kt
@@ -46,15 +46,13 @@ class ActionTests : OpenSearchTestCase() {
         }
     }
 
-    // TODO: fixme - enable the test
-    private fun `test rollover action minimum size of zero fails`() {
+    fun `test rollover action minimum size of zero fails`() {
         assertFailsWith(IllegalArgumentException::class, "Expected IllegalArgumentException for minSize less than 1") {
             randomRolloverActionConfig(minSize = ByteSizeValue.parseBytesSizeValue("0", "min_size_test"))
         }
     }
 
-    // TODO: fixme - enable the test
-    private fun `test rollover action minimum doc count of zero fails`() {
+    fun `test rollover action minimum doc count of zero fails`() {
         assertFailsWith(IllegalArgumentException::class, "Expected IllegalArgumentException for minDoc less than 1") {
             randomRolloverActionConfig(minDocs = 0)
         }
@@ -74,8 +72,7 @@ class ActionTests : OpenSearchTestCase() {
         }
     }
 
-    // TODO: fixme - enable the test
-    private fun `test rollover action round trip`() {
+    fun `test rollover action round trip`() {
         roundTripAction(randomRolloverActionConfig())
     }
 

--- a/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/model/XContentTests.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/model/XContentTests.kt
@@ -92,10 +92,10 @@ class XContentTests : OpenSearchTestCase() {
 
         val rolloverActionString = rolloverAction.toJsonString()
         val parsedRolloverAction = ISMActionsParser.instance.parse(parser(rolloverActionString), 0)
-        assertEquals("Round tripping RolloverActionConfig doesn't work", rolloverAction.convertToMap(), parsedRolloverAction.convertToMap())
+        assertEquals("Round tripping RolloverAction doesn't work", rolloverAction.convertToMap(), parsedRolloverAction.convertToMap())
     }
 
-    fun `test read_only action config parsing`() {
+    fun `test read_only action parsing`() {
         val readOnlyAction = randomReadOnlyActionConfig()
 
         val readOnlyActionString = readOnlyAction.toJsonString()
@@ -103,7 +103,7 @@ class XContentTests : OpenSearchTestCase() {
         assertEquals("Round tripping ReadOnlyAction doesn't work", readOnlyAction.convertToMap(), parsedReadOnlyAction.convertToMap())
     }
 
-    fun `test read_write action config parsing`() {
+    fun `test read_write action parsing`() {
         val readWriteAction = randomReadWriteActionConfig()
 
         val readWriteActionString = readWriteAction.toJsonString()

--- a/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/model/XContentTests.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/model/XContentTests.kt
@@ -87,12 +87,12 @@ class XContentTests : OpenSearchTestCase() {
         assertEquals("Round tripping DeleteAction doesn't work", deleteAction.convertToMap(), parsedDeleteAction.convertToMap())
     }
 
-    private fun `test rollover action config parsing`() {
-        val rolloverActionConfig = randomRolloverActionConfig()
+    fun `test rollover action parsing`() {
+        val rolloverAction = randomRolloverActionConfig()
 
-        val rolloverActionConfigString = rolloverActionConfig.toJsonString()
-        val parsedRolloverActionConfig = ISMActionsParser.instance.parse(parser(rolloverActionConfigString), 0)
-        assertEquals("Round tripping RolloverActionConfig doesn't work", rolloverActionConfig, parsedRolloverActionConfig)
+        val rolloverActionString = rolloverAction.toJsonString()
+        val parsedRolloverAction = ISMActionsParser.instance.parse(parser(rolloverActionString), 0)
+        assertEquals("Round tripping RolloverActionConfig doesn't work", rolloverAction.convertToMap(), parsedRolloverAction.convertToMap())
     }
 
     private fun `test read_only action config parsing`() {

--- a/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/util/ManagedIndexUtilsTests.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/util/ManagedIndexUtilsTests.kt
@@ -13,21 +13,26 @@ import org.opensearch.alerting.destination.message.BaseMessage
 import org.opensearch.alerting.destination.message.CustomWebhookMessage
 import org.opensearch.cluster.metadata.IndexMetadata
 import org.opensearch.common.bytes.BytesReference
+import org.opensearch.common.unit.ByteSizeValue
+import org.opensearch.common.unit.TimeValue
 import org.opensearch.common.xcontent.LoggingDeprecationHandler
 import org.opensearch.common.xcontent.XContentHelper
 import org.opensearch.common.xcontent.XContentParser
 import org.opensearch.common.xcontent.XContentType
 import org.opensearch.index.Index
 import org.opensearch.indexmanagement.IndexManagementPlugin.Companion.INDEX_MANAGEMENT_INDEX
+import org.opensearch.indexmanagement.indexstatemanagement.action.RolloverAction
+import org.opensearch.indexmanagement.indexstatemanagement.model.Conditions
 import org.opensearch.indexmanagement.indexstatemanagement.model.ManagedIndexConfig
+import org.opensearch.indexmanagement.indexstatemanagement.model.Transition
 import org.opensearch.indexmanagement.indexstatemanagement.model.coordinator.SweptManagedIndexConfig
 import org.opensearch.indexmanagement.indexstatemanagement.randomChangePolicy
 import org.opensearch.indexmanagement.indexstatemanagement.randomClusterStateManagedIndexConfig
 import org.opensearch.indexmanagement.indexstatemanagement.randomSweptManagedIndexConfig
 import org.opensearch.indexmanagement.opensearchapi.parseWithType
 import org.opensearch.test.OpenSearchTestCase
+import java.time.Instant
 
-// TODO: Fix tests after refactor
 class ManagedIndexUtilsTests : OpenSearchTestCase() {
 
     fun `test create managed index request`() {
@@ -137,8 +142,8 @@ class ManagedIndexUtilsTests : OpenSearchTestCase() {
         assertEquals("Wrong index being searched", listOf(INDEX_MANAGEMENT_INDEX), indices)
     }
 
-    /*fun `test rollover action config evaluate conditions`() {
-        val noConditionsConfig = RolloverActionConfig(minSize = null, minDocs = null, minAge = null, index = 0)
+    fun `test rollover action config evaluate conditions`() {
+        val noConditionsConfig = RolloverAction(minSize = null, minDocs = null, minAge = null, index = 0)
         assertTrue(
             "No conditions should always pass",
             noConditionsConfig
@@ -155,7 +160,7 @@ class ManagedIndexUtilsTests : OpenSearchTestCase() {
                 .evaluateConditions(indexAgeTimeValue = TimeValue.timeValueMillis(6000), numDocs = 5, indexSize = ByteSizeValue(5))
         )
 
-        val minSizeConfig = RolloverActionConfig(minSize = ByteSizeValue(5), minDocs = null, minAge = null, index = 0)
+        val minSizeConfig = RolloverAction(minSize = ByteSizeValue(5), minDocs = null, minAge = null, index = 0)
         assertFalse(
             "Less bytes should not pass",
             minSizeConfig
@@ -172,7 +177,7 @@ class ManagedIndexUtilsTests : OpenSearchTestCase() {
                 .evaluateConditions(indexAgeTimeValue = TimeValue.timeValueMillis(1000), numDocs = 0, indexSize = ByteSizeValue(10))
         )
 
-        val minDocsConfig = RolloverActionConfig(minSize = null, minDocs = 5, minAge = null, index = 0)
+        val minDocsConfig = RolloverAction(minSize = null, minDocs = 5, minAge = null, index = 0)
         assertFalse(
             "Less docs should not pass",
             minDocsConfig
@@ -189,7 +194,7 @@ class ManagedIndexUtilsTests : OpenSearchTestCase() {
                 .evaluateConditions(indexAgeTimeValue = TimeValue.timeValueMillis(1000), numDocs = 10, indexSize = ByteSizeValue.ZERO)
         )
 
-        val minAgeConfig = RolloverActionConfig(minSize = null, minDocs = null, minAge = TimeValue.timeValueSeconds(5), index = 0)
+        val minAgeConfig = RolloverAction(minSize = null, minDocs = null, minAge = TimeValue.timeValueSeconds(5), index = 0)
         assertFalse(
             "Index age that is too young should not pass",
             minAgeConfig
@@ -201,7 +206,7 @@ class ManagedIndexUtilsTests : OpenSearchTestCase() {
                 .evaluateConditions(indexAgeTimeValue = TimeValue.timeValueMillis(10000), numDocs = 0, indexSize = ByteSizeValue.ZERO)
         )
 
-        val multiConfig = RolloverActionConfig(minSize = ByteSizeValue(1), minDocs = 1, minAge = TimeValue.timeValueSeconds(5), index = 0)
+        val multiConfig = RolloverAction(minSize = ByteSizeValue(1), minDocs = 1, minAge = TimeValue.timeValueSeconds(5), index = 0)
         assertFalse(
             "No conditions met should not pass",
             multiConfig
@@ -222,9 +227,9 @@ class ManagedIndexUtilsTests : OpenSearchTestCase() {
             multiConfig
                 .evaluateConditions(indexAgeTimeValue = TimeValue.timeValueMillis(0), numDocs = 0, indexSize = ByteSizeValue(2))
         )
-    }*/
+    }
 
-    /*fun `test transition evaluate conditions`() {
+    fun `test transition evaluate conditions`() {
         val emptyTransition = Transition(stateName = "some_state", conditions = null)
         assertTrue(
             "No conditions should pass",
@@ -271,7 +276,7 @@ class ManagedIndexUtilsTests : OpenSearchTestCase() {
             rolloverTimeTransition
                 .evaluateConditions(indexCreationDate = Instant.ofEpochMilli(-1L), numDocs = null, indexSize = null, transitionStartTime = Instant.now(), rolloverDate = null)
         )
-    }*/
+    }
 
     fun `test ips in denylist`() {
         val ips = listOf(


### PR DESCRIPTION
*Issue #, if available:*
NA
*Description of changes:*
- Implements the rollover action using the new interface.
- When merging the development branch, some of the changes from the default actions retry commit https://github.com/opensearch-project/index-management/pull/212 were lost in the transition to the new SPI. 
- The default action retry was only applied during XContent parse, added it as the default value in the Action.kt class to make Actions stay the same when round tripped.
- In ManagedIndexUtils, the Transition.evaluateConditions function was missing the rolloverDate inclusion from the min rollover age as a transition condition PR https://github.com/opensearch-project/index-management/pull/215. 
- Reenabled all ManagedIndexUtilsTests

*CheckList:*
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/index-management/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
