### PR TITLE
Refactors Notification action with new interface

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -305,7 +305,6 @@ integTest {
     exclude 'org/opensearch/indexmanagement/indexstatemanagement/action/ForceMergeActionIT.class'
     exclude 'org/opensearch/indexmanagement/indexstatemanagement/action/IndexPriorityActionIT.class'
     exclude 'org/opensearch/indexmanagement/indexstatemanagement/action/IndexStateManagementHistoryIT.class'
-    exclude 'org/opensearch/indexmanagement/indexstatemanagement/action/NotificationActionIT.class'
     exclude 'org/opensearch/indexmanagement/indexstatemanagement/action/SnapshotActionIT.class'
     exclude 'org/opensearch/indexmanagement/indexstatemanagement/runner/*'
     exclude 'org/opensearch/indexmanagement/indexstatemanagement/resthandler/*'

--- a/spi/src/main/kotlin/org.opensearch.indexmanagement.spi/indexstatemanagement/model/StepContext.kt
+++ b/spi/src/main/kotlin/org.opensearch.indexmanagement.spi/indexstatemanagement/model/StepContext.kt
@@ -19,6 +19,6 @@ class StepContext(
     val client: Client,
     val threadContext: ThreadContext?,
     val user: User?,
-    val scriptService: ScriptService? = null,
-    val settings: Settings? = null,
+    val scriptService: ScriptService,
+    val settings: Settings,
 )

--- a/spi/src/main/kotlin/org.opensearch.indexmanagement.spi/indexstatemanagement/model/StepContext.kt
+++ b/spi/src/main/kotlin/org.opensearch.indexmanagement.spi/indexstatemanagement/model/StepContext.kt
@@ -7,8 +7,10 @@ package org.opensearch.indexmanagement.spi.indexstatemanagement.model
 
 import org.opensearch.client.Client
 import org.opensearch.cluster.service.ClusterService
+import org.opensearch.common.settings.Settings
 import org.opensearch.common.util.concurrent.ThreadContext
 import org.opensearch.commons.authuser.User
+import org.opensearch.script.ScriptService
 
 // TODO: Add more attributes here if needed
 class StepContext(
@@ -16,5 +18,7 @@ class StepContext(
     val clusterService: ClusterService,
     val client: Client,
     val threadContext: ThreadContext?,
-    val user: User?
+    val user: User?,
+    val scriptService: ScriptService? = null,
+    val settings: Settings? = null,
 )

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/ISMActionsParser.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/ISMActionsParser.kt
@@ -10,6 +10,7 @@ import org.opensearch.common.xcontent.XContentParser
 import org.opensearch.common.xcontent.XContentParserUtils
 import org.opensearch.indexmanagement.indexstatemanagement.action.CloseActionParser
 import org.opensearch.indexmanagement.indexstatemanagement.action.DeleteActionParser
+import org.opensearch.indexmanagement.indexstatemanagement.action.NotificationActionParser
 import org.opensearch.indexmanagement.indexstatemanagement.action.OpenActionParser
 import org.opensearch.indexmanagement.indexstatemanagement.action.ReadOnlyActionParser
 import org.opensearch.indexmanagement.indexstatemanagement.action.ReadWriteActionParser
@@ -31,6 +32,7 @@ class ISMActionsParser private constructor() {
     val parsers = mutableListOf<ActionParser>(
         CloseActionParser(),
         DeleteActionParser(),
+        NotificationActionParser(),
         OpenActionParser(),
         ReadOnlyActionParser(),
         ReadWriteActionParser(),

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/ManagedIndexRunner.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/ManagedIndexRunner.kt
@@ -13,7 +13,6 @@ import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import org.apache.logging.log4j.LogManager
-import org.locationtech.jts.algorithm.Orientation.index
 import org.opensearch.action.admin.cluster.state.ClusterStateRequest
 import org.opensearch.action.admin.cluster.state.ClusterStateResponse
 import org.opensearch.action.bulk.BackoffPolicy
@@ -267,7 +266,7 @@ object ManagedIndexRunner :
 
         val state = policy.getStateToExecute(managedIndexMetaData)
         val action: Action? = state?.getActionToExecute(managedIndexMetaData.copy(user = policy.user, threadContext = threadPool.threadContext))
-        val stepContext = StepContext(managedIndexMetaData, clusterService, client, null, null)
+        val stepContext = StepContext(managedIndexMetaData, clusterService, client, null, null, scriptService, settings)
         val step: Step? = action?.getStepToExecute(stepContext)
         val currentActionMetaData = action?.getUpdatedActionMetaData(managedIndexMetaData, state)
 

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/action/NotificationAction.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/action/NotificationAction.kt
@@ -5,7 +5,11 @@
 
 package org.opensearch.indexmanagement.indexstatemanagement.action
 
+import org.opensearch.common.io.stream.StreamOutput
+import org.opensearch.common.xcontent.ToXContent
+import org.opensearch.common.xcontent.XContentBuilder
 import org.opensearch.indexmanagement.indexstatemanagement.model.destination.Destination
+import org.opensearch.indexmanagement.indexstatemanagement.step.notification.AttemptNotificationStep
 import org.opensearch.indexmanagement.spi.indexstatemanagement.Action
 import org.opensearch.indexmanagement.spi.indexstatemanagement.Step
 import org.opensearch.indexmanagement.spi.indexstatemanagement.model.StepContext
@@ -17,15 +21,36 @@ class NotificationAction(
     index: Int
 ) : Action(name, index) {
 
-    companion object {
-        const val name = "notification"
+    init {
+        require(messageTemplate.lang == MUSTACHE) { "Notification message template must be a mustache script" }
     }
+
+    private val attemptNotificationStep = AttemptNotificationStep(this)
+    private val steps = listOf(attemptNotificationStep)
 
     override fun getStepToExecute(context: StepContext): Step {
-        TODO("Not yet implemented")
+        return attemptNotificationStep
     }
 
-    override fun getSteps(): List<Step> {
-        TODO("Not yet implemented")
+    override fun getSteps(): List<Step> = steps
+
+    override fun populateAction(builder: XContentBuilder, params: ToXContent.Params) {
+        builder.startObject(type)
+        builder.field(DESTINATION_FIELD, destination)
+        builder.field(MESSAGE_TEMPLATE_FIELD, messageTemplate)
+        builder.endObject()
+    }
+
+    override fun populateAction(out: StreamOutput) {
+        destination.writeTo(out)
+        messageTemplate.writeTo(out)
+        out.writeInt(actionIndex)
+    }
+
+    companion object {
+        const val name = "notification"
+        const val DESTINATION_FIELD = "destination"
+        const val MESSAGE_TEMPLATE_FIELD = "message_template"
+        const val MUSTACHE = "mustache"
     }
 }

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/action/NotificationActionParser.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/action/NotificationActionParser.kt
@@ -7,19 +7,48 @@ package org.opensearch.indexmanagement.indexstatemanagement.action
 
 import org.opensearch.common.io.stream.StreamInput
 import org.opensearch.common.xcontent.XContentParser
+import org.opensearch.common.xcontent.XContentParser.Token
+import org.opensearch.common.xcontent.XContentParserUtils.ensureExpectedToken
+import org.opensearch.indexmanagement.indexstatemanagement.action.NotificationAction.Companion.DESTINATION_FIELD
+import org.opensearch.indexmanagement.indexstatemanagement.action.NotificationAction.Companion.MESSAGE_TEMPLATE_FIELD
+import org.opensearch.indexmanagement.indexstatemanagement.model.destination.Destination
 import org.opensearch.indexmanagement.spi.indexstatemanagement.Action
 import org.opensearch.indexmanagement.spi.indexstatemanagement.ActionParser
+import org.opensearch.script.Script
 
 class NotificationActionParser : ActionParser() {
     override fun fromStreamInput(sin: StreamInput): Action {
-        TODO("Not yet implemented")
+        val destination = Destination(sin)
+        val messageTemplate = Script(sin)
+        val index = sin.readInt()
+
+        return NotificationAction(destination, messageTemplate, index)
     }
 
     override fun fromXContent(xcp: XContentParser, index: Int): Action {
-        TODO("Not yet implemented")
+        var destination: Destination? = null
+        var messageTemplate: Script? = null
+
+        ensureExpectedToken(Token.START_OBJECT, xcp.currentToken(), xcp)
+        while (xcp.nextToken() != Token.END_OBJECT) {
+            val fieldName = xcp.currentName()
+            xcp.nextToken()
+
+            when (fieldName) {
+                DESTINATION_FIELD -> destination = Destination.parse(xcp)
+                MESSAGE_TEMPLATE_FIELD -> messageTemplate = Script.parse(xcp, Script.DEFAULT_TEMPLATE_LANG)
+                else -> throw IllegalArgumentException("Invalid field: [$fieldName] found in NotificationAction.")
+            }
+        }
+
+        return NotificationAction(
+            destination = requireNotNull(destination) { "NotificationAction destination is null" },
+            messageTemplate = requireNotNull(messageTemplate) { "NotificationAction message template is null" },
+            index = index
+        )
     }
 
     override fun getActionType(): String {
-        TODO("Not yet implemented")
+        return NotificationAction.name
     }
 }

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/notification/AttemptNotificationStep.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/notification/AttemptNotificationStep.kt
@@ -25,11 +25,10 @@ class AttemptNotificationStep(private val action: NotificationAction) : Step(nam
     private var info: Map<String, Any>? = null
 
     override suspend fun execute(): Step {
-        if (this.context == null || this.context?.settings == null || this.context?.scriptService == null) return this
-        val context = this.context!!
+        val context = this.context ?: return this
         val indexName = context.metadata.index
-        val hostDenyList = context.settings!!.getAsList(ManagedIndexSettings.HOST_DENY_LIST)
-        val scriptService = context.scriptService!!
+        val hostDenyList = context.settings.getAsList(ManagedIndexSettings.HOST_DENY_LIST)
+        val scriptService = context.scriptService
         try {
             withContext(Dispatchers.IO) {
                 action.destination.publish(null, compileTemplate(scriptService, action.messageTemplate, context.metadata), hostDenyList)

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/notification/AttemptNotificationStep.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/notification/AttemptNotificationStep.kt
@@ -5,24 +5,76 @@
 
 package org.opensearch.indexmanagement.indexstatemanagement.step.notification
 
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import org.apache.logging.log4j.LogManager
+import org.opensearch.indexmanagement.indexstatemanagement.action.NotificationAction
+import org.opensearch.indexmanagement.indexstatemanagement.settings.ManagedIndexSettings
+import org.opensearch.indexmanagement.opensearchapi.convertToMap
 import org.opensearch.indexmanagement.spi.indexstatemanagement.Step
 import org.opensearch.indexmanagement.spi.indexstatemanagement.model.ManagedIndexMetaData
+import org.opensearch.indexmanagement.spi.indexstatemanagement.model.StepMetaData
+import org.opensearch.script.Script
+import org.opensearch.script.ScriptService
+import org.opensearch.script.TemplateScript
 
-class AttemptNotificationStep : Step(name) {
+class AttemptNotificationStep(private val action: NotificationAction) : Step(name) {
+
+    private val logger = LogManager.getLogger(javaClass)
+    private var stepStatus = StepStatus.STARTING
+    private var info: Map<String, Any>? = null
 
     override suspend fun execute(): Step {
-        TODO("Not yet implemented")
+        if (this.context == null || this.context?.settings == null || this.context?.scriptService == null) return this
+        val context = this.context!!
+        val indexName = context.metadata.index
+        val hostDenyList = context.settings!!.getAsList(ManagedIndexSettings.HOST_DENY_LIST)
+        val scriptService = context.scriptService!!
+        try {
+            withContext(Dispatchers.IO) {
+                action.destination.publish(null, compileTemplate(scriptService, action.messageTemplate, context.metadata), hostDenyList)
+            }
+
+            // publish internally throws an error for any invalid responses so its safe to assume if we reach this point it was successful
+            // publish and send throws an error for any invalid responses so its safe to assume if we reach this point it was successful
+            stepStatus = StepStatus.COMPLETED
+            info = mapOf("message" to getSuccessMessage(indexName))
+        } catch (e: Exception) {
+            handleException(indexName, e)
+        }
+
+        return this
+    }
+
+    private fun handleException(indexName: String, e: Exception) {
+        val message = getFailedMessage(indexName)
+        logger.error(message, e)
+        stepStatus = StepStatus.FAILED
+        val mutableInfo = mutableMapOf("message" to message)
+        val errorMessage = e.message
+        if (errorMessage != null) mutableInfo["cause"] = errorMessage
+        info = mutableInfo.toMap()
     }
 
     override fun getUpdatedManagedIndexMetadata(currentMetadata: ManagedIndexMetaData): ManagedIndexMetaData {
-        TODO("Not yet implemented")
+        return currentMetadata.copy(
+            stepMetaData = StepMetaData(name, getStepStartTime(currentMetadata).toEpochMilli(), stepStatus),
+            transitionTo = null,
+            info = info
+        )
     }
 
-    override fun isIdempotent(): Boolean {
-        TODO("Not yet implemented")
+    private fun compileTemplate(scriptService: ScriptService, template: Script, managedIndexMetaData: ManagedIndexMetaData): String {
+        return scriptService.compile(template, TemplateScript.CONTEXT)
+            .newInstance(template.params + mapOf("ctx" to managedIndexMetaData.convertToMap()))
+            .execute()
     }
+
+    override fun isIdempotent(): Boolean = false
 
     companion object {
         const val name = "attempt_notification"
+        fun getFailedMessage(index: String) = "Failed to send notification [index=$index]"
+        fun getSuccessMessage(index: String) = "Successfully sent notification [index=$index]"
     }
 }

--- a/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/model/ActionTests.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/model/ActionTests.kt
@@ -102,8 +102,7 @@ class ActionTests : OpenSearchTestCase() {
         roundTripAction(randomForceMergeActionConfig())
     }
 
-    // TODO: fixme - enable the test
-    private fun `test notification action round trip`() {
+    fun `test notification action round trip`() {
         roundTripAction(randomNotificationActionConfig())
     }
 

--- a/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/model/XContentTests.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/model/XContentTests.kt
@@ -137,30 +137,30 @@ class XContentTests : OpenSearchTestCase() {
         assertEquals("Round tripping ForceMergeActionConfig doesn't work", forceMergeActionConfig, parsedForceMergeActionConfig)
     }
 
-    private fun `test notification action config parsing`() {
-        val chimeNotificationActionConfig = randomNotificationActionConfig(destination = randomDestination(type = DestinationType.CHIME))
-        val slackNotificationActionConfig = randomNotificationActionConfig(destination = randomDestination(type = DestinationType.SLACK))
-        val customNotificationActionConfig = randomNotificationActionConfig(destination = randomDestination(type = DestinationType.CUSTOM_WEBHOOK))
+    fun `test notification action parsing`() {
+        val chimeNotificationAction = randomNotificationActionConfig(destination = randomDestination(type = DestinationType.CHIME))
+        val slackNotificationAction = randomNotificationActionConfig(destination = randomDestination(type = DestinationType.SLACK))
+        val customNotificationAction = randomNotificationActionConfig(destination = randomDestination(type = DestinationType.CUSTOM_WEBHOOK))
 
-        val chimeNotificationActionConfigString = chimeNotificationActionConfig.toJsonString()
-        val chimeParsedNotificationActionConfig = ISMActionsParser.instance.parse(parser(chimeNotificationActionConfigString), 0)
+        val chimeNotificationActionString = chimeNotificationAction.toJsonString()
+        val chimeParsedNotificationAction = ISMActionsParser.instance.parse(parser(chimeNotificationActionString), 0)
         assertEquals(
-            "Round tripping chime NotificationActionConfig doesn't work",
-            chimeNotificationActionConfig, chimeParsedNotificationActionConfig
+            "Round tripping chime NotificationAction doesn't work",
+            chimeNotificationAction.convertToMap(), chimeParsedNotificationAction.convertToMap()
         )
 
-        val slackNotificationActionConfigString = slackNotificationActionConfig.toJsonString()
-        val slackParsedNotificationActionConfig = ISMActionsParser.instance.parse(parser(slackNotificationActionConfigString), 0)
+        val slackNotificationActionString = slackNotificationAction.toJsonString()
+        val slackParsedNotificationAction = ISMActionsParser.instance.parse(parser(slackNotificationActionString), 0)
         assertEquals(
-            "Round tripping slack NotificationActionConfig doesn't work",
-            slackNotificationActionConfig, slackParsedNotificationActionConfig
+            "Round tripping slack NotificationAction doesn't work",
+            slackNotificationAction.convertToMap(), slackParsedNotificationAction.convertToMap()
         )
 
-        val customNotificationActionConfigString = customNotificationActionConfig.toJsonString()
-        val customParsedNotificationActionConfig = ISMActionsParser.instance.parse(parser(customNotificationActionConfigString), 0)
+        val customNotificationActionString = customNotificationAction.toJsonString()
+        val customParsedNotificationAction = ISMActionsParser.instance.parse(parser(customNotificationActionString), 0)
         assertEquals(
-            "Round tripping custom webhook NotificationActionConfig doesn't work",
-            customNotificationActionConfig, customParsedNotificationActionConfig
+            "Round tripping custom webhook NotificationAction doesn't work",
+            customNotificationAction.convertToMap(), customParsedNotificationAction.convertToMap()
         )
     }
 
@@ -168,8 +168,8 @@ class XContentTests : OpenSearchTestCase() {
         val snapshotActionConfig = randomSnapshotActionConfig("repository", "snapshot")
 
         val snapshotActionConfigString = snapshotActionConfig.toJsonString()
-        val parsedNotificationActionConfig = ISMActionsParser.instance.parse(parser(snapshotActionConfigString), 0)
-        assertEquals("Round tripping SnapshotActionConfig doesn't work", snapshotActionConfig, parsedNotificationActionConfig)
+        val parsedSnapshotActionConfig = ISMActionsParser.instance.parse(parser(snapshotActionConfigString), 0)
+        assertEquals("Round tripping SnapshotActionConfig doesn't work", snapshotActionConfig, parsedSnapshotActionConfig)
     }
 
     private fun `test allocation action config parsing`() {

--- a/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/AttemptCloseStepTests.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/AttemptCloseStepTests.kt
@@ -17,10 +17,12 @@ import org.opensearch.client.AdminClient
 import org.opensearch.client.Client
 import org.opensearch.client.IndicesAdminClient
 import org.opensearch.cluster.service.ClusterService
+import org.opensearch.common.settings.Settings
 import org.opensearch.indexmanagement.indexstatemanagement.step.close.AttemptCloseStep
 import org.opensearch.indexmanagement.spi.indexstatemanagement.Step
 import org.opensearch.indexmanagement.spi.indexstatemanagement.model.ManagedIndexMetaData
 import org.opensearch.indexmanagement.spi.indexstatemanagement.model.StepContext
+import org.opensearch.script.ScriptService
 import org.opensearch.snapshots.SnapshotInProgressException
 import org.opensearch.test.OpenSearchTestCase
 import org.opensearch.transport.RemoteTransportException
@@ -29,6 +31,8 @@ import kotlin.IllegalArgumentException
 class AttemptCloseStepTests : OpenSearchTestCase() {
 
     private val clusterService: ClusterService = mock()
+    private val scriptService: ScriptService = mock()
+    private val settings: Settings = Settings.EMPTY
 
     fun `test close step sets step status to completed when successful`() {
         val closeIndexResponse = CloseIndexResponse(true, true, listOf())
@@ -37,7 +41,7 @@ class AttemptCloseStepTests : OpenSearchTestCase() {
         runBlocking {
             val managedIndexMetaData = ManagedIndexMetaData("test", "indexUuid", "policy_id", null, null, null, null, null, null, null, null, null, null)
             val attemptCloseStep = AttemptCloseStep()
-            val context = StepContext(managedIndexMetaData, clusterService, client, null, null)
+            val context = StepContext(managedIndexMetaData, clusterService, client, null, null, scriptService, settings)
             attemptCloseStep.preExecute(logger, context).execute()
             val updatedManagedIndexMetaData = attemptCloseStep.getUpdatedManagedIndexMetadata(managedIndexMetaData)
             assertEquals("Step status is not COMPLETED", Step.StepStatus.COMPLETED, updatedManagedIndexMetaData.stepMetaData?.stepStatus)
@@ -51,7 +55,7 @@ class AttemptCloseStepTests : OpenSearchTestCase() {
         runBlocking {
             val managedIndexMetaData = ManagedIndexMetaData("test", "indexUuid", "policy_id", null, null, null, null, null, null, null, null, null, null)
             val attemptCloseStep = AttemptCloseStep()
-            val context = StepContext(managedIndexMetaData, clusterService, client, null, null)
+            val context = StepContext(managedIndexMetaData, clusterService, client, null, null, scriptService, settings)
             attemptCloseStep.preExecute(logger, context).execute()
             val updatedManagedIndexMetaData = attemptCloseStep.getUpdatedManagedIndexMetadata(managedIndexMetaData)
             assertEquals("Step status is not FAILED", Step.StepStatus.FAILED, updatedManagedIndexMetaData.stepMetaData?.stepStatus)
@@ -65,7 +69,7 @@ class AttemptCloseStepTests : OpenSearchTestCase() {
         runBlocking {
             val managedIndexMetaData = ManagedIndexMetaData("test", "indexUuid", "policy_id", null, null, null, null, null, null, null, null, null, null)
             val attemptCloseStep = AttemptCloseStep()
-            val context = StepContext(managedIndexMetaData, clusterService, client, null, null)
+            val context = StepContext(managedIndexMetaData, clusterService, client, null, null, scriptService, settings)
             attemptCloseStep.preExecute(logger, context).execute()
             val updatedManagedIndexMetaData = attemptCloseStep.getUpdatedManagedIndexMetadata(managedIndexMetaData)
             assertEquals("Step status is not FAILED", Step.StepStatus.FAILED, updatedManagedIndexMetaData.stepMetaData?.stepStatus)
@@ -79,7 +83,7 @@ class AttemptCloseStepTests : OpenSearchTestCase() {
         runBlocking {
             val managedIndexMetaData = ManagedIndexMetaData("test", "indexUuid", "policy_id", null, null, null, null, null, null, null, null, null, null)
             val attemptCloseStep = AttemptCloseStep()
-            val context = StepContext(managedIndexMetaData, clusterService, client, null, null)
+            val context = StepContext(managedIndexMetaData, clusterService, client, null, null, scriptService, settings)
             attemptCloseStep.preExecute(logger, context).execute()
             val updatedManagedIndexMetaData = attemptCloseStep.getUpdatedManagedIndexMetadata(managedIndexMetaData)
             assertEquals("Step status is not CONDITION_NOT_MET", Step.StepStatus.CONDITION_NOT_MET, updatedManagedIndexMetaData.stepMetaData?.stepStatus)
@@ -93,7 +97,7 @@ class AttemptCloseStepTests : OpenSearchTestCase() {
         runBlocking {
             val managedIndexMetaData = ManagedIndexMetaData("test", "indexUuid", "policy_id", null, null, null, null, null, null, null, null, null, null)
             val attemptCloseStep = AttemptCloseStep()
-            val context = StepContext(managedIndexMetaData, clusterService, client, null, null)
+            val context = StepContext(managedIndexMetaData, clusterService, client, null, null, scriptService, settings)
             attemptCloseStep.preExecute(logger, context).execute()
             val updatedManagedIndexMetaData = attemptCloseStep.getUpdatedManagedIndexMetadata(managedIndexMetaData)
             assertEquals("Step status is not CONDITION_NOT_MET", Step.StepStatus.CONDITION_NOT_MET, updatedManagedIndexMetaData.stepMetaData?.stepStatus)
@@ -107,7 +111,7 @@ class AttemptCloseStepTests : OpenSearchTestCase() {
         runBlocking {
             val managedIndexMetaData = ManagedIndexMetaData("test", "indexUuid", "policy_id", null, null, null, null, null, null, null, null, null, null)
             val attemptCloseStep = AttemptCloseStep()
-            val context = StepContext(managedIndexMetaData, clusterService, client, null, null)
+            val context = StepContext(managedIndexMetaData, clusterService, client, null, null, scriptService, settings)
             attemptCloseStep.preExecute(logger, context).execute()
             val updatedManagedIndexMetaData = attemptCloseStep.getUpdatedManagedIndexMetadata(managedIndexMetaData)
             assertEquals("Step status is not FAILED", Step.StepStatus.FAILED, updatedManagedIndexMetaData.stepMetaData?.stepStatus)

--- a/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/AttemptDeleteStepTests.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/AttemptDeleteStepTests.kt
@@ -17,16 +17,20 @@ import org.opensearch.client.AdminClient
 import org.opensearch.client.Client
 import org.opensearch.client.IndicesAdminClient
 import org.opensearch.cluster.service.ClusterService
+import org.opensearch.common.settings.Settings
 import org.opensearch.indexmanagement.indexstatemanagement.step.delete.AttemptDeleteStep
 import org.opensearch.indexmanagement.spi.indexstatemanagement.Step
 import org.opensearch.indexmanagement.spi.indexstatemanagement.model.ManagedIndexMetaData
 import org.opensearch.indexmanagement.spi.indexstatemanagement.model.StepContext
+import org.opensearch.script.ScriptService
 import org.opensearch.snapshots.SnapshotInProgressException
 import org.opensearch.test.OpenSearchTestCase
 
 class AttemptDeleteStepTests : OpenSearchTestCase() {
 
     private val clusterService: ClusterService = mock()
+    private val scriptService: ScriptService = mock()
+    private val settings: Settings = Settings.EMPTY
 
     fun `test delete step sets step status to completed when successful`() {
         val acknowledgedResponse = AcknowledgedResponse(true)
@@ -35,7 +39,7 @@ class AttemptDeleteStepTests : OpenSearchTestCase() {
         runBlocking {
             val managedIndexMetaData = ManagedIndexMetaData("test", "indexUuid", "policy_id", null, null, null, null, null, null, null, null, null, null)
             val attemptDeleteStep = AttemptDeleteStep()
-            val context = StepContext(managedIndexMetaData, clusterService, client, null, null)
+            val context = StepContext(managedIndexMetaData, clusterService, client, null, null, scriptService, settings)
             attemptDeleteStep.preExecute(logger, context).execute()
             val updatedManagedIndexMetaData = attemptDeleteStep.getUpdatedManagedIndexMetadata(managedIndexMetaData)
             assertEquals("Step status is not COMPLETED", Step.StepStatus.COMPLETED, updatedManagedIndexMetaData.stepMetaData?.stepStatus)
@@ -49,7 +53,7 @@ class AttemptDeleteStepTests : OpenSearchTestCase() {
         runBlocking {
             val managedIndexMetaData = ManagedIndexMetaData("test", "indexUuid", "policy_id", null, null, null, null, null, null, null, null, null, null)
             val attemptDeleteStep = AttemptDeleteStep()
-            val context = StepContext(managedIndexMetaData, clusterService, client, null, null)
+            val context = StepContext(managedIndexMetaData, clusterService, client, null, null, scriptService, settings)
             attemptDeleteStep.preExecute(logger, context).execute()
             val updatedManagedIndexMetaData = attemptDeleteStep.getUpdatedManagedIndexMetadata(managedIndexMetaData)
             assertEquals("Step status is not FAILED", Step.StepStatus.FAILED, updatedManagedIndexMetaData.stepMetaData?.stepStatus)
@@ -63,7 +67,7 @@ class AttemptDeleteStepTests : OpenSearchTestCase() {
         runBlocking {
             val managedIndexMetaData = ManagedIndexMetaData("test", "indexUuid", "policy_id", null, null, null, null, null, null, null, null, null, null)
             val attemptDeleteStep = AttemptDeleteStep()
-            val context = StepContext(managedIndexMetaData, clusterService, client, null, null)
+            val context = StepContext(managedIndexMetaData, clusterService, client, null, null, scriptService, settings)
             attemptDeleteStep.preExecute(logger, context).execute()
             val updatedManagedIndexMetaData = attemptDeleteStep.getUpdatedManagedIndexMetadata(managedIndexMetaData)
             logger.info(updatedManagedIndexMetaData)
@@ -78,7 +82,7 @@ class AttemptDeleteStepTests : OpenSearchTestCase() {
         runBlocking {
             val managedIndexMetaData = ManagedIndexMetaData("test", "indexUuid", "policy_id", null, null, null, null, null, null, null, null, null, null)
             val attemptDeleteStep = AttemptDeleteStep()
-            val context = StepContext(managedIndexMetaData, clusterService, client, null, null)
+            val context = StepContext(managedIndexMetaData, clusterService, client, null, null, scriptService, settings)
             attemptDeleteStep.preExecute(logger, context).execute()
             val updatedManagedIndexMetaData = attemptDeleteStep.getUpdatedManagedIndexMetadata(managedIndexMetaData)
             assertEquals("Step status is not CONDITION_NOT_MET", Step.StepStatus.CONDITION_NOT_MET, updatedManagedIndexMetaData.stepMetaData?.stepStatus)

--- a/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/AttemptOpenStepTests.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/AttemptOpenStepTests.kt
@@ -17,16 +17,20 @@ import org.opensearch.client.AdminClient
 import org.opensearch.client.Client
 import org.opensearch.client.IndicesAdminClient
 import org.opensearch.cluster.service.ClusterService
+import org.opensearch.common.settings.Settings
 import org.opensearch.indexmanagement.indexstatemanagement.step.open.AttemptOpenStep
 import org.opensearch.indexmanagement.spi.indexstatemanagement.Step
 import org.opensearch.indexmanagement.spi.indexstatemanagement.model.ManagedIndexMetaData
 import org.opensearch.indexmanagement.spi.indexstatemanagement.model.StepContext
+import org.opensearch.script.ScriptService
 import org.opensearch.test.OpenSearchTestCase
 import org.opensearch.transport.RemoteTransportException
 
 class AttemptOpenStepTests : OpenSearchTestCase() {
 
     private val clusterService: ClusterService = mock()
+    private val scriptService: ScriptService = mock()
+    private val settings: Settings = Settings.EMPTY
 
     fun `test open step sets step status to failed when not acknowledged`() {
         val openIndexResponse = OpenIndexResponse(false, false)
@@ -35,7 +39,7 @@ class AttemptOpenStepTests : OpenSearchTestCase() {
         runBlocking {
             val managedIndexMetaData = ManagedIndexMetaData("test", "indexUuid", "policy_id", null, null, null, null, null, null, null, null, null, null)
             val attemptOpenStep = AttemptOpenStep()
-            val context = StepContext(managedIndexMetaData, clusterService, client, null, null)
+            val context = StepContext(managedIndexMetaData, clusterService, client, null, null, scriptService, settings)
             attemptOpenStep.preExecute(logger, context).execute()
             val updatedManagedIndexMetaData = attemptOpenStep.getUpdatedManagedIndexMetadata(managedIndexMetaData)
             assertEquals("Step status is not FAILED", Step.StepStatus.FAILED, updatedManagedIndexMetaData.stepMetaData?.stepStatus)
@@ -49,7 +53,7 @@ class AttemptOpenStepTests : OpenSearchTestCase() {
         runBlocking {
             val managedIndexMetaData = ManagedIndexMetaData("test", "indexUuid", "policy_id", null, null, null, null, null, null, null, null, null, null)
             val attemptOpenStep = AttemptOpenStep()
-            val context = StepContext(managedIndexMetaData, clusterService, client, null, null)
+            val context = StepContext(managedIndexMetaData, clusterService, client, null, null, scriptService, settings)
             attemptOpenStep.preExecute(logger, context).execute()
             val updatedManagedIndexMetaData = attemptOpenStep.getUpdatedManagedIndexMetadata(managedIndexMetaData)
             assertEquals("Step status is not FAILED", Step.StepStatus.FAILED, updatedManagedIndexMetaData.stepMetaData?.stepStatus)
@@ -63,7 +67,7 @@ class AttemptOpenStepTests : OpenSearchTestCase() {
         runBlocking {
             val managedIndexMetaData = ManagedIndexMetaData("test", "indexUuid", "policy_id", null, null, null, null, null, null, null, null, null, null)
             val attemptOpenStep = AttemptOpenStep()
-            val context = StepContext(managedIndexMetaData, clusterService, client, null, null)
+            val context = StepContext(managedIndexMetaData, clusterService, client, null, null, scriptService, settings)
             attemptOpenStep.preExecute(logger, context).execute()
             val updatedManagedIndexMetaData = attemptOpenStep.getUpdatedManagedIndexMetadata(managedIndexMetaData)
             assertEquals("Step status is not FAILED", Step.StepStatus.FAILED, updatedManagedIndexMetaData.stepMetaData?.stepStatus)

--- a/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/AttemptSetReplicaCountStepTests.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/AttemptSetReplicaCountStepTests.kt
@@ -17,17 +17,21 @@ import org.opensearch.client.AdminClient
 import org.opensearch.client.Client
 import org.opensearch.client.IndicesAdminClient
 import org.opensearch.cluster.service.ClusterService
+import org.opensearch.common.settings.Settings
 import org.opensearch.indexmanagement.indexstatemanagement.action.ReplicaCountAction
 import org.opensearch.indexmanagement.indexstatemanagement.step.replicacount.AttemptReplicaCountStep
 import org.opensearch.indexmanagement.spi.indexstatemanagement.Step
 import org.opensearch.indexmanagement.spi.indexstatemanagement.model.ManagedIndexMetaData
 import org.opensearch.indexmanagement.spi.indexstatemanagement.model.StepContext
+import org.opensearch.script.ScriptService
 import org.opensearch.test.OpenSearchTestCase
 import org.opensearch.transport.RemoteTransportException
 
 class AttemptSetReplicaCountStepTests : OpenSearchTestCase() {
 
     private val clusterService: ClusterService = mock()
+    private val scriptService: ScriptService = mock()
+    private val settings: Settings = Settings.EMPTY
 
     fun `test replica step sets step status to failed when not acknowledged`() {
         val replicaCountResponse = AcknowledgedResponse(false)
@@ -37,7 +41,7 @@ class AttemptSetReplicaCountStepTests : OpenSearchTestCase() {
             val replicaCountAction = ReplicaCountAction(2, 0)
             val managedIndexMetaData = ManagedIndexMetaData("test", "indexUuid", "policy_id", null, null, null, null, null, null, null, null, null, null)
             val replicaCountStep = AttemptReplicaCountStep(replicaCountAction)
-            val context = StepContext(managedIndexMetaData, clusterService, client, null, null)
+            val context = StepContext(managedIndexMetaData, clusterService, client, null, null, scriptService, settings)
             replicaCountStep.preExecute(logger, context).execute()
             val updatedManagedIndexMetaData = replicaCountStep.getUpdatedManagedIndexMetadata(managedIndexMetaData)
             assertEquals("Step status is not FAILED", Step.StepStatus.FAILED, updatedManagedIndexMetaData.stepMetaData?.stepStatus)
@@ -52,7 +56,7 @@ class AttemptSetReplicaCountStepTests : OpenSearchTestCase() {
             val replicaCountAction = ReplicaCountAction(2, 0)
             val managedIndexMetaData = ManagedIndexMetaData("test", "indexUuid", "policy_id", null, null, null, null, null, null, null, null, null, null)
             val replicaCountStep = AttemptReplicaCountStep(replicaCountAction)
-            val context = StepContext(managedIndexMetaData, clusterService, client, null, null)
+            val context = StepContext(managedIndexMetaData, clusterService, client, null, null, scriptService, settings)
             replicaCountStep.preExecute(logger, context).execute()
             val updatedManagedIndexMetaData = replicaCountStep.getUpdatedManagedIndexMetadata(managedIndexMetaData)
             assertEquals("Step status is not FAILED", Step.StepStatus.FAILED, updatedManagedIndexMetaData.stepMetaData?.stepStatus)
@@ -67,7 +71,7 @@ class AttemptSetReplicaCountStepTests : OpenSearchTestCase() {
             val replicaCountAction = ReplicaCountAction(2, 0)
             val managedIndexMetaData = ManagedIndexMetaData("test", "indexUuid", "policy_id", null, null, null, null, null, null, null, null, null, null)
             val replicaCountStep = AttemptReplicaCountStep(replicaCountAction)
-            val context = StepContext(managedIndexMetaData, clusterService, client, null, null)
+            val context = StepContext(managedIndexMetaData, clusterService, client, null, null, scriptService, settings)
             replicaCountStep.preExecute(logger, context).execute()
             val updatedManagedIndexMetaData = replicaCountStep.getUpdatedManagedIndexMetadata(managedIndexMetaData)
             assertEquals("Step status is not FAILED", Step.StepStatus.FAILED, updatedManagedIndexMetaData.stepMetaData?.stepStatus)

--- a/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/AttemptTransitionStepTests.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/AttemptTransitionStepTests.kt
@@ -23,6 +23,7 @@ import org.opensearch.cluster.metadata.IndexMetadata
 import org.opensearch.cluster.metadata.Metadata
 import org.opensearch.cluster.service.ClusterService
 import org.opensearch.common.collect.ImmutableOpenMap
+import org.opensearch.common.settings.Settings
 import org.opensearch.index.shard.DocsStats
 import org.opensearch.indexmanagement.indexstatemanagement.action.TransitionsAction
 import org.opensearch.indexmanagement.indexstatemanagement.model.Conditions
@@ -33,6 +34,7 @@ import org.opensearch.indexmanagement.spi.indexstatemanagement.model.ManagedInde
 import org.opensearch.indexmanagement.spi.indexstatemanagement.model.StepContext
 import org.opensearch.indexmanagement.spi.indexstatemanagement.model.StepMetaData
 import org.opensearch.rest.RestStatus
+import org.opensearch.script.ScriptService
 import org.opensearch.test.OpenSearchTestCase
 import org.opensearch.transport.RemoteTransportException
 import java.time.Instant
@@ -46,6 +48,8 @@ class AttemptTransitionStepTests : OpenSearchTestCase() {
     private val metadata: Metadata = mock { on { index(any<String>()) } doReturn indexMetadata }
     private val clusterState: ClusterState = mock { on { metadata() } doReturn metadata }
     private val clusterService: ClusterService = mock { on { state() } doReturn clusterState }
+    private val scriptService: ScriptService = mock()
+    private val settings: Settings = Settings.EMPTY
 
     private val docsStats: DocsStats = mock()
     private val primaries: CommonStats = mock { on { getDocs() } doReturn docsStats }
@@ -63,7 +67,7 @@ class AttemptTransitionStepTests : OpenSearchTestCase() {
             val managedIndexMetadata = ManagedIndexMetaData("test", "indexUuid", "policy_id", null, null, null, null, null, null, null, null, null, null)
             val transitionsAction = TransitionsAction(listOf(Transition("some_state", Conditions(docCount = 5L))))
             val attemptTransitionStep = AttemptTransitionStep(transitionsAction)
-            val context = StepContext(managedIndexMetadata, clusterService, client, null, null)
+            val context = StepContext(managedIndexMetadata, clusterService, client, null, null, scriptService, settings)
             attemptTransitionStep.preExecute(logger, context).execute()
             val updatedManagedIndexMetaData = attemptTransitionStep.getUpdatedManagedIndexMetadata(managedIndexMetadata)
             assertEquals("Step status is not FAILED", Step.StepStatus.FAILED, updatedManagedIndexMetaData.stepMetaData?.stepStatus)
@@ -80,7 +84,7 @@ class AttemptTransitionStepTests : OpenSearchTestCase() {
             val managedIndexMetadata = ManagedIndexMetaData("test", "indexUuid", "policy_id", null, null, null, null, null, null, null, null, null, null)
             val transitionsAction = TransitionsAction(listOf(Transition("some_state", Conditions(docCount = 5L))))
             val attemptTransitionStep = AttemptTransitionStep(transitionsAction)
-            val context = StepContext(managedIndexMetadata, clusterService, client, null, null)
+            val context = StepContext(managedIndexMetadata, clusterService, client, null, null, scriptService, settings)
             attemptTransitionStep.preExecute(logger, context).execute()
             val updatedManagedIndexMetaData = attemptTransitionStep.getUpdatedManagedIndexMetadata(managedIndexMetadata)
             assertEquals("Step status is not FAILED", Step.StepStatus.FAILED, updatedManagedIndexMetaData.stepMetaData?.stepStatus)
@@ -97,7 +101,7 @@ class AttemptTransitionStepTests : OpenSearchTestCase() {
             val managedIndexMetadata = ManagedIndexMetaData("test", "indexUuid", "policy_id", null, null, null, null, null, null, null, null, null, null)
             val transitionsAction = TransitionsAction(listOf(Transition("some_state", Conditions(docCount = 5L))))
             val attemptTransitionStep = AttemptTransitionStep(transitionsAction)
-            val context = StepContext(managedIndexMetadata, clusterService, client, null, null)
+            val context = StepContext(managedIndexMetadata, clusterService, client, null, null, scriptService, settings)
             attemptTransitionStep.preExecute(logger, context).execute()
             val updatedManagedIndexMetaData = attemptTransitionStep.getUpdatedManagedIndexMetadata(managedIndexMetadata)
             assertEquals("Step status is not FAILED", Step.StepStatus.FAILED, updatedManagedIndexMetaData.stepMetaData?.stepStatus)

--- a/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/SetReadOnlyStepTests.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/SetReadOnlyStepTests.kt
@@ -17,16 +17,20 @@ import org.opensearch.client.AdminClient
 import org.opensearch.client.Client
 import org.opensearch.client.IndicesAdminClient
 import org.opensearch.cluster.service.ClusterService
+import org.opensearch.common.settings.Settings
 import org.opensearch.indexmanagement.indexstatemanagement.step.readonly.SetReadOnlyStep
 import org.opensearch.indexmanagement.spi.indexstatemanagement.Step
 import org.opensearch.indexmanagement.spi.indexstatemanagement.model.ManagedIndexMetaData
 import org.opensearch.indexmanagement.spi.indexstatemanagement.model.StepContext
+import org.opensearch.script.ScriptService
 import org.opensearch.test.OpenSearchTestCase
 import org.opensearch.transport.RemoteTransportException
 
 class SetReadOnlyStepTests : OpenSearchTestCase() {
 
     private val clusterService: ClusterService = mock()
+    private val scriptService: ScriptService = mock()
+    private val settings: Settings = Settings.EMPTY
 
     fun `test read only step sets step status to failed when not acknowledged`() {
         val setReadOnlyResponse = AcknowledgedResponse(false)
@@ -35,7 +39,7 @@ class SetReadOnlyStepTests : OpenSearchTestCase() {
         runBlocking {
             val managedIndexMetaData = ManagedIndexMetaData("test", "indexUuid", "policy_id", null, null, null, null, null, null, null, null, null, null)
             val setReadOnlyStep = SetReadOnlyStep()
-            val context = StepContext(managedIndexMetaData, clusterService, client, null, null)
+            val context = StepContext(managedIndexMetaData, clusterService, client, null, null, scriptService, settings)
             setReadOnlyStep.preExecute(logger, context).execute()
             val updatedManagedIndexMetaData = setReadOnlyStep.getUpdatedManagedIndexMetadata(managedIndexMetaData)
             assertEquals("Step status is not FAILED", Step.StepStatus.FAILED, updatedManagedIndexMetaData.stepMetaData?.stepStatus)
@@ -49,7 +53,7 @@ class SetReadOnlyStepTests : OpenSearchTestCase() {
         runBlocking {
             val managedIndexMetaData = ManagedIndexMetaData("test", "indexUuid", "policy_id", null, null, null, null, null, null, null, null, null, null)
             val setReadOnlyStep = SetReadOnlyStep()
-            val context = StepContext(managedIndexMetaData, clusterService, client, null, null)
+            val context = StepContext(managedIndexMetaData, clusterService, client, null, null, scriptService, settings)
             setReadOnlyStep.preExecute(logger, context).execute()
             val updatedManagedIndexMetaData = setReadOnlyStep.getUpdatedManagedIndexMetadata(managedIndexMetaData)
             assertEquals("Step status is not FAILED", Step.StepStatus.FAILED, updatedManagedIndexMetaData.stepMetaData?.stepStatus)
@@ -63,7 +67,7 @@ class SetReadOnlyStepTests : OpenSearchTestCase() {
         runBlocking {
             val managedIndexMetaData = ManagedIndexMetaData("test", "indexUuid", "policy_id", null, null, null, null, null, null, null, null, null, null)
             val setReadOnlyStep = SetReadOnlyStep()
-            val context = StepContext(managedIndexMetaData, clusterService, client, null, null)
+            val context = StepContext(managedIndexMetaData, clusterService, client, null, null, scriptService, settings)
             setReadOnlyStep.preExecute(logger, context).execute()
             val updatedManagedIndexMetaData = setReadOnlyStep.getUpdatedManagedIndexMetadata(managedIndexMetaData)
             assertEquals("Step status is not FAILED", Step.StepStatus.FAILED, updatedManagedIndexMetaData.stepMetaData?.stepStatus)

--- a/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/SetReadWriteStepTests.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/SetReadWriteStepTests.kt
@@ -17,16 +17,20 @@ import org.opensearch.client.AdminClient
 import org.opensearch.client.Client
 import org.opensearch.client.IndicesAdminClient
 import org.opensearch.cluster.service.ClusterService
+import org.opensearch.common.settings.Settings
 import org.opensearch.indexmanagement.indexstatemanagement.step.readwrite.SetReadWriteStep
 import org.opensearch.indexmanagement.spi.indexstatemanagement.Step
 import org.opensearch.indexmanagement.spi.indexstatemanagement.model.ManagedIndexMetaData
 import org.opensearch.indexmanagement.spi.indexstatemanagement.model.StepContext
+import org.opensearch.script.ScriptService
 import org.opensearch.test.OpenSearchTestCase
 import org.opensearch.transport.RemoteTransportException
 
 class SetReadWriteStepTests : OpenSearchTestCase() {
 
     private val clusterService: ClusterService = mock()
+    private val scriptService: ScriptService = mock()
+    private val settings: Settings = Settings.EMPTY
 
     fun `test read write step sets step status to failed when not acknowledged`() {
         val setReadWriteResponse = AcknowledgedResponse(false)
@@ -35,7 +39,7 @@ class SetReadWriteStepTests : OpenSearchTestCase() {
         runBlocking {
             val managedIndexMetaData = ManagedIndexMetaData("test", "indexUuid", "policy_id", null, null, null, null, null, null, null, null, null, null)
             val setReadWriteStep = SetReadWriteStep()
-            val context = StepContext(managedIndexMetaData, clusterService, client, null, null)
+            val context = StepContext(managedIndexMetaData, clusterService, client, null, null, scriptService, settings)
             setReadWriteStep.preExecute(logger, context).execute()
             val updatedManagedIndexMetaData = setReadWriteStep.getUpdatedManagedIndexMetadata(managedIndexMetaData)
             assertEquals("Step status is not FAILED", Step.StepStatus.FAILED, updatedManagedIndexMetaData.stepMetaData?.stepStatus)
@@ -49,7 +53,7 @@ class SetReadWriteStepTests : OpenSearchTestCase() {
         runBlocking {
             val managedIndexMetaData = ManagedIndexMetaData("test", "indexUuid", "policy_id", null, null, null, null, null, null, null, null, null, null)
             val setReadWriteStep = SetReadWriteStep()
-            val context = StepContext(managedIndexMetaData, clusterService, client, null, null)
+            val context = StepContext(managedIndexMetaData, clusterService, client, null, null, scriptService, settings)
             setReadWriteStep.preExecute(logger, context).execute()
             val updatedManagedIndexMetaData = setReadWriteStep.getUpdatedManagedIndexMetadata(managedIndexMetaData)
             assertEquals("Step status is not FAILED", Step.StepStatus.FAILED, updatedManagedIndexMetaData.stepMetaData?.stepStatus)
@@ -63,7 +67,7 @@ class SetReadWriteStepTests : OpenSearchTestCase() {
         runBlocking {
             val managedIndexMetaData = ManagedIndexMetaData("test", "indexUuid", "policy_id", null, null, null, null, null, null, null, null, null, null)
             val setReadWriteStep = SetReadWriteStep()
-            val context = StepContext(managedIndexMetaData, clusterService, client, null, null)
+            val context = StepContext(managedIndexMetaData, clusterService, client, null, null, scriptService, settings)
             setReadWriteStep.preExecute(logger, context).execute()
             val updatedManagedIndexMetaData = setReadWriteStep.getUpdatedManagedIndexMetadata(managedIndexMetaData)
             assertEquals("Step status is not FAILED", Step.StepStatus.FAILED, updatedManagedIndexMetaData.stepMetaData?.stepStatus)

--- a/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/WaitForRollupCompletionStepTests.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/WaitForRollupCompletionStepTests.kt
@@ -9,6 +9,7 @@ import com.nhaarman.mockitokotlin2.mock
 import kotlinx.coroutines.runBlocking
 import org.opensearch.client.Client
 import org.opensearch.cluster.service.ClusterService
+import org.opensearch.common.settings.Settings
 import org.opensearch.indexmanagement.indexstatemanagement.step.rollup.WaitForRollupCompletionStep
 import org.opensearch.indexmanagement.rollup.model.RollupMetadata
 import org.opensearch.indexmanagement.rollup.model.RollupStats
@@ -17,12 +18,15 @@ import org.opensearch.indexmanagement.spi.indexstatemanagement.model.ActionMetaD
 import org.opensearch.indexmanagement.spi.indexstatemanagement.model.ActionProperties
 import org.opensearch.indexmanagement.spi.indexstatemanagement.model.ManagedIndexMetaData
 import org.opensearch.indexmanagement.spi.indexstatemanagement.model.StepContext
+import org.opensearch.script.ScriptService
 import org.opensearch.test.OpenSearchTestCase
 import java.time.Instant
 
 class WaitForRollupCompletionStepTests : OpenSearchTestCase() {
 
     private val clusterService: ClusterService = mock()
+    private val scriptService: ScriptService = mock()
+    private val settings: Settings = Settings.EMPTY
     private val rollupId: String = "dummy-id"
     private val indexName: String = "test"
     private val metadata = ManagedIndexMetaData(
@@ -41,7 +45,7 @@ class WaitForRollupCompletionStepTests : OpenSearchTestCase() {
     fun `test wait for rollup when missing rollup id`() {
         val actionMetadata = metadata.actionMetaData!!.copy(actionProperties = ActionProperties())
         val metadata = metadata.copy(actionMetaData = actionMetadata)
-        val context = StepContext(metadata, clusterService, client, null, null)
+        val context = StepContext(metadata, clusterService, client, null, null, scriptService, settings)
         val step = WaitForRollupCompletionStep()
 
         runBlocking {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Refactors Notification action with new interface. To support the settings dynamically used in the notification action, as well as the script service used in the notification and transition actions, the settings and script service fields were added to the step context.

*CheckList:*
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/index-management/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
