### PR TITLE
Fixes flaky rollup/transform explain IT

### DIFF
--- a/src/test/kotlin/org/opensearch/indexmanagement/rollup/resthandler/RestExplainRollupActionIT.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/rollup/resthandler/RestExplainRollupActionIT.kt
@@ -68,7 +68,7 @@ class RestExplainRollupActionIT : RollupRestTestCase() {
     @Throws(Exception::class)
     fun `test explain rollup for nonexistent id`() {
         // Creating a rollup so the config index exists
-        createRollup(rollup = randomRollup(), rollupId = "doesnt_exist_some_other_id")
+        createRollup(rollup = randomRollup(), rollupId = "doesnt_exist_some_other_rollup_id")
         val response = client().makeRequest("GET", "$ROLLUP_JOBS_BASE_URI/doesnt_exist/_explain")
         assertNull("Nonexistent rollup didn't return null", response.asMap()["doesnt_exist"])
     }
@@ -76,30 +76,30 @@ class RestExplainRollupActionIT : RollupRestTestCase() {
     @Throws(Exception::class)
     fun `test explain rollup for wildcard id`() {
         // Creating a rollup so the config index exists
-        createRollup(rollup = randomRollup(), rollupId = "wildcard_some_id")
-        createRollup(rollup = randomRollup(), rollupId = "wildcard_some_other_id")
+        createRollup(rollup = randomRollup(), rollupId = "wildcard_some_rollup_id")
+        createRollup(rollup = randomRollup(), rollupId = "wildcard_some_other_rollup_id")
         val response = client().makeRequest("GET", "$ROLLUP_JOBS_BASE_URI/wildcard_some*/_explain")
         // We don't expect there to always be metadata as we are creating random rollups and the job isn't running
         // but we do expect the wildcard some* to expand to the two jobs created above and have non-null values (meaning they exist)
         val map = response.asMap()
-        assertNotNull("Non null wildcard_some_id value wasn't in the response", map["wildcard_some_id"])
-        assertNotNull("Non null wildcard_some_other_id value wasn't in the response", map["wildcard_some_other_id"])
+        assertNotNull("Non null wildcard_some_rollup_id value wasn't in the response", map["wildcard_some_rollup_id"])
+        assertNotNull("Non null wildcard_some_other_rollup_id value wasn't in the response", map["wildcard_some_other_rollup_id"])
     }
 
     @Throws(Exception::class)
     fun `test explain rollup for job that hasnt started`() {
-        createRollup(rollup = randomRollup().copy(metadataID = null), rollupId = "not_started_some_id")
-        val response = client().makeRequest("GET", "$ROLLUP_JOBS_BASE_URI/not_started_some_id/_explain")
-        val expectedMap = mapOf("not_started_some_id" to mapOf("metadata_id" to null, "rollup_metadata" to null))
+        createRollup(rollup = randomRollup().copy(metadataID = null), rollupId = "not_started_some_rollup_id")
+        val response = client().makeRequest("GET", "$ROLLUP_JOBS_BASE_URI/not_started_some_rollup_id/_explain")
+        val expectedMap = mapOf("not_started_some_rollup_id" to mapOf("metadata_id" to null, "rollup_metadata" to null))
         assertEquals("The explain response did not match expected", expectedMap, response.asMap())
     }
 
     @Throws(Exception::class)
     fun `test explain rollup for metadata_id but no metadata`() {
         // This is to test the case of a rollup existing with a metadataID but there being no metadata document
-        createRollup(rollup = randomRollup().copy(metadataID = "some_metadata_id"), rollupId = "no_meta_some_id")
-        val response = client().makeRequest("GET", "$ROLLUP_JOBS_BASE_URI/no_meta_some_id/_explain")
-        val expectedMap = mapOf("no_meta_some_id" to mapOf("metadata_id" to "some_metadata_id", "rollup_metadata" to null))
+        createRollup(rollup = randomRollup().copy(metadataID = "some_metadata_id"), rollupId = "no_meta_some_rollup_id")
+        val response = client().makeRequest("GET", "$ROLLUP_JOBS_BASE_URI/no_meta_some_rollup_id/_explain")
+        val expectedMap = mapOf("no_meta_some_rollup_id" to mapOf("metadata_id" to "some_metadata_id", "rollup_metadata" to null))
         assertEquals("The explain response did not match expected", expectedMap, response.asMap())
     }
 

--- a/src/test/kotlin/org/opensearch/indexmanagement/rollup/resthandler/RestStartRollupActionIT.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/rollup/resthandler/RestStartRollupActionIT.kt
@@ -228,6 +228,9 @@ class RestStartRollupActionIT : RollupRestTestCase() {
             metrics = emptyList()
         ).let { createRollup(it, it.id) }
 
+        // The updateRollupStartTime call can be missed if the job scheduler hasn't started listening to the new index yet,
+        // sleep a bit to let it initialize
+        Thread.sleep(2000L)
         updateRollupStartTime(rollup)
 
         waitFor {

--- a/src/test/kotlin/org/opensearch/indexmanagement/rollup/resthandler/RestStopRollupActionIT.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/rollup/resthandler/RestStopRollupActionIT.kt
@@ -284,6 +284,9 @@ class RestStopRollupActionIT : RollupRestTestCase() {
             metrics = emptyList()
         ).let { createRollup(it, it.id) }
 
+        // The updateRollupStartTime call can be missed if the job scheduler hasn't started listening to the new index yet,
+        // sleep a bit to let it initialize
+        Thread.sleep(2000L)
         updateRollupStartTime(rollup)
 
         waitFor {

--- a/src/test/kotlin/org/opensearch/indexmanagement/transform/resthandler/RestExplainTransformActionIT.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/transform/resthandler/RestExplainTransformActionIT.kt
@@ -67,7 +67,7 @@ class RestExplainTransformActionIT : TransformRestTestCase() {
     @Throws(Exception::class)
     fun `test explain transform for nonexistent id`() {
         // Creating a transform so the config index exists
-        createTransform(transform = randomTransform(), transformId = "doesnt_exist_some_other_id")
+        createTransform(transform = randomTransform(), transformId = "doesnt_exist_some_other_transform_id")
         val response = client().makeRequest("GET", "$TRANSFORM_BASE_URI/doesnt_exist/_explain")
         assertNull("Nonexistent transform didn't return null", response.asMap()["doesnt_exist"])
     }
@@ -75,29 +75,29 @@ class RestExplainTransformActionIT : TransformRestTestCase() {
     @Throws(Exception::class)
     fun `test explain transform for wildcard id`() {
         // Creating a transform so the config index exists
-        createTransform(transform = randomTransform(), transformId = "wildcard_some_id")
-        createTransform(transform = randomTransform(), transformId = "wildcard_some_other_id")
+        createTransform(transform = randomTransform(), transformId = "wildcard_some_transform_id")
+        createTransform(transform = randomTransform(), transformId = "wildcard_some_other_transform_id")
         val response = client().makeRequest("GET", "$TRANSFORM_BASE_URI/wildcard_some*/_explain")
         // We don't expect there to always be metadata we are creating random transforms and the job isn't running
         // but we do expect the wildcard some* to expand to the two jobs created above and have non-null values (meaning they exist)
         val map = response.asMap()
-        assertNotNull("Non null wildcard_some_id value wasn't in the response", map["wildcard_some_id"])
-        assertNotNull("Non null wildcard_some_other_id value wasn't in the response", map["wildcard_some_other_id"])
+        assertNotNull("Non null wildcard_some_transform_id value wasn't in the response", map["wildcard_some_transform_id"])
+        assertNotNull("Non null wildcard_some_other_transform_id value wasn't in the response", map["wildcard_some_other_transform_id"])
     }
 
     @Throws(Exception::class)
     fun `test explain transform for job that hasnt started`() {
-        createTransform(transform = randomTransform().copy(metadataId = null), transformId = "not_started_some_id")
-        val response = client().makeRequest("GET", "$TRANSFORM_BASE_URI/not_started_some_id/_explain")
-        val expectedMap = mapOf("not_started_some_id" to mapOf("metadata_id" to null, "transform_metadata" to null))
+        createTransform(transform = randomTransform().copy(metadataId = null), transformId = "not_started_some_transform_id")
+        val response = client().makeRequest("GET", "$TRANSFORM_BASE_URI/not_started_some_transform_id/_explain")
+        val expectedMap = mapOf("not_started_some_transform_id" to mapOf("metadata_id" to null, "transform_metadata" to null))
         assertEquals("The explain response did not match expected", expectedMap, response.asMap())
     }
 
     @Throws(Exception::class)
     fun `test explain transform for new transform attempted to create with metadata id`() {
-        createTransform(transform = randomTransform().copy(metadataId = "some_metadata_id"), transformId = "no_meta_some_id")
-        val response = client().makeRequest("GET", "$TRANSFORM_BASE_URI/no_meta_some_id/_explain")
-        val expectedMap = mapOf("no_meta_some_id" to mapOf("metadata_id" to null, "transform_metadata" to null))
+        createTransform(transform = randomTransform().copy(metadataId = "some_metadata_id"), transformId = "no_meta_some_transform_id")
+        val response = client().makeRequest("GET", "$TRANSFORM_BASE_URI/no_meta_some_transform_id/_explain")
+        val expectedMap = mapOf("no_meta_some_transform_id" to mapOf("metadata_id" to null, "transform_metadata" to null))
         assertEquals("The explain response did not match expected", expectedMap, response.asMap())
     }
 

--- a/src/test/kotlin/org/opensearch/indexmanagement/transform/resthandler/RestStartTransformActionIT.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/transform/resthandler/RestStartTransformActionIT.kt
@@ -78,7 +78,7 @@ class RestStartTransformActionIT : TransformRestTestCase() {
     @Throws(Exception::class)
     fun `test starting a failed transform`() {
         val transform = randomTransform().copy(
-            id = "restart_failed_rollup",
+            id = "restart_failed_transform",
             schemaVersion = 1L,
             enabled = true,
             jobSchedule = IntervalSchedule(Instant.now(), 1, ChronoUnit.MINUTES),
@@ -144,7 +144,7 @@ class RestStartTransformActionIT : TransformRestTestCase() {
         generateNYCTaxiData("source_restart_finished_transform")
         assertIndexExists("source_restart_finished_transform")
         val transform = randomTransform().copy(
-            id = "restart_finished_rollup",
+            id = "restart_finished_transform",
             schemaVersion = 1L,
             enabled = true,
             jobSchedule = IntervalSchedule(Instant.now(), 1, ChronoUnit.MINUTES),


### PR DESCRIPTION
Signed-off-by: Robert Downs <downsrob@amazon.com>

*Issue #, if available:*
NA
*Description of changes:*

- RestExplainRollupActionIT and RestExplainTransformActionIT were using the same ids for the generated rollups and transforms in the integration test, so if one of the integration test classes ran after the other without the config index being cleaned up in between, there would be a version conflict engine exception error.

- added a sleep to RestStartRollupActionIT and RestStopRollupActionIT after the multi shard index is created, as I saw a flaky failure where updateRollupStartTime wasn't picked up by the job scheduler after this index was created

Example error:
```
org.opensearch.indexmanagement.rollup.resthandler.RestExplainRollupActionIT > test explain rollup for nonexistent id FAILED
    org.opensearch.client.ResponseException: method [PUT], host [http://127.0.0.1:40959], URI [/_plugins/_rollup/jobs/doesnt_exist_some_other_id?refresh=true], status line [HTTP/1.1 409 Conflict]
    {"error":{"root_cause":[{"type":"version_conflict_engine_exception","reason":"[doesnt_exist_some_other_id]: version conflict, document already exists (current version [1])","index":".opendistro-ism-config","shard":"0","index_uuid":"5h55veaiSGiqOItIjYQIFg"}],"type":"version_conflict_engine_exception","reason":"[doesnt_exist_some_other_id]: version conflict, document already exists (current version [1])","index":".opendistro-ism-config","shard":"0","index_uuid":"5h55veaiSGiqOItIjYQIFg"},"status":409}
        at __randomizedtesting.SeedInfo.seed([AFE34FA586EDDCD9:7160312F0325F871]:0)
        at org.opensearch.client.RestClient.convertResponse(RestClient.java:344)
        at org.opensearch.client.RestClient.performRequest(RestClient.java:314)
        at org.opensearch.client.RestClient.performRequest(RestClient.java:289)
        at org.opensearch.indexmanagement.TestHelpersKt.makeRequest(TestHelpers.kt:85)
        at org.opensearch.indexmanagement.TestHelpersKt.makeRequest$default(TestHelpers.kt:74)
        at org.opensearch.indexmanagement.rollup.RollupRestTestCase.createRollupJson(RollupRestTestCase.kt:72)
        at org.opensearch.indexmanagement.rollup.RollupRestTestCase.createRollup(RollupRestTestCase.kt:52)
        at org.opensearch.indexmanagement.rollup.RollupRestTestCase.createRollup$default(RollupRestTestCase.kt:50)
        at org.opensearch.indexmanagement.rollup.resthandler.RestExplainRollupActionIT.test explain rollup for nonexistent id(RestExplainRollupActionIT.kt:71)
REPRODUCE WITH: ./gradlew ':integTest' --tests "org.opensearch.indexmanagement.rollup.resthandler.RestExplainRollupActionIT.test explain rollup for nonexistent id" -Dtests.seed=AFE34FA586EDDCD9 -Dtests.security.manager=false -Dtests.locale=ro -Dtests.timezone=Africa/Casablanca -Druntime.java=14
```
Seen in [this CI run](https://github.com/opensearch-project/index-management/runs/4809383475?check_suite_focus=true).

*CheckList:*
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/index-management/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
