### PR TITLE
Adds workaround repositories block to resolve missing jcenter dependency

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -3,4 +3,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+pluginManagement {
+    repositories {
+        mavenCentral()
+        gradlePluginPortal()
+    }
+}
+
 rootProject.name = 'opensearch-index-management'


### PR DESCRIPTION
Signed-off-by: Robert Downs <downsrob@amazon.com>

*Issue #, if available:*
https://github.com/opensearch-project/opensearch-build/issues/1456
*Description of changes:*
The 1.0.0-RC15 version of detekt used by index management depends on com.beust:jcommander:1.74, which detekt tried to pull from jcenter. As per the opensearch-build issue linked above, a workaround is to define a repositories block at the top of the settings.gradle file that allows us to control the order and first search in maven central.

*CheckList:*
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/index-management/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
