### PR TITLE
Makes rest APIs use new metadata service

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -306,9 +306,6 @@ integTest {
     if (System.getProperty("tests.clustername") != null) {
         exclude 'org/opensearch/indexmanagement/indexstatemanagement/MetadataRegressionIT.class'
     }
-
-    // TODO: Remove me after refactoring all actions
-    exclude 'org/opensearch/indexmanagement/indexstatemanagement/resthandler/*'
 }
 
 String bwcVersion = "1.13.2.0"

--- a/spi/src/main/kotlin/org.opensearch.indexmanagement.spi/indexstatemanagement/IndexMetadataService.kt
+++ b/spi/src/main/kotlin/org.opensearch.indexmanagement.spi/indexstatemanagement/IndexMetadataService.kt
@@ -31,4 +31,9 @@ interface IndexMetadataService {
      * Returns all the indices metadata
      */
     suspend fun getMetadataForAllIndices(client: Client, clusterService: ClusterService): Map<String, ISMIndexMetadata>
+
+    /**
+     * Returns an optional setting path which, when set to true in the index settings, overrides a cluster level metadata write block.
+     */
+    fun getIndexMetadataWriteOverrideSetting(): String? = null
 }

--- a/spi/src/main/kotlin/org.opensearch.indexmanagement.spi/indexstatemanagement/model/ISMIndexMetadata.kt
+++ b/spi/src/main/kotlin/org.opensearch.indexmanagement.spi/indexstatemanagement/model/ISMIndexMetadata.kt
@@ -5,7 +5,6 @@
 
 package org.opensearch.indexmanagement.spi.indexstatemanagement.model
 
-// TODO need to have more information here
 data class ISMIndexMetadata(
     val indexUuid: String,
     val indexCreationDate: Long,

--- a/spi/src/main/kotlin/org.opensearch.indexmanagement.spi/indexstatemanagement/model/ManagedIndexMetaData.kt
+++ b/spi/src/main/kotlin/org.opensearch.indexmanagement.spi/indexstatemanagement/model/ManagedIndexMetaData.kt
@@ -9,7 +9,6 @@ import org.opensearch.common.Strings
 import org.opensearch.common.io.stream.StreamInput
 import org.opensearch.common.io.stream.StreamOutput
 import org.opensearch.common.io.stream.Writeable
-import org.opensearch.common.util.concurrent.ThreadContext
 import org.opensearch.common.xcontent.ToXContent
 import org.opensearch.common.xcontent.ToXContentFragment
 import org.opensearch.common.xcontent.XContentBuilder
@@ -18,7 +17,6 @@ import org.opensearch.common.xcontent.XContentHelper
 import org.opensearch.common.xcontent.XContentParser
 import org.opensearch.common.xcontent.XContentParserUtils
 import org.opensearch.common.xcontent.json.JsonXContent
-import org.opensearch.commons.authuser.User
 import org.opensearch.index.seqno.SequenceNumbers
 import org.opensearch.indexmanagement.spi.indexstatemanagement.addObject
 import java.io.IOException
@@ -40,13 +38,7 @@ data class ManagedIndexMetaData(
     val info: Map<String, Any>?,
     val id: String = NO_ID,
     val seqNo: Long = SequenceNumbers.UNASSIGNED_SEQ_NO,
-    val primaryTerm: Long = SequenceNumbers.UNASSIGNED_PRIMARY_TERM,
-    // TODO: Remove this once the step interface is updated to pass in user information.
-    //  The user information is not being stored/written anywhere, this is only intended to be used during the step execution.
-    val user: User? = null,
-    // TODO: Remove this once the step interface is updated to pass in thread context information.
-    //  This information is not being stored/written anywhere, this is only intended to be used during the step execution.
-    val threadContext: ThreadContext? = null
+    val primaryTerm: Long = SequenceNumbers.UNASSIGNED_PRIMARY_TERM
 ) : Writeable, ToXContentFragment {
 
     @Suppress("ComplexMethod")

--- a/spi/src/main/kotlin/org.opensearch.indexmanagement.spi/indexstatemanagement/model/StepContext.kt
+++ b/spi/src/main/kotlin/org.opensearch.indexmanagement.spi/indexstatemanagement/model/StepContext.kt
@@ -12,7 +12,6 @@ import org.opensearch.common.util.concurrent.ThreadContext
 import org.opensearch.commons.authuser.User
 import org.opensearch.script.ScriptService
 
-// TODO: Add more attributes here if needed
 class StepContext(
     val metadata: ManagedIndexMetaData,
     val clusterService: ClusterService,

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/ManagedIndexRunner.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/ManagedIndexRunner.kt
@@ -304,11 +304,8 @@ object ManagedIndexRunner :
         }
 
         val state = policy.getStateToExecute(managedIndexMetaData)
-        val action: Action? = state?.getActionToExecute(
-            managedIndexMetaData.copy(user = policy.user, threadContext = threadPool.threadContext),
-            indexMetadataProvider
-        )
-        val stepContext = StepContext(managedIndexMetaData, clusterService, client, null, null, scriptService, settings)
+        val action: Action? = state?.getActionToExecute(managedIndexMetaData, indexMetadataProvider)
+        val stepContext = StepContext(managedIndexMetaData, clusterService, client, threadPool.threadContext, policy.user, scriptService, settings)
         val step: Step? = action?.getStepToExecute(stepContext)
         val currentActionMetaData = action?.getUpdatedActionMetadata(managedIndexMetaData, state.name)
 

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/MetadataService.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/MetadataService.kt
@@ -51,8 +51,8 @@ class MetadataService(
 
     @Volatile private var runningLock = false // in case 2 moveMetadata() process running
 
-    private val successfullyIndexedIndices = mutableSetOf<metadataDocID>()
-    private var failedToIndexIndices = mutableMapOf<metadataDocID, BulkItemResponse.Failure>()
+    private val successfullyIndexedIndices = mutableSetOf<MetadataDocID>()
+    private var failedToIndexIndices = mutableMapOf<MetadataDocID, BulkItemResponse.Failure>()
     private var failedToCleanIndices = mutableSetOf<Index>()
 
     private var counter = 0
@@ -98,7 +98,23 @@ class MetadataService(
             // filter out previous failedToClean indices which already been indexed
             clusterStateManagedIndexMetadata =
                 clusterStateManagedIndexMetadata.filter { it.key !in failedToCleanIndices.map { index -> index.name } }
-            val indexUuidMap = clusterStateManagedIndexMetadata.map { indicesMetadata[it.key].indexUUID to it.key }.toMap()
+
+            // filter out cluster state metadata with outdated index uuid
+            val corruptManagedIndices = mutableListOf<Index>()
+            val indexUuidMap = mutableMapOf<IndexUuid, IndexName>()
+            clusterStateManagedIndexMetadata.forEach { (indexName, metadata) ->
+                val indexMetadata = indicesMetadata[indexName]
+                val currentIndexUuid = indexMetadata.indexUUID
+                if (currentIndexUuid != metadata?.indexUuid) {
+                    corruptManagedIndices.add(indexMetadata.index)
+                } else {
+                    indexUuidMap[currentIndexUuid] = indexName
+                }
+            }
+            logger.info("Corrupt managed indices with outdated index uuid in metadata: $corruptManagedIndices")
+            clusterStateManagedIndexMetadata = clusterStateManagedIndexMetadata.filter { (indexName, _) ->
+                indexName !in corruptManagedIndices.map { it.name }
+            }
 
             if (clusterStateManagedIndexMetadata.isEmpty()) {
                 if (failedToCleanIndices.isNotEmpty()) {
@@ -107,7 +123,7 @@ class MetadataService(
                     finishFlag = false; runningLock = false
                     return
                 }
-                if (counter++ > 2) {
+                if (counter++ > 2 && corruptManagedIndices.isEmpty()) {
                     logger.info("Move Metadata succeed, set finish flag to true. Indices failed to get indexed: $failedToIndexIndices")
                     updateStatusSetting(1)
                     finishFlag = true; runningLock = false
@@ -138,7 +154,7 @@ class MetadataService(
             // clean metadata for indices which metadata already been indexed
             val indicesToCleanMetadata =
                 indexUuidMap.filter { it.key in successfullyIndexedIndices }.map { Index(it.value, it.key) }
-                    .toList() + failedToCleanIndices
+                    .toList() + failedToCleanIndices + corruptManagedIndices
 
             cleanMetadatas(indicesToCleanMetadata)
             if (failedToCleanIndices.isNotEmpty()) {
@@ -239,4 +255,6 @@ class MetadataService(
     }
 }
 
-typealias metadataDocID = String
+typealias MetadataDocID = String
+typealias IndexUuid = String
+typealias IndexName = String

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/resthandler/RestAddPolicyAction.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/resthandler/RestAddPolicyAction.kt
@@ -12,6 +12,8 @@ import org.opensearch.indexmanagement.IndexManagementPlugin.Companion.ISM_BASE_U
 import org.opensearch.indexmanagement.IndexManagementPlugin.Companion.LEGACY_ISM_BASE_URI
 import org.opensearch.indexmanagement.indexstatemanagement.transport.action.addpolicy.AddPolicyAction
 import org.opensearch.indexmanagement.indexstatemanagement.transport.action.addpolicy.AddPolicyRequest
+import org.opensearch.indexmanagement.indexstatemanagement.util.DEFAULT_INDEX_TYPE
+import org.opensearch.indexmanagement.indexstatemanagement.util.TYPE_PARAM_KEY
 import org.opensearch.rest.BaseRestHandler
 import org.opensearch.rest.BaseRestHandler.RestChannelConsumer
 import org.opensearch.rest.RestHandler.ReplacedRoute
@@ -57,9 +59,11 @@ class RestAddPolicyAction : BaseRestHandler() {
             mapOf()
         }
 
+        val indexType = request.param(TYPE_PARAM_KEY, DEFAULT_INDEX_TYPE)
+
         val policyID = requireNotNull(body.getOrDefault("policy_id", null)) { "Missing policy_id" }
 
-        val addPolicyRequest = AddPolicyRequest(indices.toList(), policyID as String)
+        val addPolicyRequest = AddPolicyRequest(indices.toList(), policyID as String, indexType)
 
         return RestChannelConsumer { channel ->
             client.execute(AddPolicyAction.INSTANCE, addPolicyRequest, RestToXContentListener(channel))

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/resthandler/RestChangePolicyAction.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/resthandler/RestChangePolicyAction.kt
@@ -14,6 +14,8 @@ import org.opensearch.indexmanagement.IndexManagementPlugin.Companion.LEGACY_ISM
 import org.opensearch.indexmanagement.indexstatemanagement.model.ChangePolicy
 import org.opensearch.indexmanagement.indexstatemanagement.transport.action.changepolicy.ChangePolicyAction
 import org.opensearch.indexmanagement.indexstatemanagement.transport.action.changepolicy.ChangePolicyRequest
+import org.opensearch.indexmanagement.indexstatemanagement.util.DEFAULT_INDEX_TYPE
+import org.opensearch.indexmanagement.indexstatemanagement.util.TYPE_PARAM_KEY
 import org.opensearch.rest.BaseRestHandler
 import org.opensearch.rest.BaseRestHandler.RestChannelConsumer
 import org.opensearch.rest.RestHandler.ReplacedRoute
@@ -51,11 +53,13 @@ class RestChangePolicyAction : BaseRestHandler() {
             throw IllegalArgumentException("Missing index")
         }
 
+        val indexType = request.param(TYPE_PARAM_KEY, DEFAULT_INDEX_TYPE)
+
         val xcp = request.contentParser()
         ensureExpectedToken(Token.START_OBJECT, xcp.nextToken(), xcp)
         val changePolicy = ChangePolicy.parse(xcp)
 
-        val changePolicyRequest = ChangePolicyRequest(indices.toList(), changePolicy)
+        val changePolicyRequest = ChangePolicyRequest(indices.toList(), changePolicy, indexType)
 
         return RestChannelConsumer { channel ->
             client.execute(ChangePolicyAction.INSTANCE, changePolicyRequest, RestToXContentListener(channel))

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/resthandler/RestExplainAction.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/resthandler/RestExplainAction.kt
@@ -14,11 +14,13 @@ import org.opensearch.indexmanagement.IndexManagementPlugin.Companion.LEGACY_ISM
 import org.opensearch.indexmanagement.indexstatemanagement.model.SearchParams
 import org.opensearch.indexmanagement.indexstatemanagement.transport.action.explain.ExplainAction
 import org.opensearch.indexmanagement.indexstatemanagement.transport.action.explain.ExplainRequest
+import org.opensearch.indexmanagement.indexstatemanagement.util.DEFAULT_INDEX_TYPE
 import org.opensearch.indexmanagement.indexstatemanagement.util.DEFAULT_JOB_SORT_FIELD
 import org.opensearch.indexmanagement.indexstatemanagement.util.DEFAULT_PAGINATION_FROM
 import org.opensearch.indexmanagement.indexstatemanagement.util.DEFAULT_PAGINATION_SIZE
 import org.opensearch.indexmanagement.indexstatemanagement.util.DEFAULT_QUERY_STRING
 import org.opensearch.indexmanagement.indexstatemanagement.util.DEFAULT_SORT_ORDER
+import org.opensearch.indexmanagement.indexstatemanagement.util.TYPE_PARAM_KEY
 import org.opensearch.rest.BaseRestHandler
 import org.opensearch.rest.BaseRestHandler.RestChannelConsumer
 import org.opensearch.rest.RestHandler.ReplacedRoute
@@ -68,11 +70,14 @@ class RestExplainAction : BaseRestHandler() {
         val sortOrder = request.param("sortOrder", DEFAULT_SORT_ORDER)
         val queryString = request.param("queryString", DEFAULT_QUERY_STRING)
 
+        val indexType = request.param(TYPE_PARAM_KEY, DEFAULT_INDEX_TYPE)
+
         val explainRequest = ExplainRequest(
             indices.toList(),
             request.paramAsBoolean("local", false),
             request.paramAsTime("master_timeout", MasterNodeRequest.DEFAULT_MASTER_NODE_TIMEOUT),
-            SearchParams(size, from, sortField, sortOrder, queryString)
+            SearchParams(size, from, sortField, sortOrder, queryString),
+            indexType
         )
 
         return RestChannelConsumer { channel ->

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/resthandler/RestRemovePolicyAction.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/resthandler/RestRemovePolicyAction.kt
@@ -11,6 +11,8 @@ import org.opensearch.indexmanagement.IndexManagementPlugin.Companion.ISM_BASE_U
 import org.opensearch.indexmanagement.IndexManagementPlugin.Companion.LEGACY_ISM_BASE_URI
 import org.opensearch.indexmanagement.indexstatemanagement.transport.action.removepolicy.RemovePolicyAction
 import org.opensearch.indexmanagement.indexstatemanagement.transport.action.removepolicy.RemovePolicyRequest
+import org.opensearch.indexmanagement.indexstatemanagement.util.DEFAULT_INDEX_TYPE
+import org.opensearch.indexmanagement.indexstatemanagement.util.TYPE_PARAM_KEY
 import org.opensearch.rest.BaseRestHandler
 import org.opensearch.rest.RestHandler.ReplacedRoute
 import org.opensearch.rest.RestHandler.Route
@@ -49,7 +51,9 @@ class RestRemovePolicyAction : BaseRestHandler() {
             throw IllegalArgumentException("Missing indices")
         }
 
-        val removePolicyRequest = RemovePolicyRequest(indices.toList())
+        val indexType = request.param(TYPE_PARAM_KEY, DEFAULT_INDEX_TYPE)
+
+        val removePolicyRequest = RemovePolicyRequest(indices.toList(), indexType)
 
         return RestChannelConsumer { channel ->
             client.execute(RemovePolicyAction.INSTANCE, removePolicyRequest, RestToXContentListener(channel))

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/resthandler/RestRetryFailedManagedIndexAction.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/resthandler/RestRetryFailedManagedIndexAction.kt
@@ -13,6 +13,8 @@ import org.opensearch.indexmanagement.IndexManagementPlugin.Companion.ISM_BASE_U
 import org.opensearch.indexmanagement.IndexManagementPlugin.Companion.LEGACY_ISM_BASE_URI
 import org.opensearch.indexmanagement.indexstatemanagement.transport.action.retryfailedmanagedindex.RetryFailedManagedIndexAction
 import org.opensearch.indexmanagement.indexstatemanagement.transport.action.retryfailedmanagedindex.RetryFailedManagedIndexRequest
+import org.opensearch.indexmanagement.indexstatemanagement.util.DEFAULT_INDEX_TYPE
+import org.opensearch.indexmanagement.indexstatemanagement.util.TYPE_PARAM_KEY
 import org.opensearch.rest.BaseRestHandler
 import org.opensearch.rest.BaseRestHandler.RestChannelConsumer
 import org.opensearch.rest.RestHandler.ReplacedRoute
@@ -56,9 +58,12 @@ class RestRetryFailedManagedIndexAction : BaseRestHandler() {
             mapOf()
         }
 
+        val indexType = request.param(TYPE_PARAM_KEY, DEFAULT_INDEX_TYPE)
+
         val retryFailedRequest = RetryFailedManagedIndexRequest(
             indices.toList(), body["state"] as String?,
-            request.paramAsTime("master_timeout", DEFAULT_MASTER_NODE_TIMEOUT)
+            request.paramAsTime("master_timeout", DEFAULT_MASTER_NODE_TIMEOUT),
+            indexType
         )
 
         return RestChannelConsumer { channel ->

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/rollup/AttemptCreateRollupJobStep.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/rollup/AttemptCreateRollupJobStep.kt
@@ -39,7 +39,7 @@ class AttemptCreateRollupJobStep(private val action: RollupAction) : Step(name) 
         val hasPreviousRollupAttemptFailed = managedIndexMetadata.actionMetaData?.actionProperties?.hasRollupFailed
 
         // Creating a rollup job
-        val rollup = action.ismRollup.toRollup(indexName, managedIndexMetadata.user)
+        val rollup = action.ismRollup.toRollup(indexName, context.user)
         rollupId = rollup.id
         logger.info("Attempting to create a rollup job $rollupId for index $indexName")
 

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/transport/action/addpolicy/AddPolicyRequest.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/transport/action/addpolicy/AddPolicyRequest.kt
@@ -10,23 +10,31 @@ import org.opensearch.action.ActionRequestValidationException
 import org.opensearch.action.ValidateActions
 import org.opensearch.common.io.stream.StreamInput
 import org.opensearch.common.io.stream.StreamOutput
+import org.opensearch.indexmanagement.indexstatemanagement.util.DEFAULT_INDEX_TYPE
 import java.io.IOException
 
 class AddPolicyRequest(
     val indices: List<String>,
-    val policyID: String
+    val policyID: String,
+    val indexType: String
 ) : ActionRequest() {
 
     @Throws(IOException::class)
     constructor(sin: StreamInput) : this(
         indices = sin.readStringList(),
-        policyID = sin.readString()
+        policyID = sin.readString(),
+        indexType = sin.readString()
     )
 
     override fun validate(): ActionRequestValidationException? {
         var validationException: ActionRequestValidationException? = null
         if (indices.isEmpty()) {
             validationException = ValidateActions.addValidationError("Missing indices", validationException)
+        } else if (indexType != DEFAULT_INDEX_TYPE && indices.size > 1) {
+            validationException = ValidateActions.addValidationError(
+                MULTIPLE_INDICES_CUSTOM_INDEX_TYPE_ERROR,
+                validationException
+            )
         }
         return validationException
     }
@@ -35,5 +43,11 @@ class AddPolicyRequest(
     override fun writeTo(out: StreamOutput) {
         out.writeStringCollection(indices)
         out.writeString(policyID)
+        out.writeString(indexType)
+    }
+
+    companion object {
+        const val MULTIPLE_INDICES_CUSTOM_INDEX_TYPE_ERROR =
+            "Cannot add policy to more than one index name/pattern when using a custom index type"
     }
 }

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/transport/action/addpolicy/TransportAddPolicyAction.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/transport/action/addpolicy/TransportAddPolicyAction.kt
@@ -5,21 +5,9 @@
 
 package org.opensearch.indexmanagement.indexstatemanagement.transport.action.addpolicy
 
-/*
- * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License").
- * You may not use this file except in compliance with the License.
- * A copy of the License is located at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * or in the "license" file accompanying this file. This file is distributed
- * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
- */
-
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
 import org.apache.logging.log4j.LogManager
 import org.opensearch.ExceptionsHelper
 import org.opensearch.OpenSearchSecurityException
@@ -39,9 +27,7 @@ import org.opensearch.action.support.HandledTransportAction
 import org.opensearch.action.support.IndicesOptions
 import org.opensearch.action.support.master.AcknowledgedResponse
 import org.opensearch.client.node.NodeClient
-import org.opensearch.cluster.ClusterState
 import org.opensearch.cluster.block.ClusterBlockException
-import org.opensearch.cluster.metadata.IndexNameExpressionResolver
 import org.opensearch.cluster.service.ClusterService
 import org.opensearch.common.inject.Inject
 import org.opensearch.common.settings.Settings
@@ -49,7 +35,9 @@ import org.opensearch.common.unit.TimeValue
 import org.opensearch.common.xcontent.NamedXContentRegistry
 import org.opensearch.commons.ConfigConstants
 import org.opensearch.commons.authuser.User
+import org.opensearch.index.Index
 import org.opensearch.indexmanagement.IndexManagementPlugin.Companion.INDEX_MANAGEMENT_INDEX
+import org.opensearch.indexmanagement.indexstatemanagement.DefaultIndexMetadataService
 import org.opensearch.indexmanagement.indexstatemanagement.IndexMetadataProvider
 import org.opensearch.indexmanagement.indexstatemanagement.IndexMetadataProvider.Companion.EVALUATION_FAILURE_MESSAGE
 import org.opensearch.indexmanagement.indexstatemanagement.model.Policy
@@ -58,10 +46,13 @@ import org.opensearch.indexmanagement.indexstatemanagement.settings.ManagedIndex
 import org.opensearch.indexmanagement.indexstatemanagement.transport.action.ISMStatusResponse
 import org.opensearch.indexmanagement.indexstatemanagement.transport.action.managedIndex.ManagedIndexAction
 import org.opensearch.indexmanagement.indexstatemanagement.transport.action.managedIndex.ManagedIndexRequest
+import org.opensearch.indexmanagement.indexstatemanagement.util.DEFAULT_INDEX_TYPE
 import org.opensearch.indexmanagement.indexstatemanagement.util.FailedIndex
 import org.opensearch.indexmanagement.indexstatemanagement.util.managedIndexConfigIndexRequest
+import org.opensearch.indexmanagement.indexstatemanagement.util.removeClusterStateMetadatas
 import org.opensearch.indexmanagement.opensearchapi.parseFromGetResponse
 import org.opensearch.indexmanagement.settings.IndexManagementSettings
+import org.opensearch.indexmanagement.spi.indexstatemanagement.model.ISMIndexMetadata
 import org.opensearch.indexmanagement.util.IndexUtils
 import org.opensearch.indexmanagement.util.SecurityUtils.Companion.buildUser
 import org.opensearch.indexmanagement.util.SecurityUtils.Companion.userHasPermissionForResource
@@ -84,7 +75,6 @@ class TransportAddPolicyAction @Inject constructor(
     val settings: Settings,
     val clusterService: ClusterService,
     val xContentRegistry: NamedXContentRegistry,
-    val indexNameExpressionResolver: IndexNameExpressionResolver,
     val indexMetadataProvider: IndexMetadataProvider
 ) : HandledTransportAction<AddPolicyRequest, ISMStatusResponse>(
     AddPolicyAction.NAME, transportService, actionFilters, ::AddPolicyRequest
@@ -110,6 +100,7 @@ class TransportAddPolicyAction @Inject constructor(
         AddPolicyHandler(client, listener, request).start()
     }
 
+    @Suppress("TooManyFunctions")
     inner class AddPolicyHandler(
         private val client: NodeClient,
         private val actionListener: ActionListener<ISMStatusResponse>,
@@ -118,7 +109,7 @@ class TransportAddPolicyAction @Inject constructor(
     ) {
         private lateinit var startTime: Instant
         private lateinit var policy: Policy
-        private val resolvedIndices = mutableListOf<String>()
+        private val permittedIndices = mutableListOf<String>()
         private val indicesToAdd = mutableMapOf<String, String>() // uuid: name
         private val failedIndices: MutableList<FailedIndex> = mutableListOf()
 
@@ -131,41 +122,47 @@ class TransportAddPolicyAction @Inject constructor(
             if (!validateUserConfiguration(user, filterByEnabled, actionListener)) {
                 return
             }
-            val requestedIndices = mutableListOf<String>()
-            request.indices.forEach { index ->
-                requestedIndices.addAll(
-                    indexNameExpressionResolver.concreteIndexNames(
-                        clusterService.state(),
-                        IndicesOptions.lenientExpand(),
-                        true,
-                        index
-                    )
-                )
-            }
-            if (requestedIndices.isEmpty()) {
-                // Nothing to do will ignore since found no matching indices
-                actionListener.onResponse(ISMStatusResponse(0, failedIndices))
-                return
-            }
-            if (user == null) {
-                resolvedIndices.addAll(requestedIndices)
-                getPolicy()
-            } else {
-                validateAndGetPolicy(0, requestedIndices)
+            getClusterState()
+        }
+
+        @Suppress("SpreadOperator")
+        fun getClusterState() {
+            startTime = Instant.now()
+            CoroutineScope(Dispatchers.IO).launch {
+                val indexNameToMetadata: MutableMap<String, ISMIndexMetadata> = HashMap()
+                try {
+                    indexNameToMetadata.putAll(indexMetadataProvider.getISMIndexMetadataByType(request.indexType, request.indices))
+                } catch (e: Exception) {
+                    actionListener.onFailure(ExceptionsHelper.unwrapCause(e) as Exception)
+                    return@launch
+                }
+                indexNameToMetadata.forEach { (indexName, indexMetadata) ->
+                    indicesToAdd.putIfAbsent(indexMetadata.indexUuid, indexName)
+                }
+                if (indicesToAdd.isEmpty()) {
+                    // Nothing to do will ignore since found no matching indices
+                    actionListener.onResponse(ISMStatusResponse(0, failedIndices))
+                    return@launch
+                }
+                if (user != null) {
+                    validateIndexPermissions(0, indicesToAdd.values.toList())
+                } else {
+                    removeClosedIndices()
+                }
             }
         }
 
         /**
          * We filter the requested indices to the indices user has permission to manage and apply policies only on top of those
          */
-        private fun validateAndGetPolicy(current: Int, indices: List<String>) {
+        private fun validateIndexPermissions(current: Int, indices: List<String>) {
             val request = ManagedIndexRequest().indices(indices[current])
             client.execute(
                 ManagedIndexAction.INSTANCE,
                 request,
                 object : ActionListener<AcknowledgedResponse> {
                     override fun onResponse(response: AcknowledgedResponse) {
-                        resolvedIndices.add(indices[current])
+                        permittedIndices.add(indices[current])
                         proceed(current, indices)
                     }
 
@@ -186,13 +183,52 @@ class TransportAddPolicyAction @Inject constructor(
 
         private fun proceed(current: Int, indices: List<String>) {
             if (current < indices.count() - 1) {
-                validateAndGetPolicy(current + 1, indices)
+                validateIndexPermissions(current + 1, indices)
             } else {
                 // sanity check that there are indices - if none then return
-                if (resolvedIndices.isEmpty()) {
+                if (permittedIndices.isEmpty()) {
                     actionListener.onResponse(ISMStatusResponse(0, failedIndices))
                     return
                 }
+                // Filter out the indices that the user does not have permissions for
+                indicesToAdd.values.removeIf { !permittedIndices.contains(it) }
+                removeClosedIndices()
+            }
+        }
+
+        private fun removeClosedIndices() {
+            // Do another cluster state request to fail closed indices
+            if (request.indexType == DEFAULT_INDEX_TYPE) {
+                val strictExpandOptions = IndicesOptions.strictExpand()
+                val clusterStateRequest = ClusterStateRequest()
+                    .clear()
+                    .indices(*indicesToAdd.values.toTypedArray())
+                    .metadata(true)
+                    .local(false)
+                    .waitForTimeout(TimeValue.timeValueMillis(ADD_POLICY_TIMEOUT_IN_MILLIS))
+                    .indicesOptions(strictExpandOptions)
+                client.admin()
+                    .cluster()
+                    .state(
+                        clusterStateRequest,
+                        object : ActionListener<ClusterStateResponse> {
+                            override fun onResponse(response: ClusterStateResponse) {
+                                CoroutineScope(Dispatchers.IO).launch { removeClusterStateMetadatas(client, log, indicesToAdd.map { Index(it.value, it.key) }) }
+
+                                val defaultIndexMetadataService = indexMetadataProvider.services[DEFAULT_INDEX_TYPE] as DefaultIndexMetadataService
+                                getUuidsForClosedIndices(response.state, defaultIndexMetadataService).forEach {
+                                    failedIndices.add(FailedIndex(indicesToAdd[it] as String, it, "This index is closed"))
+                                    indicesToAdd.remove(it)
+                                }
+                                getPolicy()
+                            }
+
+                            override fun onFailure(t: Exception) {
+                                actionListener.onFailure(ExceptionsHelper.unwrapCause(t) as Exception)
+                            }
+                        }
+                    )
+            } else {
                 getPolicy()
             }
         }
@@ -233,7 +269,7 @@ class TransportAddPolicyAction @Inject constructor(
         private fun onUpdateMapping(response: AcknowledgedResponse) {
             if (response.isAcknowledged) {
                 log.info("Successfully created or updated $INDEX_MANAGEMENT_INDEX with newest mappings.")
-                getClusterState()
+                getExistingManagedIndices()
             } else {
                 log.error("Unable to create or update $INDEX_MANAGEMENT_INDEX with newest mapping.")
 
@@ -246,46 +282,7 @@ class TransportAddPolicyAction @Inject constructor(
             }
         }
 
-        @Suppress("SpreadOperator")
-        fun getClusterState() {
-            val strictExpandOptions = IndicesOptions.strictExpand()
-
-            val clusterStateRequest = ClusterStateRequest()
-                .clear()
-                .indices(*resolvedIndices.toTypedArray())
-                .metadata(true)
-                .local(false)
-                .waitForTimeout(TimeValue.timeValueMillis(ADD_POLICY_TIMEOUT_IN_MILLIS))
-                .indicesOptions(strictExpandOptions)
-
-            startTime = Instant.now()
-
-            client.admin()
-                .cluster()
-                .state(
-                    clusterStateRequest,
-                    object : ActionListener<ClusterStateResponse> {
-                        override fun onResponse(response: ClusterStateResponse) {
-                            response.state.metadata.indices.forEach {
-                                indicesToAdd.putIfAbsent(it.value.indexUUID, it.key)
-                            }
-
-                            populateLists(response.state)
-                        }
-
-                        override fun onFailure(t: Exception) {
-                            actionListener.onFailure(ExceptionsHelper.unwrapCause(t) as Exception)
-                        }
-                    }
-                )
-        }
-
-        private fun populateLists(state: ClusterState) {
-            getUuidsForClosedIndices(state).forEach {
-                failedIndices.add(FailedIndex(indicesToAdd[it] as String, it, "This index is closed"))
-                indicesToAdd.remove(it)
-            }
-
+        private fun getExistingManagedIndices() {
             // Removing all the unmanageable Indices
             indicesToAdd.entries.removeIf { (uuid, indexName) ->
                 val shouldRemove = indexMetadataProvider.isUnManageableIndex(indexName)
@@ -294,7 +291,6 @@ class TransportAddPolicyAction @Inject constructor(
                 }
                 shouldRemove
             }
-
             if (indicesToAdd.isEmpty()) {
                 actionListener.onResponse(ISMStatusResponse(0, failedIndices))
                 return

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/transport/action/changepolicy/ChangePolicyRequest.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/transport/action/changepolicy/ChangePolicyRequest.kt
@@ -11,23 +11,31 @@ import org.opensearch.action.ValidateActions
 import org.opensearch.common.io.stream.StreamInput
 import org.opensearch.common.io.stream.StreamOutput
 import org.opensearch.indexmanagement.indexstatemanagement.model.ChangePolicy
+import org.opensearch.indexmanagement.indexstatemanagement.util.DEFAULT_INDEX_TYPE
 import java.io.IOException
 
 class ChangePolicyRequest(
     val indices: List<String>,
-    val changePolicy: ChangePolicy
+    val changePolicy: ChangePolicy,
+    val indexType: String
 ) : ActionRequest() {
 
     @Throws(IOException::class)
     constructor(sin: StreamInput) : this(
         indices = sin.readStringList(),
-        changePolicy = ChangePolicy(sin)
+        changePolicy = ChangePolicy(sin),
+        indexType = sin.readString()
     )
 
     override fun validate(): ActionRequestValidationException? {
         var validationException: ActionRequestValidationException? = null
         if (indices.isEmpty()) {
             validationException = ValidateActions.addValidationError("Missing indices", validationException)
+        } else if (indexType != DEFAULT_INDEX_TYPE && indices.size > 1) {
+            validationException = ValidateActions.addValidationError(
+                MULTIPLE_INDICES_CUSTOM_INDEX_TYPE_ERROR,
+                validationException
+            )
         }
         return validationException
     }
@@ -36,5 +44,11 @@ class ChangePolicyRequest(
     override fun writeTo(out: StreamOutput) {
         out.writeStringCollection(indices)
         changePolicy.writeTo(out)
+        out.writeString(indexType)
+    }
+
+    companion object {
+        const val MULTIPLE_INDICES_CUSTOM_INDEX_TYPE_ERROR =
+            "Cannot change policy on more than one index name/pattern when using a custom index type"
     }
 }

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/transport/action/changepolicy/TransportChangePolicyAction.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/transport/action/changepolicy/TransportChangePolicyAction.kt
@@ -5,6 +5,9 @@
 
 package org.opensearch.indexmanagement.indexstatemanagement.transport.action.changepolicy
 
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
 import org.apache.logging.log4j.LogManager
 import org.opensearch.ExceptionsHelper
 import org.opensearch.OpenSearchSecurityException
@@ -23,7 +26,7 @@ import org.opensearch.action.support.HandledTransportAction
 import org.opensearch.action.support.IndicesOptions
 import org.opensearch.action.support.master.AcknowledgedResponse
 import org.opensearch.client.node.NodeClient
-import org.opensearch.cluster.ClusterState
+import org.opensearch.cluster.metadata.IndexMetadata
 import org.opensearch.cluster.service.ClusterService
 import org.opensearch.common.inject.Inject
 import org.opensearch.common.settings.Settings
@@ -32,23 +35,28 @@ import org.opensearch.commons.ConfigConstants
 import org.opensearch.commons.authuser.User
 import org.opensearch.index.Index
 import org.opensearch.indexmanagement.IndexManagementPlugin
+import org.opensearch.indexmanagement.indexstatemanagement.DefaultIndexMetadataService
+import org.opensearch.indexmanagement.indexstatemanagement.IndexMetadataProvider
 import org.opensearch.indexmanagement.indexstatemanagement.model.ManagedIndexConfig
 import org.opensearch.indexmanagement.indexstatemanagement.model.Policy
 import org.opensearch.indexmanagement.indexstatemanagement.model.coordinator.SweptManagedIndexConfig
 import org.opensearch.indexmanagement.indexstatemanagement.opensearchapi.buildMgetMetadataRequest
 import org.opensearch.indexmanagement.indexstatemanagement.opensearchapi.getManagedIndexMetadata
-import org.opensearch.indexmanagement.indexstatemanagement.opensearchapi.mgetResponseToList
+import org.opensearch.indexmanagement.indexstatemanagement.opensearchapi.mgetResponseToMap
 import org.opensearch.indexmanagement.indexstatemanagement.resthandler.RestChangePolicyAction
 import org.opensearch.indexmanagement.indexstatemanagement.transport.action.ISMStatusResponse
 import org.opensearch.indexmanagement.indexstatemanagement.transport.action.managedIndex.ManagedIndexAction
 import org.opensearch.indexmanagement.indexstatemanagement.transport.action.managedIndex.ManagedIndexRequest
+import org.opensearch.indexmanagement.indexstatemanagement.util.DEFAULT_INDEX_TYPE
 import org.opensearch.indexmanagement.indexstatemanagement.util.FailedIndex
 import org.opensearch.indexmanagement.indexstatemanagement.util.isSafeToChange
+import org.opensearch.indexmanagement.indexstatemanagement.util.managedIndexMetadataID
 import org.opensearch.indexmanagement.indexstatemanagement.util.updateManagedIndexRequest
 import org.opensearch.indexmanagement.opensearchapi.contentParser
 import org.opensearch.indexmanagement.opensearchapi.parseFromGetResponse
 import org.opensearch.indexmanagement.opensearchapi.parseWithType
 import org.opensearch.indexmanagement.settings.IndexManagementSettings
+import org.opensearch.indexmanagement.spi.indexstatemanagement.model.ISMIndexMetadata
 import org.opensearch.indexmanagement.spi.indexstatemanagement.model.ManagedIndexMetaData
 import org.opensearch.indexmanagement.util.IndexManagementException
 import org.opensearch.indexmanagement.util.IndexUtils
@@ -64,14 +72,15 @@ import java.lang.IllegalArgumentException
 
 private val log = LogManager.getLogger(TransportChangePolicyAction::class.java)
 
-@Suppress("SpreadOperator", "TooManyFunctions")
+@Suppress("SpreadOperator", "TooManyFunctions", "LongParameterList")
 class TransportChangePolicyAction @Inject constructor(
     val client: NodeClient,
     transportService: TransportService,
     actionFilters: ActionFilters,
     val clusterService: ClusterService,
     val settings: Settings,
-    val xContentRegistry: NamedXContentRegistry
+    val xContentRegistry: NamedXContentRegistry,
+    val indexMetadataProvider: IndexMetadataProvider
 ) : HandledTransportAction<ChangePolicyRequest, ISMStatusResponse>(
     ChangePolicyAction.NAME, transportService, actionFilters, ::ChangePolicyRequest
 ) {
@@ -98,9 +107,10 @@ class TransportChangePolicyAction @Inject constructor(
         private val failedIndices = mutableListOf<FailedIndex>()
         private val managedIndicesToUpdate = mutableListOf<Pair<String, String>>()
         private val indexUuidToCurrentState = mutableMapOf<String, String>()
+        private val indicesToUpdate = mutableMapOf<String, String>() // uuid -> name
+        private val indexUuidToIndexMetadata = mutableMapOf<String, IndexMetadata>() // uuid -> indexmetadata
         private val changePolicy = request.changePolicy
         private lateinit var policy: Policy
-        private lateinit var clusterState: ClusterState
         private var updated: Int = 0
 
         fun start() {
@@ -154,6 +164,7 @@ class TransportChangePolicyAction @Inject constructor(
             }
         }
 
+        @Suppress("ReturnCount")
         private fun onGetPolicyResponse(response: GetResponse) {
             if (!response.isExists || response.isSourceEmpty) {
                 actionListener.onFailure(OpenSearchStatusException("Could not find policy=${request.changePolicy.policyID}", RestStatus.NOT_FOUND))
@@ -187,50 +198,92 @@ class TransportChangePolicyAction @Inject constructor(
                 return
             }
 
-            getClusterState()
+            getIndicesToUpdate()
+        }
+
+        private fun getIndicesToUpdate() {
+            CoroutineScope(Dispatchers.IO).launch {
+                val indexNameToMetadata: MutableMap<String, ISMIndexMetadata> = HashMap()
+                try {
+                    indexNameToMetadata.putAll(indexMetadataProvider.getISMIndexMetadataByType(request.indexType, request.indices))
+                } catch (e: Exception) {
+                    actionListener.onFailure(ExceptionsHelper.unwrapCause(e) as Exception)
+                    return@launch
+                }
+                indexNameToMetadata.forEach { (indexName, indexMetadata) ->
+                    indicesToUpdate.putIfAbsent(indexMetadata.indexUuid, indexName)
+                }
+                if (request.indexType == DEFAULT_INDEX_TYPE) {
+                    getClusterState()
+                } else {
+                    getManagedIndexMetadata()
+                }
+            }
         }
 
         @Suppress("SpreadOperator")
         private fun getClusterState() {
+            val strictExpandOptions = IndicesOptions.strictExpand()
             val clusterStateRequest = ClusterStateRequest()
                 .clear()
                 .indices(*request.indices.toTypedArray())
                 .metadata(true)
                 .local(false)
-                .indicesOptions(IndicesOptions.strictExpand())
+                .indicesOptions(strictExpandOptions)
+            client.admin()
+                .cluster()
+                .state(
+                    clusterStateRequest,
+                    object : ActionListener<ClusterStateResponse> {
+                        override fun onResponse(response: ClusterStateResponse) {
+                            val clusterState = response.state
+                            val defaultIndexMetadataService = indexMetadataProvider.services[DEFAULT_INDEX_TYPE] as DefaultIndexMetadataService
+                            clusterState.metadata.indices.forEach {
+                                val indexUUID = defaultIndexMetadataService.getCustomIndexUUID(it.value)
+                                indexUuidToIndexMetadata[indexUUID] = it.value
+                            }
+                            // ISMIndexMetadata from the default index metadata service uses lenient expand, we want to use strict expand, filter
+                            // out the indices which are not also in the strict expand response
+                            indicesToUpdate.filter { indexUuidToIndexMetadata.containsKey(it.key) }
+                            getManagedIndexMetadata()
+                        }
 
-            client.admin().cluster().state(clusterStateRequest, ActionListener.wrap(::onClusterStateResponse, ::onFailure))
+                        override fun onFailure(t: Exception) {
+                            actionListener.onFailure(ExceptionsHelper.unwrapCause(t) as Exception)
+                        }
+                    }
+                )
         }
 
-        @Suppress("ComplexMethod")
-        private fun onClusterStateResponse(response: ClusterStateResponse) {
-            clusterState = response.state
-
-            // get back managed index metadata
-            client.multiGet(buildMgetMetadataRequest(clusterState), ActionListener.wrap(::onMgetMetadataResponse, ::onFailure))
+        private fun getManagedIndexMetadata() {
+            client.multiGet(
+                buildMgetMetadataRequest(indicesToUpdate.toList().map { it.first }),
+                ActionListener.wrap(::onMgetMetadataResponse, ::onFailure)
+            )
         }
 
         @Suppress("ComplexMethod")
         private fun onMgetMetadataResponse(mgetResponse: MultiGetResponse) {
-            val metadataList = mgetResponseToList(mgetResponse)
+            val metadataMap = mgetResponseToMap(mgetResponse)
             val includedStates = changePolicy.include.map { it.state }.toSet()
 
-            clusterState.metadata.indices.forEachIndexed { ind, it ->
-                val indexMetaData = it.value
-                val clusterStateMetadata = it.value.getManagedIndexMetadata()
-                val mgetFailure = metadataList[ind]?.second
-                val managedIndexMetadata: ManagedIndexMetaData? = metadataList[ind]?.first
+            indicesToUpdate.forEach { (indexUuid, indexName) ->
+                // indexMetaData and clusterStateMetadata will be null for non-default index types
+                val indexMetaData = indexUuidToIndexMetadata[indexUuid]
+                val clusterStateMetadata = indexMetaData?.getManagedIndexMetadata()
+                val mgetFailure = metadataMap[indexUuid]?.second
+                val managedIndexMetadata: ManagedIndexMetaData? = metadataMap[managedIndexMetadataID(indexUuid)]?.first
 
                 val currentState = managedIndexMetadata?.stateMetaData?.name
                 if (currentState != null) {
-                    indexUuidToCurrentState[indexMetaData.indexUUID] = currentState
+                    indexUuidToCurrentState[indexUuid] = currentState
                 }
 
                 when {
                     mgetFailure != null ->
                         failedIndices.add(
                             FailedIndex(
-                                indexMetaData.index.name, indexMetaData.index.uuid,
+                                indexName, indexUuid,
                                 "Failed to get managed index metadata, $mgetFailure"
                             )
                         )
@@ -239,7 +292,7 @@ class TransportChangePolicyAction @Inject constructor(
                     managedIndexMetadata?.transitionTo != null ->
                         failedIndices.add(
                             FailedIndex(
-                                indexMetaData.index.name, indexMetaData.index.uuid,
+                                indexName, indexUuid,
                                 RestChangePolicyAction.INDEX_IN_TRANSITION
                             )
                         )
@@ -248,21 +301,21 @@ class TransportChangePolicyAction @Inject constructor(
                         if (clusterStateMetadata != null) {
                             failedIndices.add(
                                 FailedIndex(
-                                    indexMetaData.index.name, indexMetaData.index.uuid,
+                                    indexName, indexUuid,
                                     "Cannot change policy until metadata has finished migrating"
                                 )
                             )
                         } else {
-                            managedIndicesToUpdate.add(indexMetaData.index.name to indexMetaData.index.uuid)
+                            managedIndicesToUpdate.add(indexName to indexUuid)
                         }
                     }
                     // else if the includedStates is empty (i.e. not being used) then we will always try to update the managed index
-                    includedStates.isEmpty() -> managedIndicesToUpdate.add(indexMetaData.index.name to indexMetaData.index.uuid)
+                    includedStates.isEmpty() -> managedIndicesToUpdate.add(indexName to indexUuid)
                     // else only update the managed index if its currently in one of the included states
                     includedStates.contains(managedIndexMetadata.stateMetaData?.name) ->
-                        managedIndicesToUpdate.add(indexMetaData.index.name to indexMetaData.index.uuid)
+                        managedIndicesToUpdate.add(indexName to indexUuid)
                     // else the managed index did not match any of the included state filters and we will not update it
-                    else -> log.debug("Skipping ${indexMetaData.index.name} as it does not match any of the include state filters")
+                    else -> log.debug("Skipping $indexName as it does not match any of the include state filters")
                 }
             }
 

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/transport/action/explain/ExplainRequest.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/transport/action/explain/ExplainRequest.kt
@@ -7,10 +7,12 @@ package org.opensearch.indexmanagement.indexstatemanagement.transport.action.exp
 
 import org.opensearch.action.ActionRequest
 import org.opensearch.action.ActionRequestValidationException
+import org.opensearch.action.ValidateActions
 import org.opensearch.common.io.stream.StreamInput
 import org.opensearch.common.io.stream.StreamOutput
 import org.opensearch.common.unit.TimeValue
 import org.opensearch.indexmanagement.indexstatemanagement.model.SearchParams
+import org.opensearch.indexmanagement.indexstatemanagement.util.DEFAULT_INDEX_TYPE
 import java.io.IOException
 
 class ExplainRequest : ActionRequest {
@@ -19,17 +21,20 @@ class ExplainRequest : ActionRequest {
     val local: Boolean
     val masterTimeout: TimeValue
     val searchParams: SearchParams
+    val indexType: String
 
     constructor(
         indices: List<String>,
         local: Boolean,
         masterTimeout: TimeValue,
-        searchParams: SearchParams
+        searchParams: SearchParams,
+        indexType: String
     ) : super() {
         this.indices = indices
         this.local = local
         this.masterTimeout = masterTimeout
         this.searchParams = searchParams
+        this.indexType = indexType
     }
 
     @Throws(IOException::class)
@@ -37,11 +42,19 @@ class ExplainRequest : ActionRequest {
         indices = sin.readStringList(),
         local = sin.readBoolean(),
         masterTimeout = sin.readTimeValue(),
-        searchParams = SearchParams(sin)
+        searchParams = SearchParams(sin),
+        indexType = sin.readString()
     )
 
     override fun validate(): ActionRequestValidationException? {
-        return null
+        var validationException: ActionRequestValidationException? = null
+        if (indexType != DEFAULT_INDEX_TYPE && indices.size > 1) {
+            validationException = ValidateActions.addValidationError(
+                MULTIPLE_INDICES_CUSTOM_INDEX_TYPE_ERROR,
+                validationException
+            )
+        }
+        return validationException
     }
 
     @Throws(IOException::class)
@@ -50,5 +63,11 @@ class ExplainRequest : ActionRequest {
         out.writeBoolean(local)
         out.writeTimeValue(masterTimeout)
         searchParams.writeTo(out)
+        out.writeString(indexType)
+    }
+
+    companion object {
+        const val MULTIPLE_INDICES_CUSTOM_INDEX_TYPE_ERROR =
+            "Cannot call explain on more than one index name/pattern when using a custom index type"
     }
 }

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/transport/action/explain/TransportExplainAction.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/transport/action/explain/TransportExplainAction.kt
@@ -5,6 +5,9 @@
 
 package org.opensearch.indexmanagement.indexstatemanagement.transport.action.explain
 
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
 import org.apache.logging.log4j.LogManager
 import org.opensearch.ExceptionsHelper
 import org.opensearch.OpenSearchSecurityException
@@ -18,7 +21,6 @@ import org.opensearch.action.search.SearchRequest
 import org.opensearch.action.search.SearchResponse
 import org.opensearch.action.support.ActionFilters
 import org.opensearch.action.support.HandledTransportAction
-import org.opensearch.action.support.IndicesOptions
 import org.opensearch.action.support.master.AcknowledgedResponse
 import org.opensearch.client.node.NodeClient
 import org.opensearch.cluster.metadata.IndexMetadata
@@ -35,12 +37,20 @@ import org.opensearch.index.IndexNotFoundException
 import org.opensearch.index.query.Operator
 import org.opensearch.index.query.QueryBuilders
 import org.opensearch.indexmanagement.IndexManagementPlugin.Companion.INDEX_MANAGEMENT_INDEX
+import org.opensearch.indexmanagement.indexstatemanagement.IndexMetadataProvider
 import org.opensearch.indexmanagement.indexstatemanagement.ManagedIndexCoordinator.Companion.MAX_HITS
+import org.opensearch.indexmanagement.indexstatemanagement.model.SearchParams
 import org.opensearch.indexmanagement.indexstatemanagement.opensearchapi.getManagedIndexMetadata
 import org.opensearch.indexmanagement.indexstatemanagement.transport.action.managedIndex.ManagedIndexAction
 import org.opensearch.indexmanagement.indexstatemanagement.transport.action.managedIndex.ManagedIndexRequest
-import org.opensearch.indexmanagement.indexstatemanagement.util.isMetadataMoved
+import org.opensearch.indexmanagement.indexstatemanagement.util.DEFAULT_INDEX_TYPE
+import org.opensearch.indexmanagement.indexstatemanagement.util.MANAGED_INDEX_FIELD
+import org.opensearch.indexmanagement.indexstatemanagement.util.MANAGED_INDEX_INDEX_UUID_FIELD
+import org.opensearch.indexmanagement.indexstatemanagement.util.MANAGED_INDEX_NAME_FIELD
+import org.opensearch.indexmanagement.indexstatemanagement.util.MetadataCheck
+import org.opensearch.indexmanagement.indexstatemanagement.util.checkMetadata
 import org.opensearch.indexmanagement.indexstatemanagement.util.managedIndexMetadataID
+import org.opensearch.indexmanagement.spi.indexstatemanagement.model.ISMIndexMetadata
 import org.opensearch.indexmanagement.spi.indexstatemanagement.model.ManagedIndexMetaData
 import org.opensearch.indexmanagement.util.SecurityUtils.Companion.buildUser
 import org.opensearch.search.builder.SearchSourceBuilder
@@ -52,13 +62,22 @@ import org.opensearch.transport.TransportService
 
 private val log = LogManager.getLogger(TransportExplainAction::class.java)
 
+// TODO: Move these to higher level and refactor plugin to make it more readable
+typealias IndexUUID = String
+typealias PolicyID = String
+typealias IndexName = String
+typealias ManagedIndexConfigDocUUID = String
+typealias ManagedIndexMetadataDocUUID = String // managedIndexMetadataID(indexUuid) -> <indexUuid>#metadata
+typealias ManagedIndexMetadataMap = Map<String, String?>
+
 @Suppress("SpreadOperator")
 class TransportExplainAction @Inject constructor(
     val client: NodeClient,
     transportService: TransportService,
     actionFilters: ActionFilters,
     val clusterService: ClusterService,
-    val xContentRegistry: NamedXContentRegistry
+    val xContentRegistry: NamedXContentRegistry,
+    val indexMetadataProvider: IndexMetadataProvider
 ) : HandledTransportAction<ExplainRequest, ExplainResponse>(
     ExplainAction.NAME, transportService, actionFilters, ::ExplainRequest
 ) {
@@ -81,15 +100,17 @@ class TransportExplainAction @Inject constructor(
     ) {
         private val indices: List<String> = request.indices
         private val explainAll: Boolean = indices.isEmpty()
-        private val wildcard: Boolean = indices.any { it.contains("*") }
 
-        // map of index to index metadata got from config index job
-        private val managedIndicesMetaDataMap: MutableMap<String, Map<String, String?>> = mutableMapOf()
-        private val managedIndices: MutableList<String> = mutableListOf()
+        // Map of indexName to index metadata got from config index job which is fake/not a real full metadata document
+        private val managedIndicesMetaDataMap: MutableMap<IndexName, ManagedIndexMetadataMap> = mutableMapOf()
+        private val managedIndices: MutableList<IndexName> = mutableListOf()
 
-        private val indexNames: MutableList<String> = mutableListOf()
-        private val enabledState: MutableMap<String, Boolean> = mutableMapOf()
-        private val indexPolicyIDs = mutableListOf<String?>()
+        // indexNames are the ones that will be iterated on and shown in the final response
+        // throughout request they are cleared and rewritten
+        private val indexNames: MutableList<IndexName> = mutableListOf()
+        private val indexNamesToUUIDs: MutableMap<IndexName, IndexUUID> = mutableMapOf()
+        private val enabledState: MutableMap<IndexName, Boolean> = mutableMapOf()
+        private val indexPolicyIDs = mutableListOf<PolicyID?>()
         private val indexMetadatas = mutableListOf<ManagedIndexMetaData?>()
         private var totalManagedIndices = 0
 
@@ -100,8 +121,30 @@ class TransportExplainAction @Inject constructor(
                     ConfigConstants.OPENSEARCH_SECURITY_USER_INFO_THREAD_CONTEXT
                 )}"
             )
-            val params = request.searchParams
+            // Use the indexMetadataProvider to get the index names and uuids corresponding to this index type
+            CoroutineScope(Dispatchers.IO).launch {
+                val indexNameToMetadata: MutableMap<String, ISMIndexMetadata> = HashMap()
+                try {
+                    if (explainAll) {
+                        indexNameToMetadata.putAll(indexMetadataProvider.getAllISMIndexMetadataByType(request.indexType))
+                    } else {
+                        indexNameToMetadata.putAll(indexMetadataProvider.getISMIndexMetadataByType(request.indexType, indices))
+                    }
+                } catch (e: Exception) {
+                    actionListener.onFailure(ExceptionsHelper.unwrapCause(e) as Exception)
+                    return@launch
+                }
+                // These index names are resolved and populated by the indexMetadataProvider specific to the index type
+                indexNames.addAll(indexNameToMetadata.keys)
+                indexNamesToUUIDs.putAll(indexNameToMetadata.mapValues { it.value.indexUuid })
 
+                val params = request.searchParams
+                val searchRequest = getSearchMetadataRequest(params, indexNamesToUUIDs.values.toList(), if (explainAll) params.size else MAX_HITS)
+                searchForMetadata(searchRequest)
+            }
+        }
+
+        private fun getSearchMetadataRequest(params: SearchParams, indexUUIDs: List<String>, searchSize: Int): SearchRequest {
             val sortBuilder = SortBuilders
                 .fieldSort(params.sortField)
                 .order(SortOrder.fromString(params.sortOrder))
@@ -110,41 +153,25 @@ class TransportExplainAction @Inject constructor(
                 .must(
                     QueryBuilders
                         .queryStringQuery(params.queryString)
-                        .defaultField("managed_index.name")
+                        .defaultField(MANAGED_INDEX_NAME_FIELD)
                         .defaultOperator(Operator.AND)
-                )
+                ).filter(QueryBuilders.termsQuery(MANAGED_INDEX_INDEX_UUID_FIELD, indexUUIDs))
 
-            var searchSourceBuilder = SearchSourceBuilder()
+            val searchSourceBuilder = SearchSourceBuilder()
                 .from(params.from)
                 .fetchSource(FETCH_SOURCE)
                 .seqNoAndPrimaryTerm(true)
                 .version(true)
                 .sort(sortBuilder)
+                .size(searchSize)
+                .query(queryBuilder)
 
-            if (!explainAll) {
-                searchSourceBuilder = searchSourceBuilder.size(MAX_HITS)
-                if (wildcard) { // explain/index*
-                    indices.forEach {
-                        if (it.contains("*")) {
-                            queryBuilder.should(QueryBuilders.wildcardQuery("managed_index.index", it))
-                        } else {
-                            queryBuilder.should(QueryBuilders.termsQuery("managed_index.index", it))
-                        }
-                    }
-                } else { // explain/{index}
-                    queryBuilder.filter(QueryBuilders.termsQuery("managed_index.index", indices))
-                }
-            } else { // explain all
-                searchSourceBuilder = searchSourceBuilder.size(params.size)
-                queryBuilder.filter(QueryBuilders.existsQuery("managed_index"))
-            }
-
-            searchSourceBuilder = searchSourceBuilder.query(queryBuilder)
-
-            val searchRequest = SearchRequest()
+            return SearchRequest()
                 .indices(INDEX_MANAGEMENT_INDEX)
                 .source(searchSourceBuilder)
+        }
 
+        private fun searchForMetadata(searchRequest: SearchRequest) {
             client.threadPool().threadContext.stashContext().use { threadContext ->
                 client.search(
                     searchRequest,
@@ -156,7 +183,7 @@ class TransportExplainAction @Inject constructor(
                             }
 
                             response.hits.hits.map {
-                                val hitMap = it.sourceAsMap["managed_index"] as Map<String, Any>
+                                val hitMap = it.sourceAsMap[MANAGED_INDEX_FIELD] as Map<String, Any>
                                 val managedIndex = hitMap["index"] as String
                                 managedIndices.add(managedIndex)
                                 enabledState[managedIndex] = hitMap["enabled"] as Boolean
@@ -164,7 +191,7 @@ class TransportExplainAction @Inject constructor(
                                     "index" to hitMap["index"] as String?,
                                     "index_uuid" to hitMap["index_uuid"] as String?,
                                     "policy_id" to hitMap["policy_id"] as String?,
-                                    "enabled" to hitMap["enabled"]?.toString()
+                                    ManagedIndexMetaData.ENABLED to hitMap["enabled"]?.toString()
                                 )
                             }
 
@@ -173,29 +200,33 @@ class TransportExplainAction @Inject constructor(
                                 if (managedIndices.size == 0) {
                                     // edge case: if specify query param pagination size to be 0
                                     // we still show total managed indices
+                                    indexNames.clear()
                                     sendResponse()
                                     return
                                 } else {
+                                    // Clear and add the managedIndices from the response to preserve the sort order and size
+                                    indexNames.clear()
                                     indexNames.addAll(managedIndices)
-                                    getMetadata(managedIndices, threadContext)
+                                    // Remove entries in case they were limited due to request size
+                                    indexNamesToUUIDs.filterKeys { indexNames.contains(it) }
+                                    getMetadata(indexNames, threadContext)
                                     return
                                 }
                             }
 
                             // explain/{index} return results for all indices
-                            indexNames.addAll(indices)
-                            getMetadata(indices, threadContext)
+                            getMetadata(indexNames, threadContext)
                         }
 
                         override fun onFailure(t: Exception) {
                             if (t is IndexNotFoundException) {
                                 // config index hasn't been initialized
                                 // show all requested indices not managed
-                                if (indices.isNotEmpty()) {
-                                    indexNames.addAll(indices)
-                                    getMetadata(indices, threadContext)
+                                if (!explainAll) {
+                                    getMetadata(indexNames, threadContext)
                                     return
                                 }
+                                indexNames.clear()
                                 sendResponse()
                                 return
                             }
@@ -207,50 +238,45 @@ class TransportExplainAction @Inject constructor(
         }
 
         @Suppress("SpreadOperator")
-        fun getMetadata(indices: List<String>, threadContext: ThreadContext.StoredContext) {
-            val clusterStateRequest = ClusterStateRequest()
-            val strictExpandIndicesOptions = IndicesOptions.strictExpand()
+        fun getMetadata(indexNames: List<String>, threadContext: ThreadContext.StoredContext) {
+            if (request.indexType == DEFAULT_INDEX_TYPE) {
+                val clusterStateRequest = ClusterStateRequest()
+                clusterStateRequest.clear()
+                    .indices(*indexNames.toTypedArray())
+                    .metadata(true)
+                    .local(request.local)
+                    .masterNodeTimeout(request.masterTimeout)
 
-            clusterStateRequest.clear()
-                .indices(*indices.toTypedArray())
-                .metadata(true)
-                .local(request.local)
-                .masterNodeTimeout(request.masterTimeout)
-                .indicesOptions(strictExpandIndicesOptions)
+                client.admin().cluster().state(
+                    clusterStateRequest,
+                    object : ActionListener<ClusterStateResponse> {
+                        override fun onResponse(response: ClusterStateResponse) {
+                            val clusterStateIndexMetadatas = response.state.metadata.indices.associate { it.key to it.value }
+                            getMetadataMap(clusterStateIndexMetadatas, threadContext)
+                        }
 
-            client.admin().cluster().state(
-                clusterStateRequest,
-                object : ActionListener<ClusterStateResponse> {
-                    override fun onResponse(response: ClusterStateResponse) {
-                        onClusterStateResponse(response, threadContext)
+                        override fun onFailure(t: Exception) {
+                            actionListener.onFailure(ExceptionsHelper.unwrapCause(t) as Exception)
+                        }
                     }
-
-                    override fun onFailure(t: Exception) {
-                        actionListener.onFailure(ExceptionsHelper.unwrapCause(t) as Exception)
-                    }
-                }
-            )
+                )
+            } else {
+                getMetadataMap(null, threadContext)
+            }
         }
 
-        fun onClusterStateResponse(clusterStateResponse: ClusterStateResponse, threadContext: ThreadContext.StoredContext) {
-            val clusterStateIndexMetadatas = clusterStateResponse.state.metadata.indices.map { it.key to it.value }.toMap()
-
-            if (wildcard) {
-                indexNames.clear() // clear wildcard (index*) from indexNames
-                clusterStateIndexMetadatas.forEach { indexNames.add(it.key) }
-            }
-
-            val indices = clusterStateIndexMetadatas.map { it.key to it.value.indexUUID }.toMap()
+        private fun getMetadataMap(clusterStateIndexMetadatas: Map<IndexName, IndexMetadata>?, threadContext: ThreadContext.StoredContext) {
             val mgetMetadataReq = MultiGetRequest()
-            indices.map { it.value }.forEach { uuid ->
+            indexNamesToUUIDs.values.forEach { uuid ->
                 mgetMetadataReq.add(MultiGetRequest.Item(INDEX_MANAGEMENT_INDEX, managedIndexMetadataID(uuid)).routing(uuid))
             }
             client.multiGet(
                 mgetMetadataReq,
                 object : ActionListener<MultiGetResponse> {
                     override fun onResponse(response: MultiGetResponse) {
-                        val metadataMap = response.responses.map { it.id to getMetadata(it.response)?.toMap() }.toMap()
-                        buildResponse(indices, metadataMap, clusterStateIndexMetadatas, threadContext)
+                        val metadataMap: Map<ManagedIndexMetadataDocUUID, ManagedIndexMetadataMap?> =
+                            response.responses.associate { it.id to getMetadata(it.response)?.toMap() }
+                        buildResponse(indexNamesToUUIDs, metadataMap, clusterStateIndexMetadatas, threadContext)
                     }
 
                     override fun onFailure(t: Exception) {
@@ -260,34 +286,37 @@ class TransportExplainAction @Inject constructor(
             )
         }
 
-        // metadataMap: doc id -> metadataMap, doc id for metadata is [managedIndexMetadataID(indexUuid)]
-        fun buildResponse(
-            indices: Map<String, String>,
-            metadataMap: Map<String, Map<String, String>?>,
-            clusterStateIndexMetadatas: Map<String, IndexMetadata>,
+        @Suppress("ComplexMethod", "NestedBlockDepth")
+        private fun buildResponse(
+            indices: Map<IndexName, IndexUUID>,
+            metadataMap: Map<ManagedIndexMetadataDocUUID, ManagedIndexMetadataMap?>,
+            clusterStateIndexMetadatas: Map<IndexName, IndexMetadata>?,
             threadContext: ThreadContext.StoredContext
         ) {
-
-            // cluster state response will not resisting the sort order
+            // cluster state response will not resist the sort order
             // so use the order from previous search result saved in indexNames
             for (indexName in indexNames) {
-                var managedIndexMetadataMap = managedIndicesMetaDataMap[indexName]
-                indexPolicyIDs.add(managedIndexMetadataMap?.get("policy_id")) // use policyID from metadata
+                var metadataMapFromManagedIndex = managedIndicesMetaDataMap[indexName]
+                indexPolicyIDs.add(metadataMapFromManagedIndex?.get("policy_id"))
 
-                val clusterStateMetadata = clusterStateIndexMetadatas[indexName]?.getManagedIndexMetadata()
                 var managedIndexMetadata: ManagedIndexMetaData? = null
-                val configIndexMetadataMap = metadataMap[indices[indexName]?.let { managedIndexMetadataID(it) }]
-                if (managedIndexMetadataMap != null) {
-                    if (configIndexMetadataMap != null) { // if has metadata saved, use that
-                        managedIndexMetadataMap = configIndexMetadataMap
+                val managedIndexMetadataDocUUID = indices[indexName]?.let { managedIndexMetadataID(it) }
+                val configIndexMetadataMap = metadataMap[managedIndexMetadataDocUUID]
+                if (metadataMapFromManagedIndex != null) {
+                    if (configIndexMetadataMap != null) {
+                        metadataMapFromManagedIndex = configIndexMetadataMap
                     }
-                    if (managedIndexMetadataMap.isNotEmpty()) {
-                        managedIndexMetadata = ManagedIndexMetaData.fromMap(managedIndexMetadataMap)
+                    if (metadataMapFromManagedIndex.isNotEmpty()) {
+                        managedIndexMetadata = ManagedIndexMetaData.fromMap(metadataMapFromManagedIndex)
                     }
 
-                    if (!isMetadataMoved(clusterStateMetadata, configIndexMetadataMap, log)) {
-                        val info = mapOf("message" to "Metadata is pending migration")
-                        managedIndexMetadata = clusterStateMetadata?.copy(info = info)
+                    // clusterStateIndexMetadatas will not be null only for the default index type
+                    if (clusterStateIndexMetadatas != null) {
+                        val currentIndexUuid = indices[indexName]
+                        val clusterStateMetadata = clusterStateIndexMetadatas[indexName]?.getManagedIndexMetadata()
+                        val metadataCheck = checkMetadata(clusterStateMetadata, configIndexMetadataMap, currentIndexUuid, log)
+                        val info = metadataStatusToInfo[metadataCheck]
+                        info?.let { managedIndexMetadata = clusterStateMetadata?.copy(info = it) }
                     }
                 }
                 indexMetadatas.add(managedIndexMetadata)
@@ -305,7 +334,7 @@ class TransportExplainAction @Inject constructor(
             threadContext.restore()
             val filteredIndices = mutableListOf<String>()
             val filteredMetadata = mutableListOf<ManagedIndexMetaData?>()
-            val filteredPolicies = mutableListOf<String?>()
+            val filteredPolicies = mutableListOf<PolicyID?>()
             val enabledStatus = mutableMapOf<String, Boolean>()
             filter(0, filteredIndices, filteredMetadata, filteredPolicies, enabledStatus)
         }
@@ -314,7 +343,7 @@ class TransportExplainAction @Inject constructor(
             current: Int,
             filteredIndices: MutableList<String>,
             filteredMetadata: MutableList<ManagedIndexMetaData?>,
-            filteredPolicies: MutableList<String?>,
+            filteredPolicies: MutableList<PolicyID?>,
             enabledStatus: MutableMap<String, Boolean>
         ) {
             val request = ManagedIndexRequest().indices(indexNames[current])
@@ -358,27 +387,40 @@ class TransportExplainAction @Inject constructor(
         private fun sendResponse(
             indices: List<String> = indexNames,
             metadata: List<ManagedIndexMetaData?> = indexMetadatas,
-            policies: List<String?> = indexPolicyIDs,
+            policies: List<PolicyID?> = indexPolicyIDs,
             enabledStatus: Map<String, Boolean> = enabledState,
             totalIndices: Int = totalManagedIndices
         ) {
             actionListener.onResponse(ExplainResponse(indices, policies, metadata, totalIndices, enabledStatus))
         }
 
+        @Suppress("ReturnCount")
         private fun getMetadata(response: GetResponse?): ManagedIndexMetaData? {
             if (response == null || response.sourceAsBytesRef == null)
                 return null
 
-            val xcp = XContentHelper.createParser(
-                xContentRegistry,
-                LoggingDeprecationHandler.INSTANCE,
-                response.sourceAsBytesRef,
-                XContentType.JSON
-            )
-            return ManagedIndexMetaData.parseWithType(
-                xcp,
-                response.id, response.seqNo, response.primaryTerm
-            )
+            try {
+                val xcp = XContentHelper.createParser(
+                    xContentRegistry,
+                    LoggingDeprecationHandler.INSTANCE,
+                    response.sourceAsBytesRef,
+                    XContentType.JSON
+                )
+                return ManagedIndexMetaData.parseWithType(xcp, response.id, response.seqNo, response.primaryTerm)
+            } catch (e: Exception) {
+                log.error("Failed to parse the ManagedIndexMetadata for ${response.id}", e)
+            }
+
+            return null
         }
+    }
+
+    companion object {
+        const val METADATA_MOVING_WARNING = "Managed index's metadata is pending migration."
+        const val METADATA_CORRUPT_WARNING = "Managed index's metadata is corrupt, please use remove policy API to clean it."
+        val metadataStatusToInfo = mapOf(
+            MetadataCheck.PENDING to mapOf("message" to METADATA_MOVING_WARNING),
+            MetadataCheck.CORRUPT to mapOf("message" to METADATA_CORRUPT_WARNING)
+        )
     }
 }

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/transport/action/removepolicy/RemovePolicyRequest.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/transport/action/removepolicy/RemovePolicyRequest.kt
@@ -10,27 +10,29 @@ import org.opensearch.action.ActionRequestValidationException
 import org.opensearch.action.ValidateActions
 import org.opensearch.common.io.stream.StreamInput
 import org.opensearch.common.io.stream.StreamOutput
+import org.opensearch.indexmanagement.indexstatemanagement.util.DEFAULT_INDEX_TYPE
 import java.io.IOException
 
-class RemovePolicyRequest : ActionRequest {
-
-    val indices: List<String>
-
-    constructor(
-        indices: List<String>
-    ) : super() {
-        this.indices = indices
-    }
+class RemovePolicyRequest(
+    val indices: List<String>,
+    val indexType: String
+) : ActionRequest() {
 
     @Throws(IOException::class)
     constructor(sin: StreamInput) : this(
-        indices = sin.readStringList()
+        indices = sin.readStringList(),
+        indexType = sin.readString()
     )
 
     override fun validate(): ActionRequestValidationException? {
         var validationException: ActionRequestValidationException? = null
         if (indices.isEmpty()) {
             validationException = ValidateActions.addValidationError("Missing indices", validationException)
+        } else if (indexType != DEFAULT_INDEX_TYPE && indices.size > 1) {
+            validationException = ValidateActions.addValidationError(
+                MULTIPLE_INDICES_CUSTOM_INDEX_TYPE_ERROR,
+                validationException
+            )
         }
         return validationException
     }
@@ -38,5 +40,11 @@ class RemovePolicyRequest : ActionRequest {
     @Throws(IOException::class)
     override fun writeTo(out: StreamOutput) {
         out.writeStringCollection(indices)
+        out.writeString(indexType)
+    }
+
+    companion object {
+        const val MULTIPLE_INDICES_CUSTOM_INDEX_TYPE_ERROR =
+            "Cannot remove policy from more than one index name/pattern when using a custom index type"
     }
 }

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/transport/action/removepolicy/TransportRemovePolicyAction.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/transport/action/removepolicy/TransportRemovePolicyAction.kt
@@ -5,6 +5,9 @@
 
 package org.opensearch.indexmanagement.indexstatemanagement.transport.action.removepolicy
 
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
 import org.apache.logging.log4j.LogManager
 import org.opensearch.ExceptionsHelper
 import org.opensearch.OpenSearchSecurityException
@@ -22,13 +25,11 @@ import org.opensearch.action.support.HandledTransportAction
 import org.opensearch.action.support.IndicesOptions
 import org.opensearch.action.support.master.AcknowledgedResponse
 import org.opensearch.client.node.NodeClient
-import org.opensearch.cluster.ClusterState
 import org.opensearch.cluster.block.ClusterBlockException
 import org.opensearch.cluster.metadata.IndexMetadata.INDEX_BLOCKS_READ_ONLY_ALLOW_DELETE_SETTING
 import org.opensearch.cluster.metadata.IndexMetadata.INDEX_READ_ONLY_SETTING
 import org.opensearch.cluster.metadata.IndexMetadata.SETTING_READ_ONLY
 import org.opensearch.cluster.metadata.IndexMetadata.SETTING_READ_ONLY_ALLOW_DELETE
-import org.opensearch.cluster.service.ClusterService
 import org.opensearch.common.inject.Inject
 import org.opensearch.common.settings.Settings
 import org.opensearch.commons.ConfigConstants
@@ -36,14 +37,19 @@ import org.opensearch.commons.authuser.User
 import org.opensearch.index.Index
 import org.opensearch.index.IndexNotFoundException
 import org.opensearch.indexmanagement.IndexManagementPlugin.Companion.INDEX_MANAGEMENT_INDEX
+import org.opensearch.indexmanagement.indexstatemanagement.DefaultIndexMetadataService
+import org.opensearch.indexmanagement.indexstatemanagement.IndexMetadataProvider
 import org.opensearch.indexmanagement.indexstatemanagement.opensearchapi.getUuidsForClosedIndices
 import org.opensearch.indexmanagement.indexstatemanagement.settings.ManagedIndexSettings
 import org.opensearch.indexmanagement.indexstatemanagement.transport.action.ISMStatusResponse
 import org.opensearch.indexmanagement.indexstatemanagement.transport.action.managedIndex.ManagedIndexAction
 import org.opensearch.indexmanagement.indexstatemanagement.transport.action.managedIndex.ManagedIndexRequest
+import org.opensearch.indexmanagement.indexstatemanagement.util.DEFAULT_INDEX_TYPE
 import org.opensearch.indexmanagement.indexstatemanagement.util.FailedIndex
 import org.opensearch.indexmanagement.indexstatemanagement.util.deleteManagedIndexMetadataRequest
 import org.opensearch.indexmanagement.indexstatemanagement.util.deleteManagedIndexRequest
+import org.opensearch.indexmanagement.indexstatemanagement.util.removeClusterStateMetadatas
+import org.opensearch.indexmanagement.spi.indexstatemanagement.model.ISMIndexMetadata
 import org.opensearch.indexmanagement.util.IndexManagementException
 import org.opensearch.indexmanagement.util.SecurityUtils.Companion.buildUser
 import org.opensearch.rest.RestStatus
@@ -55,7 +61,7 @@ class TransportRemovePolicyAction @Inject constructor(
     val client: NodeClient,
     transportService: TransportService,
     actionFilters: ActionFilters,
-    val clusterService: ClusterService
+    val indexMetadataProvider: IndexMetadataProvider
 ) : HandledTransportAction<RemovePolicyRequest, ISMStatusResponse>(
     RemovePolicyAction.NAME, transportService, actionFilters, ::RemovePolicyRequest
 ) {
@@ -75,7 +81,7 @@ class TransportRemovePolicyAction @Inject constructor(
 
         private val failedIndices: MutableList<FailedIndex> = mutableListOf()
         private val indicesToRemove = mutableMapOf<String, String>() // uuid: name
-        private val indicesWithAutoManageBlock = mutableSetOf<String>()
+        private val indicesWithAutoManageFalseBlock = mutableSetOf<String>()
         private val indicesWithReadOnlyBlock = mutableSetOf<String>()
         private val indicesWithReadOnlyAllowDeleteBlock = mutableSetOf<String>()
 
@@ -86,20 +92,20 @@ class TransportRemovePolicyAction @Inject constructor(
                 )}"
             )
             if (user == null) {
-                getClusterState()
+                getIndicesToRemove()
             } else {
-                validateAndGetClusterState()
+                validateAndGetIndices()
             }
         }
 
-        private fun validateAndGetClusterState() {
-            val request = ManagedIndexRequest().indices(*request.indices.toTypedArray())
+        private fun validateAndGetIndices() {
+            val managedIndexRequest = ManagedIndexRequest().indices(*request.indices.toTypedArray())
             client.execute(
                 ManagedIndexAction.INSTANCE,
-                request,
+                managedIndexRequest,
                 object : ActionListener<AcknowledgedResponse> {
                     override fun onResponse(response: AcknowledgedResponse) {
-                        getClusterState()
+                        getIndicesToRemove()
                     }
 
                     override fun onFailure(e: java.lang.Exception) {
@@ -117,6 +123,26 @@ class TransportRemovePolicyAction @Inject constructor(
                     }
                 }
             )
+        }
+
+        private fun getIndicesToRemove() {
+            CoroutineScope(Dispatchers.IO).launch {
+                val indexNameToMetadata: MutableMap<String, ISMIndexMetadata> = HashMap()
+                try {
+                    indexNameToMetadata.putAll(indexMetadataProvider.getISMIndexMetadataByType(request.indexType, request.indices))
+                } catch (e: Exception) {
+                    actionListener.onFailure(ExceptionsHelper.unwrapCause(e) as Exception)
+                    return@launch
+                }
+                indexNameToMetadata.forEach { (indexName, indexMetadata) ->
+                    indicesToRemove.putIfAbsent(indexMetadata.indexUuid, indexName)
+                }
+                if (request.indexType == DEFAULT_INDEX_TYPE) {
+                    getClusterState()
+                } else {
+                    getExistingManagedIndices()
+                }
+            }
         }
 
         private fun getClusterState() {
@@ -138,9 +164,8 @@ class TransportRemovePolicyAction @Inject constructor(
                             override fun onResponse(response: ClusterStateResponse) {
                                 val indexMetadatas = response.state.metadata.indices
                                 indexMetadatas.forEach {
-                                    indicesToRemove.putIfAbsent(it.value.indexUUID, it.key)
                                     if (it.value.settings.get(ManagedIndexSettings.AUTO_MANAGE.key) == "false") {
-                                        indicesWithAutoManageBlock.add(it.value.indexUUID)
+                                        indicesWithAutoManageFalseBlock.add(it.value.indexUUID)
                                     }
                                     if (it.value.settings.get(SETTING_READ_ONLY) == "true") {
                                         indicesWithReadOnlyBlock.add(it.value.indexUUID)
@@ -149,7 +174,14 @@ class TransportRemovePolicyAction @Inject constructor(
                                         indicesWithReadOnlyAllowDeleteBlock.add(it.value.indexUUID)
                                     }
                                 }
-                                populateLists(response.state)
+
+                                val defaultIndexMetadataService = indexMetadataProvider.services[DEFAULT_INDEX_TYPE] as DefaultIndexMetadataService
+                                getUuidsForClosedIndices(response.state, defaultIndexMetadataService).forEach {
+                                    failedIndices.add(FailedIndex(indicesToRemove[it] as String, it, "This index is closed"))
+                                    indicesToRemove.remove(it)
+                                }
+
+                                getExistingManagedIndices()
                             }
 
                             override fun onFailure(t: Exception) {
@@ -160,11 +192,7 @@ class TransportRemovePolicyAction @Inject constructor(
             }
         }
 
-        private fun populateLists(state: ClusterState) {
-            getUuidsForClosedIndices(state).forEach {
-                failedIndices.add(FailedIndex(indicesToRemove[it] as String, it, "This index is closed"))
-                indicesToRemove.remove(it)
-            }
+        private fun getExistingManagedIndices() {
             if (indicesToRemove.isEmpty()) {
                 actionListener.onResponse(ISMStatusResponse(0, failedIndices))
                 return
@@ -206,7 +234,11 @@ class TransportRemovePolicyAction @Inject constructor(
                             }
                         }
 
-                        updateSettings(indicesToRemove)
+                        if (request.indexType == DEFAULT_INDEX_TYPE) {
+                            updateSettings(indicesToRemove)
+                        } else {
+                            removeManagedIndices()
+                        }
                     }
 
                     override fun onFailure(t: Exception) {
@@ -225,7 +257,7 @@ class TransportRemovePolicyAction @Inject constructor(
         @Suppress("SpreadOperator")
         fun updateSettings(indices: Map<String, String>) {
             // indices divide to read_only, read_only_allow_delete, normal
-            val indicesUuidsSet = indices.keys.toSet() - indicesWithAutoManageBlock
+            val indicesUuidsSet = indices.keys.toSet() - indicesWithAutoManageFalseBlock
             val readOnlyIndices = indicesUuidsSet.filter { it in indicesWithReadOnlyBlock }
             val readOnlyAllowDeleteIndices = (indicesUuidsSet - readOnlyIndices).filter { it in indicesWithReadOnlyAllowDeleteBlock }
             val normalIndices = indicesUuidsSet - readOnlyIndices - readOnlyAllowDeleteIndices
@@ -320,6 +352,8 @@ class TransportRemovePolicyAction @Inject constructor(
 
                             // clean metadata for indicesToRemove
                             val indicesToRemoveMetadata = indicesToRemove.map { Index(it.value, it.key) }
+                            // best effort
+                            CoroutineScope(Dispatchers.IO).launch { removeClusterStateMetadatas(client, log, indicesToRemoveMetadata) }
                             removeMetadatas(indicesToRemoveMetadata)
                         }
 

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/transport/action/retryfailedmanagedindex/RetryFailedManagedIndexRequest.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/transport/action/retryfailedmanagedindex/RetryFailedManagedIndexRequest.kt
@@ -11,35 +11,33 @@ import org.opensearch.action.ValidateActions
 import org.opensearch.common.io.stream.StreamInput
 import org.opensearch.common.io.stream.StreamOutput
 import org.opensearch.common.unit.TimeValue
+import org.opensearch.indexmanagement.indexstatemanagement.util.DEFAULT_INDEX_TYPE
 import java.io.IOException
 
-class RetryFailedManagedIndexRequest : ActionRequest {
-
-    val indices: List<String>
-    val startState: String?
-    val masterTimeout: TimeValue
-
-    constructor(
-        indices: List<String>,
-        startState: String?,
-        masterTimeout: TimeValue
-    ) : super() {
-        this.indices = indices
-        this.startState = startState
-        this.masterTimeout = masterTimeout
-    }
+class RetryFailedManagedIndexRequest(
+    val indices: List<String>,
+    val startState: String?,
+    val masterTimeout: TimeValue,
+    val indexType: String
+) : ActionRequest() {
 
     @Throws(IOException::class)
     constructor(sin: StreamInput) : this(
         indices = sin.readStringList(),
         startState = sin.readOptionalString(),
-        masterTimeout = sin.readTimeValue()
+        masterTimeout = sin.readTimeValue(),
+        indexType = sin.readString()
     )
 
     override fun validate(): ActionRequestValidationException? {
         var validationException: ActionRequestValidationException? = null
         if (indices.isEmpty()) {
             validationException = ValidateActions.addValidationError("Missing indices", validationException)
+        } else if (indexType != DEFAULT_INDEX_TYPE && indices.size > 1) {
+            validationException = ValidateActions.addValidationError(
+                MULTIPLE_INDICES_CUSTOM_INDEX_TYPE_ERROR,
+                validationException
+            )
         }
         return validationException
     }
@@ -49,5 +47,11 @@ class RetryFailedManagedIndexRequest : ActionRequest {
         out.writeStringCollection(indices)
         out.writeOptionalString(startState)
         out.writeTimeValue(masterTimeout)
+        out.writeString(indexType)
+    }
+
+    companion object {
+        const val MULTIPLE_INDICES_CUSTOM_INDEX_TYPE_ERROR =
+            "Cannot retry on more than one index name/pattern when using a custom index type"
     }
 }

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/transport/action/updateindexmetadata/TransportUpdateManagedIndexMetaDataAction.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/transport/action/updateindexmetadata/TransportUpdateManagedIndexMetaDataAction.kt
@@ -27,6 +27,7 @@ import org.opensearch.common.io.stream.StreamInput
 import org.opensearch.common.io.stream.Writeable
 import org.opensearch.index.Index
 import org.opensearch.indexmanagement.IndexManagementPlugin
+import org.opensearch.indexmanagement.indexstatemanagement.IndexMetadataProvider
 import org.opensearch.indexmanagement.spi.indexstatemanagement.model.ManagedIndexMetaData
 import org.opensearch.threadpool.ThreadPool
 import org.opensearch.transport.TransportService
@@ -36,6 +37,7 @@ class TransportUpdateManagedIndexMetaDataAction @Inject constructor(
     clusterService: ClusterService,
     transportService: TransportService,
     actionFilters: ActionFilters,
+    val indexMetadataProvider: IndexMetadataProvider,
     indexNameExpressionResolver: IndexNameExpressionResolver
 ) : TransportMasterNodeAction<UpdateManagedIndexMetaDataRequest, AcknowledgedResponse>(
     UpdateManagedIndexMetaDataAction.INSTANCE.name(),
@@ -53,11 +55,25 @@ class TransportUpdateManagedIndexMetaDataAction @Inject constructor(
     override fun checkBlock(request: UpdateManagedIndexMetaDataRequest, state: ClusterState): ClusterBlockException? {
         // https://github.com/elastic/elasticsearch/commit/ae14b4e6f96b554ca8f4aaf4039b468f52df0123
         // This commit will help us to give each individual index name and the error that is cause it. For now it will be a generic error message.
-        val indicesToAddTo = request.indicesToAddManagedIndexMetaDataTo.map { it.first.name }.toTypedArray()
-        val indicesToRemoveFrom = request.indicesToRemoveManagedIndexMetaDataFrom.map { it.name }.toTypedArray()
-        val indices = indicesToAddTo + indicesToRemoveFrom
+        val indicesToAddTo = request.indicesToAddManagedIndexMetaDataTo.map { it.first }.toTypedArray()
+        val indicesToRemoveFrom = request.indicesToRemoveManagedIndexMetaDataFrom.map { it }.toTypedArray()
+        val indices = checkExtensionsOverrideBlock(indicesToAddTo + indicesToRemoveFrom, state)
 
         return state.blocks.indicesBlockedException(ClusterBlockLevel.METADATA_WRITE, indices)
+    }
+
+    /*
+     * Index Management extensions may provide an index setting, which, if set to true, overrides the cluster metadata write block
+     */
+    private fun checkExtensionsOverrideBlock(indices: Array<Index>, state: ClusterState): Array<String> {
+        val indexBlockOverrideSettings = indexMetadataProvider.getIndexMetadataWriteOverrideSettings()
+        val indicesToBlock = indices.toMutableList()
+        indexBlockOverrideSettings.forEach { indexBlockOverrideSetting ->
+            indicesToBlock.removeIf { state.metadata.getIndexSafe(it).settings.getAsBoolean(indexBlockOverrideSetting, false) }
+        }
+        return indicesToBlock
+            .map { it.name }
+            .toTypedArray()
     }
 
     override fun masterOperation(

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/util/ManagedIndexUtils.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/util/ManagedIndexUtils.kt
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-@file:Suppress("TooManyFunctions")
+@file:Suppress("TooManyFunctions", "MatchingDeclarationName")
 @file:JvmName("ManagedIndexUtils")
 package org.opensearch.indexmanagement.indexstatemanagement.util
 
@@ -477,19 +477,35 @@ fun Action.isAllowed(allowList: List<String>): Boolean = allowList.contains(this
  *
  * log warning if remaining cluster state metadata has newer last_updated_time
  */
-fun isMetadataMoved(
+@Suppress("ReturnCount", "ComplexCondition", "ComplexMethod")
+fun checkMetadata(
     clusterStateMetadata: ManagedIndexMetaData?,
     configIndexMetadata: Any?,
+    currentIndexUuid: String?,
     logger: Logger
-): Boolean {
+): MetadataCheck {
+    // indexUuid saved in ISM metadata may be outdated
+    // if an index restored from snapshot
+    val indexUuid1 = clusterStateMetadata?.indexUuid
+    val indexUuid2 = when (configIndexMetadata) {
+        is ManagedIndexMetaData -> configIndexMetadata.indexUuid
+        is Map<*, *> -> configIndexMetadata["index_uuid"]
+        else -> null
+    } as String?
+    if ((indexUuid1 != null && indexUuid1 != currentIndexUuid) ||
+        (indexUuid2 != null && indexUuid2 != currentIndexUuid)
+    ) {
+        return MetadataCheck.CORRUPT
+    }
+
     if (clusterStateMetadata != null) {
-        if (configIndexMetadata == null) return false
+        if (configIndexMetadata == null) return MetadataCheck.PENDING
 
         // compare last updated time between 2 metadatas
         val t1 = clusterStateMetadata.stepMetaData?.startTime
         val t2 = when (configIndexMetadata) {
-            is ManagedIndexMetaData? -> configIndexMetadata.stepMetaData?.startTime
-            is Map<*, *>? -> {
+            is ManagedIndexMetaData -> configIndexMetadata.stepMetaData?.startTime
+            is Map<*, *> -> {
                 val stepMetadata = configIndexMetadata["step"] as Map<String, Any>?
                 stepMetadata?.get("start_time")
             }
@@ -499,7 +515,11 @@ fun isMetadataMoved(
             logger.warn("Cluster state metadata get updates after moved for [${clusterStateMetadata.index}]")
         }
     }
-    return true
+    return MetadataCheck.SUCCESS
+}
+
+enum class MetadataCheck {
+    PENDING, CORRUPT, SUCCESS
 }
 
 /**

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/util/ManagedIndexUtils.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/util/ManagedIndexUtils.kt
@@ -522,56 +522,6 @@ enum class MetadataCheck {
     PENDING, CORRUPT, SUCCESS
 }
 
-/**
- * Check if cluster state metadata has been moved to config index
- *
- * log warning if remaining cluster state metadata has newer last_updated_time
- */
-@Suppress("ReturnCount", "ComplexCondition", "ComplexMethod")
-fun checkMetadata(
-    clusterStateMetadata: ManagedIndexMetaData?,
-    configIndexMetadata: Any?,
-    currentIndexUuid: String?,
-    logger: Logger
-): MetadataCheck {
-    // indexUuid saved in ISM metadata may be outdated
-    // if an index restored from snapshot
-    val indexUuid1 = clusterStateMetadata?.indexUuid
-    val indexUuid2 = when (configIndexMetadata) {
-        is ManagedIndexMetaData -> configIndexMetadata.indexUuid
-        is Map<*, *> -> configIndexMetadata["index_uuid"]
-        else -> null
-    } as String?
-    if ((indexUuid1 != null && indexUuid1 != currentIndexUuid) ||
-        (indexUuid2 != null && indexUuid2 != currentIndexUuid)
-    ) {
-        return MetadataCheck.CORRUPT
-    }
-
-    if (clusterStateMetadata != null) {
-        if (configIndexMetadata == null) return MetadataCheck.PENDING
-
-        // compare last updated time between 2 metadatas
-        val t1 = clusterStateMetadata.stepMetaData?.startTime
-        val t2 = when (configIndexMetadata) {
-            is ManagedIndexMetaData -> configIndexMetadata.stepMetaData?.startTime
-            is Map<*, *> -> {
-                val stepMetadata = configIndexMetadata["step"] as Map<String, Any>?
-                stepMetadata?.get("start_time")
-            }
-            else -> null
-        } as Long?
-        if (t1 != null && t2 != null && t1 > t2) {
-            logger.warn("Cluster state metadata get updates after moved for [${clusterStateMetadata.index}]")
-        }
-    }
-    return MetadataCheck.SUCCESS
-}
-
-enum class MetadataCheck {
-    PENDING, CORRUPT, SUCCESS
-}
-
 private val baseMessageLogger = LogManager.getLogger(BaseMessage::class.java)
 
 fun BaseMessage.isHostInDenylist(networks: List<String>): Boolean {

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/util/RestHandlerUtils.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/util/RestHandlerUtils.kt
@@ -6,6 +6,9 @@
 @file:Suppress("TopLevelPropertyNaming", "MatchingDeclarationName")
 package org.opensearch.indexmanagement.indexstatemanagement.util
 
+import org.apache.logging.log4j.Logger
+import org.opensearch.action.support.master.AcknowledgedResponse
+import org.opensearch.client.Client
 import org.opensearch.common.io.stream.StreamInput
 import org.opensearch.common.io.stream.StreamOutput
 import org.opensearch.common.io.stream.Writeable
@@ -13,9 +16,14 @@ import org.opensearch.common.xcontent.ToXContent
 import org.opensearch.common.xcontent.ToXContentFragment
 import org.opensearch.common.xcontent.XContentBuilder
 import org.opensearch.common.xcontent.XContentFactory
+import org.opensearch.index.Index
 import org.opensearch.indexmanagement.indexstatemanagement.model.ChangePolicy
 import org.opensearch.indexmanagement.indexstatemanagement.model.ManagedIndexConfig
+import org.opensearch.indexmanagement.indexstatemanagement.transport.action.updateindexmetadata.UpdateManagedIndexMetaDataAction
+import org.opensearch.indexmanagement.indexstatemanagement.transport.action.updateindexmetadata.UpdateManagedIndexMetaDataRequest
 import org.opensearch.indexmanagement.opensearchapi.optionalTimeField
+import org.opensearch.indexmanagement.opensearchapi.suspendUntil
+import java.lang.Exception
 import java.time.Instant
 
 const val WITH_TYPE = "with_type"
@@ -30,10 +38,14 @@ const val UPDATED_INDICES = "updated_indices"
 const val TOTAL_MANAGED_INDICES = "total_managed_indices"
 
 const val ISM_TEMPLATE_FIELD = "policy.ism_template"
+const val MANAGED_INDEX_FIELD = "managed_index"
+const val MANAGED_INDEX_NAME_FIELD = "$MANAGED_INDEX_FIELD.name"
+const val MANAGED_INDEX_INDEX_FIELD = "$MANAGED_INDEX_FIELD.index"
+const val MANAGED_INDEX_INDEX_UUID_FIELD = "$MANAGED_INDEX_FIELD.index_uuid"
 
 const val DEFAULT_PAGINATION_SIZE = 20
 const val DEFAULT_PAGINATION_FROM = 0
-const val DEFAULT_JOB_SORT_FIELD = "managed_index.index"
+const val DEFAULT_JOB_SORT_FIELD = MANAGED_INDEX_INDEX_FIELD
 const val DEFAULT_POLICY_SORT_FIELD = "policy.policy_id.keyword"
 const val DEFAULT_SORT_ORDER = "asc"
 const val DEFAULT_QUERY_STRING = "*"
@@ -42,6 +54,7 @@ const val INDEX_HIDDEN = "index.hidden"
 const val INDEX_NUMBER_OF_SHARDS = "index.number_of_shards"
 const val INDEX_NUMBER_OF_REPLICAS = "index.number_of_replicas"
 
+const val TYPE_PARAM_KEY = "type"
 const val DEFAULT_INDEX_TYPE = "_default"
 
 fun buildInvalidIndexResponse(builder: XContentBuilder, failedIndices: List<FailedIndex>) {
@@ -99,4 +112,18 @@ fun getPartialChangePolicyBuilder(
         .optionalTimeField(ManagedIndexConfig.LAST_UPDATED_TIME_FIELD, Instant.now())
         .field(ManagedIndexConfig.CHANGE_POLICY_FIELD, changePolicy)
     return builder.endObject().endObject()
+}
+
+/**
+ * Removes the managed index metadata from the cluster state for the the provided indices.
+ */
+suspend fun removeClusterStateMetadatas(client: Client, logger: Logger, indices: List<Index>) {
+    val request = UpdateManagedIndexMetaDataRequest(indicesToRemoveManagedIndexMetaDataFrom = indices)
+
+    try {
+        val response: AcknowledgedResponse = client.suspendUntil { execute(UpdateManagedIndexMetaDataAction.INSTANCE, request, it) }
+        logger.debug("Cleaned cluster state metadata for $indices, ${response.isAcknowledged}")
+    } catch (e: Exception) {
+        logger.error("Failed to clean cluster state metadata for $indices")
+    }
 }

--- a/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/MetadataRegressionIT.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/MetadataRegressionIT.kt
@@ -18,6 +18,8 @@ import org.opensearch.indexmanagement.indexstatemanagement.action.ReplicaCountAc
 import org.opensearch.indexmanagement.indexstatemanagement.model.Policy
 import org.opensearch.indexmanagement.indexstatemanagement.model.State
 import org.opensearch.indexmanagement.indexstatemanagement.settings.ManagedIndexSettings
+import org.opensearch.indexmanagement.indexstatemanagement.transport.action.explain.TransportExplainAction.Companion.METADATA_CORRUPT_WARNING
+import org.opensearch.indexmanagement.indexstatemanagement.transport.action.explain.TransportExplainAction.Companion.METADATA_MOVING_WARNING
 import org.opensearch.indexmanagement.indexstatemanagement.transport.action.updateindexmetadata.UpdateManagedIndexMetaDataAction
 import org.opensearch.indexmanagement.indexstatemanagement.transport.action.updateindexmetadata.UpdateManagedIndexMetaDataRequest
 import org.opensearch.indexmanagement.waitFor
@@ -88,7 +90,7 @@ class MetadataRegressionIT : IndexStateManagementIntegTestCase() {
 
         waitFor {
             assertEquals(
-                "Metadata is pending migration",
+                METADATA_MOVING_WARNING,
                 getExplainManagedIndexMetaData(indexName).info?.get("message")
             )
         }
@@ -173,7 +175,7 @@ class MetadataRegressionIT : IndexStateManagementIntegTestCase() {
 
         waitFor {
             assertEquals(
-                "Metadata is pending migration",
+                METADATA_MOVING_WARNING,
                 getExplainManagedIndexMetaData(indexName).info?.get("message")
             )
         }
@@ -197,6 +199,57 @@ class MetadataRegressionIT : IndexStateManagementIntegTestCase() {
                 getNumberOfReplicasSetting(indexName)
             )
         }
+    }
+
+    fun `test clean corrupt metadata`() {
+        val indexName = "${testIndexName}_index_3"
+        val policyID = "${testIndexName}_testPolicyName_3"
+        val action = ReplicaCountAction(10, 0)
+        val states = listOf(State(name = "ReplicaCountState", actions = listOf(action), transitions = listOf()))
+        val policy = Policy(
+            id = policyID,
+            description = "$testIndexName description",
+            schemaVersion = 1L,
+            lastUpdatedTime = Instant.now().truncatedTo(ChronoUnit.MILLIS),
+            errorNotification = randomErrorNotification(),
+            defaultState = states[0].name,
+            states = states
+        )
+
+        createPolicy(policy, policyID)
+        createIndex(indexName)
+
+        // create a job
+        addPolicyToIndex(indexName, policyID)
+
+        // put some metadata into cluster state
+        val indexMetadata = getIndexMetadata(indexName)
+        metadataToClusterState = metadataToClusterState.copy(
+            index = indexName,
+            indexUuid = "randomindexuuid",
+            policyID = policyID
+        )
+        val request = UpdateManagedIndexMetaDataRequest(
+            indicesToAddManagedIndexMetaDataTo = listOf(
+                Pair(Index(indexName, indexMetadata.indexUUID), metadataToClusterState)
+            )
+        )
+        client().execute(UpdateManagedIndexMetaDataAction.INSTANCE, request).get()
+        logger.info("check if metadata is saved in cluster state: ${getIndexMetadata(indexName).getCustomData("managed_index_metadata")}")
+
+        waitFor {
+            assertEquals(
+                METADATA_CORRUPT_WARNING,
+                getExplainManagedIndexMetaData(indexName).info?.get("message")
+            )
+        }
+
+        waitFor(Instant.ofEpochSecond(120)) {
+            assertEquals(null, getExplainManagedIndexMetaData(indexName).info?.get("message"))
+            assertEquals(null, getIndexMetadata(indexName).getCustomData("managed_index_metadata"))
+        }
+
+        logger.info("corrupt metadata has been cleaned")
     }
 
     fun `test new node skip execution when old node exist in cluster`() {

--- a/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/coordinator/ManagedIndexCoordinatorIT.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/coordinator/ManagedIndexCoordinatorIT.kt
@@ -5,7 +5,6 @@
 
 package org.opensearch.indexmanagement.indexstatemanagement.coordinator
 
-import org.opensearch.client.ResponseException
 import org.opensearch.indexmanagement.indexstatemanagement.IndexStateManagementRestTestCase
 import org.opensearch.indexmanagement.indexstatemanagement.action.DeleteAction
 import org.opensearch.indexmanagement.indexstatemanagement.action.ForceMergeAction
@@ -15,15 +14,12 @@ import org.opensearch.indexmanagement.indexstatemanagement.model.Policy
 import org.opensearch.indexmanagement.indexstatemanagement.model.State
 import org.opensearch.indexmanagement.indexstatemanagement.model.Transition
 import org.opensearch.indexmanagement.indexstatemanagement.randomErrorNotification
-import org.opensearch.indexmanagement.indexstatemanagement.resthandler.RestExplainAction
 import org.opensearch.indexmanagement.indexstatemanagement.settings.ManagedIndexSettings
 import org.opensearch.indexmanagement.indexstatemanagement.step.forcemerge.WaitForForceMergeStep
 import org.opensearch.indexmanagement.indexstatemanagement.step.rollover.AttemptRolloverStep
-import org.opensearch.indexmanagement.makeRequest
+import org.opensearch.indexmanagement.indexstatemanagement.util.TOTAL_MANAGED_INDICES
 import org.opensearch.indexmanagement.spi.indexstatemanagement.model.ManagedIndexMetaData
 import org.opensearch.indexmanagement.waitFor
-import org.opensearch.rest.RestRequest
-import org.opensearch.rest.RestStatus
 import java.time.Instant
 import java.time.temporal.ChronoUnit
 import kotlin.test.assertFailsWith
@@ -128,35 +124,9 @@ class ManagedIndexCoordinatorIT : IndexStateManagementRestTestCase() {
 
         // Verify ManagedIndexMetadata has been cleared
         waitFor {
-            try {
-                client().makeRequest(RestRequest.Method.GET.toString(), RestExplainAction.EXPLAIN_BASE_URI)
-                fail("Expected a failure")
-            } catch (e: ResponseException) {
-                assertEquals("Unexpected RestStatus", RestStatus.NOT_FOUND, e.response.restStatus())
-                val actualMessage = e.response.asMap()
-                val expectedErrorMessage = mapOf(
-                    "error" to mapOf(
-                        "root_cause" to listOf(
-                            mapOf(
-                                "type" to "illegal_argument_exception", "reason" to "Missing indices",
-                                "reason" to "no such index [$index]",
-                                "index_uuid" to "_na_",
-                                "index" to index,
-                                "resource.type" to "index_or_alias",
-                                "type" to "index_not_found_exception",
-                                "resource.id" to index
-                            )
-                        ),
-                        "type" to "index_not_found_exception",
-                        "reason" to "no such index [$index]",
-                        "index_uuid" to "_na_",
-                        "index" to index,
-                        "resource.type" to "index_or_alias",
-                        "resource.id" to index
-                    ),
-                    "status" to 404
-                )
-                assertEquals(expectedErrorMessage, actualMessage)
+            val expected = mapOf(TOTAL_MANAGED_INDICES to 0)
+            waitFor {
+                assertEquals(expected, getExplainMap(null))
             }
         }
     }

--- a/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/model/ActionTests.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/model/ActionTests.kt
@@ -16,6 +16,7 @@ import org.opensearch.indexmanagement.indexstatemanagement.ISMActionsParser
 import org.opensearch.indexmanagement.indexstatemanagement.action.DeleteAction
 import org.opensearch.indexmanagement.indexstatemanagement.randomAllocationActionConfig
 import org.opensearch.indexmanagement.indexstatemanagement.randomCloseActionConfig
+import org.opensearch.indexmanagement.indexstatemanagement.randomDeleteActionConfig
 import org.opensearch.indexmanagement.indexstatemanagement.randomForceMergeActionConfig
 import org.opensearch.indexmanagement.indexstatemanagement.randomIndexPriorityActionConfig
 import org.opensearch.indexmanagement.indexstatemanagement.randomNotificationActionConfig
@@ -37,8 +38,6 @@ import java.io.ByteArrayInputStream
 import java.io.ByteArrayOutputStream
 import kotlin.test.assertFailsWith
 
-// TODO remove this suppression when refactoring is done
-@Suppress("UnusedPrivateMember")
 class ActionTests : OpenSearchTestCase() {
 
     fun `test invalid timeout for delete action fails`() {
@@ -65,15 +64,13 @@ class ActionTests : OpenSearchTestCase() {
         }
     }
 
-    // TODO: fixme - enable the test
-    private fun `test force merge action max num segments of zero fails`() {
+    fun `test force merge action max num segments of zero fails`() {
         assertFailsWith(IllegalArgumentException::class, "Expected IllegalArgumentException for maxNumSegments less than 1") {
             randomForceMergeActionConfig(maxNumSegments = 0)
         }
     }
 
-    // TODO: fixme - enable the test
-    private fun `test allocation action empty parameters fails`() {
+    fun `test allocation action empty parameters fails`() {
         assertFailsWith(IllegalArgumentException::class, "Expected IllegalArgumentException for empty parameters") {
             randomAllocationActionConfig()
         }
@@ -132,6 +129,10 @@ class ActionTests : OpenSearchTestCase() {
 
     fun `test open action round trip`() {
         roundTripAction(randomOpenActionConfig())
+    }
+
+    fun `test delete action round trip`() {
+        roundTripAction(randomDeleteActionConfig())
     }
 
     fun `test action timeout and retry round trip`() {

--- a/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/resthandler/ISMTemplateRestAPIIT.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/resthandler/ISMTemplateRestAPIIT.kt
@@ -31,6 +31,7 @@ class ISMTemplateRestAPIIT : IndexStateManagementRestTestCase() {
     private val policyID2 = "t2"
     private val policyID3 = "t3"
 
+    @Suppress("UNCHECKED_CAST")
     fun `test add template with invalid index pattern`() {
         try {
             val ismTemp = ISMTemplate(listOf(" "), 100, randomInstant())
@@ -44,6 +45,7 @@ class ISMTemplateRestAPIIT : IndexStateManagementRestTestCase() {
         }
     }
 
+    @Suppress("UNCHECKED_CAST")
     fun `test add template with self-overlapping index pattern`() {
         try {
             val ismTemp = ISMTemplate(listOf("ab*"), 100, randomInstant())
@@ -58,6 +60,7 @@ class ISMTemplateRestAPIIT : IndexStateManagementRestTestCase() {
         }
     }
 
+    @Suppress("UNCHECKED_CAST")
     fun `test add template with overlapping index pattern`() {
         try {
             val ismTemp = ISMTemplate(listOf("log*"), 100, randomInstant())
@@ -86,9 +89,9 @@ class ISMTemplateRestAPIIT : IndexStateManagementRestTestCase() {
 
         val ismTemp = ISMTemplate(listOf("log*"), 100, randomInstant())
 
-        val actionConfig = ReadOnlyAction(0)
+        val action = ReadOnlyAction(0)
         val states = listOf(
-            State("ReadOnlyState", listOf(actionConfig), listOf())
+            State("ReadOnlyState", listOf(action), listOf())
         )
         val policy = Policy(
             id = policyID,

--- a/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/resthandler/RestChangePolicyActionIT.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/resthandler/RestChangePolicyActionIT.kt
@@ -551,8 +551,8 @@ class RestChangePolicyActionIT : IndexStateManagementRestTestCase() {
 
     fun `test allowing change policy to happen in middle of state if same state structure`() {
         // Creates a policy that has one state with rollover
-        val actionConfig = RolloverAction(index = 0, minDocs = 100_000_000, minAge = null, minSize = null, minPrimaryShardSize = null)
-        val stateWithReadOnlyAction = randomState(actions = listOf(actionConfig))
+        val action = RolloverAction(index = 0, minDocs = 100_000_000, minAge = null, minSize = null, minPrimaryShardSize = null)
+        val stateWithReadOnlyAction = randomState(actions = listOf(action))
         val randomPolicy = randomPolicy(states = listOf(stateWithReadOnlyAction))
         val policy = createPolicy(randomPolicy)
         val indexName = "${testIndexName}_safe-000001"

--- a/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/resthandler/RestExplainActionIT.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/resthandler/RestExplainActionIT.kt
@@ -158,6 +158,7 @@ class RestExplainActionIT : IndexStateManagementRestTestCase() {
                         ManagedIndexMetaData.POLICY_ID to managedIndexConfig.policyID::equals,
                         ManagedIndexMetaData.POLICY_SEQ_NO to policy.seqNo.toInt()::equals,
                         ManagedIndexMetaData.POLICY_PRIMARY_TERM to policy.primaryTerm.toInt()::equals,
+                        ManagedIndexMetaData.INDEX_CREATION_DATE to fun(indexCreationDate: Any?): Boolean = (indexCreationDate as Long) > 1L,
                         StateMetaData.STATE to fun(stateMetaDataMap: Any?): Boolean =
                             assertStateEquals(
                                 StateMetaData(policy.defaultState, Instant.now().toEpochMilli()),
@@ -207,6 +208,7 @@ class RestExplainActionIT : IndexStateManagementRestTestCase() {
                         PolicyRetryInfoMetaData.RETRY_INFO to fun(retryInfoMetaDataMap: Any?): Boolean =
                             assertRetryInfoEquals(PolicyRetryInfoMetaData(true, 0), retryInfoMetaDataMap),
                         ManagedIndexMetaData.INFO to fun(info: Any?): Boolean = expectedInfoString == info.toString(),
+                        ManagedIndexMetaData.INDEX_CREATION_DATE to fun(indexCreationDate: Any?): Boolean = (indexCreationDate as Long) > 1L,
                         ManagedIndexMetaData.ENABLED to true::equals
                     )
                 ),

--- a/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/resthandler/RestRetryFailedManagedIndexActionIT.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/resthandler/RestRetryFailedManagedIndexActionIT.kt
@@ -254,9 +254,9 @@ class RestRetryFailedManagedIndexActionIT : IndexStateManagementRestTestCase() {
     fun `test reset action start time`() {
         val indexName = "${testIndexName}_drewberry"
         val policyID = "${testIndexName}_policy_1"
-        val config = randomForceMergeActionConfig(maxNumSegments = 1)
-        config.configRetry = ActionRetry(0)
-        val policy = randomPolicy(states = listOf(randomState(actions = listOf(config))))
+        val action = randomForceMergeActionConfig(maxNumSegments = 1)
+        action.configRetry = ActionRetry(0)
+        val policy = randomPolicy(states = listOf(randomState(actions = listOf(action))))
         createPolicy(policy, policyId = policyID)
         createIndex(indexName, policyID)
 

--- a/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/transport/action/addpolicy/AddPolicyRequestTests.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/transport/action/addpolicy/AddPolicyRequestTests.kt
@@ -7,6 +7,7 @@ package org.opensearch.indexmanagement.indexstatemanagement.transport.action.add
 
 import org.opensearch.common.io.stream.BytesStreamOutput
 import org.opensearch.common.io.stream.StreamInput
+import org.opensearch.indexmanagement.indexstatemanagement.util.DEFAULT_INDEX_TYPE
 import org.opensearch.test.OpenSearchTestCase
 
 class AddPolicyRequestTests : OpenSearchTestCase() {
@@ -14,7 +15,7 @@ class AddPolicyRequestTests : OpenSearchTestCase() {
     fun `test add policy request`() {
         val indices = listOf("index1", "index2")
         val policyID = "policyID"
-        val req = AddPolicyRequest(indices, policyID)
+        val req = AddPolicyRequest(indices, policyID, DEFAULT_INDEX_TYPE)
 
         val out = BytesStreamOutput()
         req.writeTo(out)
@@ -22,5 +23,14 @@ class AddPolicyRequestTests : OpenSearchTestCase() {
         val newReq = AddPolicyRequest(sin)
         assertEquals(indices, newReq.indices)
         assertEquals(policyID, newReq.policyID)
+    }
+
+    fun `test add policy request with non default index type and multiple indices fails`() {
+        val indices = listOf("index1", "index2")
+        val policyID = "policyID"
+        val req = AddPolicyRequest(indices, policyID, "non-existent-index-type")
+        val actualException: String? = req.validate()?.validationErrors()?.firstOrNull()
+        val expectedException: String = AddPolicyRequest.MULTIPLE_INDICES_CUSTOM_INDEX_TYPE_ERROR
+        assertEquals("Add policy request should have failed validation with specific exception", actualException, expectedException)
     }
 }

--- a/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/transport/action/changepolicy/ChangePolicyRequestTests.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/transport/action/changepolicy/ChangePolicyRequestTests.kt
@@ -9,6 +9,7 @@ import org.opensearch.common.io.stream.BytesStreamOutput
 import org.opensearch.common.io.stream.StreamInput
 import org.opensearch.indexmanagement.indexstatemanagement.model.ChangePolicy
 import org.opensearch.indexmanagement.indexstatemanagement.model.StateFilter
+import org.opensearch.indexmanagement.indexstatemanagement.util.DEFAULT_INDEX_TYPE
 import org.opensearch.test.OpenSearchTestCase
 
 class ChangePolicyRequestTests : OpenSearchTestCase() {
@@ -17,7 +18,7 @@ class ChangePolicyRequestTests : OpenSearchTestCase() {
         val indices = listOf("index1", "index2")
         val stateFilter = StateFilter("state1")
         val changePolicy = ChangePolicy("policyID", "state1", listOf(stateFilter), true)
-        val req = ChangePolicyRequest(indices, changePolicy)
+        val req = ChangePolicyRequest(indices, changePolicy, DEFAULT_INDEX_TYPE)
 
         val out = BytesStreamOutput()
         req.writeTo(out)
@@ -25,5 +26,15 @@ class ChangePolicyRequestTests : OpenSearchTestCase() {
         val newReq = ChangePolicyRequest(sin)
         assertEquals(indices, newReq.indices)
         assertEquals(changePolicy, newReq.changePolicy)
+    }
+
+    fun `test change policy request with non default index type and multiple indices fails`() {
+        val indices = listOf("index1", "index2")
+        val stateFilter = StateFilter("state1")
+        val changePolicy = ChangePolicy("policyID", "state1", listOf(stateFilter), true)
+        val req = ChangePolicyRequest(indices, changePolicy, "non-existent-index-type")
+        val actualException: String? = req.validate()?.validationErrors()?.firstOrNull()
+        val expectedException: String = ChangePolicyRequest.MULTIPLE_INDICES_CUSTOM_INDEX_TYPE_ERROR
+        assertEquals("Add policy request should have failed validation with specific exception", actualException, expectedException)
     }
 }

--- a/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/transport/action/indexpolicy/IndexPolicyResponseTests.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/transport/action/indexpolicy/IndexPolicyResponseTests.kt
@@ -32,8 +32,8 @@ class IndexPolicyResponseTests : OpenSearchTestCase() {
         val primaryTerm: Long = 123
         val seqNo: Long = 456
         val policyID = "policyID"
-        val actionConfig = IndexPriorityAction(50, 0)
-        val states = listOf(State(name = "SetPriorityState", actions = listOf(actionConfig), transitions = listOf()))
+        val action = IndexPriorityAction(50, 0)
+        val states = listOf(State(name = "SetPriorityState", actions = listOf(action), transitions = listOf()))
         val policy = Policy(
             id = policyID,
             description = "description",

--- a/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/transport/action/removepolicy/RemovePolicyRequestTests.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/transport/action/removepolicy/RemovePolicyRequestTests.kt
@@ -7,18 +7,27 @@ package org.opensearch.indexmanagement.indexstatemanagement.transport.action.rem
 
 import org.opensearch.common.io.stream.BytesStreamOutput
 import org.opensearch.common.io.stream.StreamInput
+import org.opensearch.indexmanagement.indexstatemanagement.util.DEFAULT_INDEX_TYPE
 import org.opensearch.test.OpenSearchTestCase
 
 class RemovePolicyRequestTests : OpenSearchTestCase() {
 
     fun `test remove policy request`() {
         val indices = listOf("index1", "index2")
-        val req = RemovePolicyRequest(indices)
+        val req = RemovePolicyRequest(indices, DEFAULT_INDEX_TYPE)
 
         val out = BytesStreamOutput()
         req.writeTo(out)
         val sin = StreamInput.wrap(out.bytes().toBytesRef().bytes)
         val newReq = RemovePolicyRequest(sin)
         assertEquals(indices, newReq.indices)
+    }
+
+    fun `test remove policy request with non default index type and multiple indices fails`() {
+        val indices = listOf("index1", "index2")
+        val req = RemovePolicyRequest(indices, "non-existent-index-type")
+        val actualException: String? = req.validate()?.validationErrors()?.firstOrNull()
+        val expectedException: String = RemovePolicyRequest.MULTIPLE_INDICES_CUSTOM_INDEX_TYPE_ERROR
+        assertEquals("Remove policy request should have failed validation with specific exception", actualException, expectedException)
     }
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
**SPI**
- Makes IndexMetadataService.getMetadata into a suspend method
- Adds indexCreationDate to ManagedIndexMetadata
- Adds loadExtensions code to populate the list of action parsers and metadata providers from the plugin extensions
- Creates the DefaultIndexMetadataService to use a cluster state rest call to get a map of index names to index uuid and creation date given a list of index names
- Adds IndexMetadataProvider class to manage the map of index types to metadata services
  - if an IndexMetadataService is added for an index type which is already mapped, an error is thrown, the cluster would fail to start
- Adds getIndexMetadataWriteOverrideSettings to the IndexMetadataProvider class to return the list of non-null IndexMetadataWriteOverrideSettings from the IndexMetadataServices. This is used in the Update Managed Index Metadata rest api

**Add Policy**
- Makes add policy rest API use the default index metadata service provided by the IndexMetadataProvider.
- As the metadata service resolves index names, the index name resolver was removed from the add policy transport
- Following that, validating index permissions needed to occur before other validations, as we don't want to include the resolved index name of an index which the user does not have permissions to view in the failedIndices response

**Explain**
- Combines ExplainAll into Explain, making totalManagedIndices and enabledState included in all explain responses.
- Adds typealias and constants to the TransportExplainAction class
- Uses indexMetadataProvider to resolve index names and get index names and types from the provider specific to the index type

**Change Policy**
- Uses indexMetadataProvider to resolve index names and get index names and types from the provider specific to the index type
- Gets the cluster state for default index types to check if metadata migration is ongoing

**Remove Policy**
- Uses indexMetadataProvider to resolve index names and get index names and types from the provider specific to the index type
- Gets the cluster state for default index types to fail closed indices, and set auto manage to false on indices before removing the policy

**Retry Failed Managed Index**
- Uses indexMetadataProvider to resolve index names and get index names and types from the provider specific to the index type
- Gets the cluster state for default index types to check if metadata migration is ongoing

**Get Policy/Policies**
- No refactoring changes needed
- Added simple integration tests

**Delete Policy**
- No refactoring changes needed
- Added simple integration test

**Update Managed Index Metadata**
- Uses IndexMetadataWriteOverrideSetting from each index metadata provider to enable extensions to have the option of overriding the cluster metadata write block. If any extension provides an index setting for the IndexMetadataWriteOverrideSetting which resolves to true, the metadata write will be allowed for that index, despite the cluster metadata write block.

*CheckList:*
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/index-management/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
