### PR TITLE
Upgrades detekt version, fixes flaky tests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,7 +30,7 @@ buildscript {
         classpath "org.opensearch.gradle:build-tools:${opensearch_version}"
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:${kotlin_version}"
         classpath "org.jetbrains.kotlin:kotlin-allopen:${kotlin_version}"
-        classpath "io.gitlab.arturbosch.detekt:detekt-gradle-plugin:1.0.0-RC15"
+        classpath "io.gitlab.arturbosch.detekt:detekt-gradle-plugin:1.17.1"
         classpath "org.jacoco:org.jacoco.agent:0.8.5"
     }
 }

--- a/detekt.yml
+++ b/detekt.yml
@@ -1,8 +1,11 @@
-failFast: false
-
 # TODO: Remove this before initial release, only for developmental purposes
+build:
+  maxIssues: 10
+
 exceptions:
   TooGenericExceptionCaught:
+    active: false
+  SwallowedException: # Detekt fails to pick up the logger, and produces too many false positives for this rule
     active: false
 
 style:
@@ -10,3 +13,12 @@ style:
     active: false
   MaxLineLength:
     maxLineLength: 150
+    excludes: ['**/test/**']
+
+complexity:
+  LargeClass:
+    excludes: ['**/test/**']
+  LongMethod:
+    excludes: ['**/test/**']
+  LongParameterList:
+    excludes: ['**/test/**']

--- a/src/main/kotlin/org/opensearch/indexmanagement/IndexManagementPlugin.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/IndexManagementPlugin.kt
@@ -455,15 +455,15 @@ class IndexManagementPlugin : JobSchedulerExtension, NetworkPlugin, ActionPlugin
 class GuiceHolder @Inject constructor(
     remoteClusterService: TransportService
 ) : LifecycleComponent {
-    override fun close() {}
+    override fun close() { /* do nothing */ }
     override fun lifecycleState(): Lifecycle.State? {
         return null
     }
 
-    override fun addLifecycleListener(listener: LifecycleListener) {}
-    override fun removeLifecycleListener(listener: LifecycleListener) {}
-    override fun start() {}
-    override fun stop() {}
+    override fun addLifecycleListener(listener: LifecycleListener) { /* do nothing */ }
+    override fun removeLifecycleListener(listener: LifecycleListener) { /* do nothing */ }
+    override fun start() { /* do nothing */ }
+    override fun stop() { /* do nothing */ }
 
     companion object {
         lateinit var remoteClusterService: RemoteClusterService

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/IndexStateManagementHistory.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/IndexStateManagementHistory.kt
@@ -186,7 +186,7 @@ class IndexStateManagementHistory(
     }
 
     private fun getIndicesToDelete(clusterStateResponse: ClusterStateResponse): List<String> {
-        var indicesToDelete = mutableListOf<String>()
+        val indicesToDelete = mutableListOf<String>()
         for (entry in clusterStateResponse.state.metadata.indices()) {
             val indexMetaData = entry.value
             val creationTime = indexMetaData.creationDate

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/ManagedIndexCoordinator.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/ManagedIndexCoordinator.kt
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-@file:Suppress("ReturnCount")
 package org.opensearch.indexmanagement.indexstatemanagement
 
 import kotlinx.coroutines.CoroutineName
@@ -98,7 +97,7 @@ import org.opensearch.threadpool.ThreadPool
  * a user wants to update an existing [ManagedIndexConfig] to a new policy (or updated version of policy)
  * then they must use the ChangePolicy API.
  */
-@Suppress("TooManyFunctions")
+@Suppress("TooManyFunctions", "ReturnCount", "NestedBlockDepth", "LongParameterList")
 @OpenForTesting
 class ManagedIndexCoordinator(
     private val settings: Settings,

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/model/ISMTemplate.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/model/ISMTemplate.kt
@@ -5,7 +5,6 @@
 
 package org.opensearch.indexmanagement.indexstatemanagement.model
 
-import org.apache.logging.log4j.LogManager
 import org.opensearch.common.io.stream.StreamInput
 import org.opensearch.common.io.stream.StreamOutput
 import org.opensearch.common.io.stream.Writeable
@@ -20,8 +19,6 @@ import org.opensearch.indexmanagement.opensearchapi.optionalTimeField
 import java.io.IOException
 import java.lang.IllegalArgumentException
 import java.time.Instant
-
-private val log = LogManager.getLogger(ISMTemplate::class.java)
 
 data class ISMTemplate(
     val indexPatterns: List<String>,

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/model/coordinator/SweptManagedIndexConfig.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/model/coordinator/SweptManagedIndexConfig.kt
@@ -31,7 +31,7 @@ data class SweptManagedIndexConfig(
 ) {
 
     companion object {
-        @Suppress("ComplexMethod")
+        @Suppress("ComplexMethod", "UnusedPrivateMember")
         @JvmStatic
         @Throws(IOException::class)
         fun parse(xcp: XContentParser, id: String = NO_ID, seqNo: Long, primaryTerm: Long): SweptManagedIndexConfig {

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/resthandler/RestChangePolicyAction.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/resthandler/RestChangePolicyAction.kt
@@ -5,7 +5,6 @@
 
 package org.opensearch.indexmanagement.indexstatemanagement.resthandler
 
-import org.apache.logging.log4j.LogManager
 import org.opensearch.client.node.NodeClient
 import org.opensearch.common.Strings
 import org.opensearch.common.xcontent.XContentParser.Token
@@ -25,8 +24,6 @@ import org.opensearch.rest.action.RestToXContentListener
 import java.io.IOException
 
 class RestChangePolicyAction : BaseRestHandler() {
-
-    private val log = LogManager.getLogger(javaClass)
 
     override fun routes(): List<Route> {
         return emptyList()

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/resthandler/RestIndexPolicyAction.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/resthandler/RestIndexPolicyAction.kt
@@ -5,7 +5,6 @@
 
 package org.opensearch.indexmanagement.indexstatemanagement.resthandler
 
-import org.apache.logging.log4j.LogManager
 import org.opensearch.action.support.WriteRequest
 import org.opensearch.client.node.NodeClient
 import org.opensearch.cluster.service.ClusterService
@@ -35,8 +34,6 @@ import org.opensearch.rest.RestStatus
 import org.opensearch.rest.action.RestResponseListener
 import java.io.IOException
 import java.time.Instant
-
-private val log = LogManager.getLogger(RestIndexPolicyAction::class.java)
 
 class RestIndexPolicyAction(
     settings: Settings,

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/resthandler/RestRetryFailedManagedIndexAction.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/resthandler/RestRetryFailedManagedIndexAction.kt
@@ -5,7 +5,6 @@
 
 package org.opensearch.indexmanagement.indexstatemanagement.resthandler
 
-import org.apache.logging.log4j.LogManager
 import org.opensearch.action.support.master.MasterNodeRequest.DEFAULT_MASTER_NODE_TIMEOUT
 import org.opensearch.client.node.NodeClient
 import org.opensearch.common.Strings
@@ -23,8 +22,6 @@ import org.opensearch.rest.RestRequest.Method.POST
 import org.opensearch.rest.action.RestToXContentListener
 
 class RestRetryFailedManagedIndexAction : BaseRestHandler() {
-
-    private val log = LogManager.getLogger(javaClass)
 
     override fun routes(): List<Route> {
         return emptyList()

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/settings/LegacyOpenDistroManagedIndexSettings.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/settings/LegacyOpenDistroManagedIndexSettings.kt
@@ -11,6 +11,7 @@ import org.opensearch.indexmanagement.indexstatemanagement.ISMActionsParser
 import java.util.concurrent.TimeUnit
 import java.util.function.Function
 
+@Suppress("UtilityClassWithPublicConstructor")
 class LegacyOpenDistroManagedIndexSettings {
     companion object {
         const val DEFAULT_ISM_ENABLED = true

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/settings/ManagedIndexSettings.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/settings/ManagedIndexSettings.kt
@@ -9,6 +9,7 @@ import org.opensearch.common.settings.Setting
 import org.opensearch.common.unit.TimeValue
 import java.util.function.Function
 
+@Suppress("UtilityClassWithPublicConstructor")
 class ManagedIndexSettings {
     companion object {
         const val DEFAULT_ISM_ENABLED = true

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/allocation/AttemptAllocationStep.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/allocation/AttemptAllocationStep.kt
@@ -8,6 +8,8 @@ package org.opensearch.indexmanagement.indexstatemanagement.step.allocation
 import org.opensearch.indexmanagement.spi.indexstatemanagement.Step
 import org.opensearch.indexmanagement.spi.indexstatemanagement.model.ManagedIndexMetaData
 
+// TODO remove this suppression when refactoring is done
+@Suppress("UnusedPrivateMember", "FunctionOnlyReturningConstant")
 class AttemptAllocationStep : Step(name) {
 
     override suspend fun execute(): Step {

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/forcemerge/AttemptCallForceMergeStep.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/forcemerge/AttemptCallForceMergeStep.kt
@@ -8,6 +8,8 @@ package org.opensearch.indexmanagement.indexstatemanagement.step.forcemerge
 import org.opensearch.indexmanagement.spi.indexstatemanagement.Step
 import org.opensearch.indexmanagement.spi.indexstatemanagement.model.ManagedIndexMetaData
 
+// TODO remove this suppression when refactoring is done
+@Suppress("UnusedPrivateMember", "FunctionOnlyReturningConstant")
 class AttemptCallForceMergeStep : Step(name) {
 
     override suspend fun execute(): Step {

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/forcemerge/AttemptSetReadOnlyStep.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/forcemerge/AttemptSetReadOnlyStep.kt
@@ -8,6 +8,8 @@ package org.opensearch.indexmanagement.indexstatemanagement.step.forcemerge
 import org.opensearch.indexmanagement.spi.indexstatemanagement.Step
 import org.opensearch.indexmanagement.spi.indexstatemanagement.model.ManagedIndexMetaData
 
+// TODO remove this suppression when refactoring is done
+@Suppress("UnusedPrivateMember", "FunctionOnlyReturningConstant")
 class AttemptSetReadOnlyStep : Step(name) {
 
     override suspend fun execute(): Step {

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/forcemerge/WaitForForceMergeStep.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/forcemerge/WaitForForceMergeStep.kt
@@ -8,6 +8,8 @@ package org.opensearch.indexmanagement.indexstatemanagement.step.forcemerge
 import org.opensearch.indexmanagement.spi.indexstatemanagement.Step
 import org.opensearch.indexmanagement.spi.indexstatemanagement.model.ManagedIndexMetaData
 
+// TODO remove this suppression when refactoring is done
+@Suppress("UnusedPrivateMember", "FunctionOnlyReturningConstant")
 class WaitForForceMergeStep : Step(name) {
 
     override suspend fun execute(): Step {

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/rollup/WaitForRollupCompletionStep.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/rollup/WaitForRollupCompletionStep.kt
@@ -83,7 +83,7 @@ class WaitForRollupCompletionStep : Step(name) {
             RollupMetadata.Status.STOPPED -> {
                 stepStatus = StepStatus.FAILED
                 hasRollupFailed = true
-                info = mapOf("message" to getJobFailedMessage(rollupJobId, indexName), "cause" to getJobStoppedMessage())
+                info = mapOf("message" to getJobFailedMessage(rollupJobId, indexName), "cause" to JOB_STOPPED_MESSAGE)
             }
         }
     }
@@ -117,11 +117,11 @@ class WaitForRollupCompletionStep : Step(name) {
 
     companion object {
         const val name = "wait_for_rollup_completion"
+        const val JOB_STOPPED_MESSAGE = "Rollup job was stopped"
         fun getFailedMessage(rollupJob: String, index: String) = "Failed to get the status of rollup job [$rollupJob] [index=$index]"
         fun getJobProcessingMessage(rollupJob: String, index: String) = "Rollup job [$rollupJob] is still processing [index=$index]"
         fun getJobCompletionMessage(rollupJob: String, index: String) = "Rollup job [$rollupJob] completed [index=$index]"
         fun getJobFailedMessage(rollupJob: String, index: String) = "Rollup job [$rollupJob] failed [index=$index]"
-        fun getJobStoppedMessage() = "Rollup job was stopped"
         fun getMissingRollupJobMessage(index: String) = "Rollup job was not found [index=$index]"
     }
 }

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/snapshot/AttemptSnapshotStep.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/snapshot/AttemptSnapshotStep.kt
@@ -8,6 +8,8 @@ package org.opensearch.indexmanagement.indexstatemanagement.step.snapshot
 import org.opensearch.indexmanagement.spi.indexstatemanagement.Step
 import org.opensearch.indexmanagement.spi.indexstatemanagement.model.ManagedIndexMetaData
 
+// TODO remove this suppression when refactoring is done
+@Suppress("UnusedPrivateMember", "FunctionOnlyReturningConstant")
 class AttemptSnapshotStep : Step(name) {
 
     override suspend fun execute(): Step {

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/snapshot/WaitForSnapshotStep.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/snapshot/WaitForSnapshotStep.kt
@@ -8,6 +8,8 @@ package org.opensearch.indexmanagement.indexstatemanagement.step.snapshot
 import org.opensearch.indexmanagement.spi.indexstatemanagement.Step
 import org.opensearch.indexmanagement.spi.indexstatemanagement.model.ManagedIndexMetaData
 
+// TODO remove this suppression when refactoring is done
+@Suppress("UnusedPrivateMember", "FunctionOnlyReturningConstant")
 class WaitForSnapshotStep : Step(name) {
 
     override suspend fun execute(): Step {

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/transport/action/addpolicy/TransportAddPolicyAction.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/transport/action/addpolicy/TransportAddPolicyAction.kt
@@ -73,7 +73,7 @@ import java.time.Instant
 
 private val log = LogManager.getLogger(TransportAddPolicyAction::class.java)
 
-@Suppress("SpreadOperator", "ReturnCount")
+@Suppress("SpreadOperator", "ReturnCount", "LongParameterList")
 class TransportAddPolicyAction @Inject constructor(
     val client: NodeClient,
     transportService: TransportService,

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/transport/action/indexpolicy/TransportIndexPolicyAction.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/transport/action/indexpolicy/TransportIndexPolicyAction.kt
@@ -49,6 +49,7 @@ import org.opensearch.transport.TransportService
 
 private val log = LogManager.getLogger(TransportIndexPolicyAction::class.java)
 
+@Suppress("LongParameterList")
 class TransportIndexPolicyAction @Inject constructor(
     val client: NodeClient,
     transportService: TransportService,

--- a/src/main/kotlin/org/opensearch/indexmanagement/refreshanalyzer/RefreshSearchAnalyzerResponse.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/refreshanalyzer/RefreshSearchAnalyzerResponse.kt
@@ -60,8 +60,8 @@ class RefreshSearchAnalyzerResponse : BroadcastResponse {
 
     // TODO: restrict it for testing
     fun getSuccessfulRefreshDetails(): MutableMap<String, List<String>> {
-        var successfulRefreshDetails: MutableMap<String, List<String>> = HashMap()
-        var failedIndices = mutableSetOf<String>()
+        val successfulRefreshDetails: MutableMap<String, List<String>> = HashMap()
+        val failedIndices = mutableSetOf<String>()
         for (failure in shardFailures) {
             failedIndices.add(failure.index()!!)
         }

--- a/src/main/kotlin/org/opensearch/indexmanagement/rollup/RollupIndexer.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/rollup/RollupIndexer.kt
@@ -58,7 +58,7 @@ class RollupIndexer(
         try {
             var requestsToRetry = convertResponseToRequests(rollup, internalComposite)
             var stats = RollupStats(0, 0, requestsToRetry.size.toLong(), 0, 0)
-            var nonRetryableFailures = mutableListOf<BulkItemResponse>()
+            val nonRetryableFailures = mutableListOf<BulkItemResponse>()
             if (requestsToRetry.isNotEmpty()) {
                 retryIngestPolicy.retry(logger, listOf(RestStatus.TOO_MANY_REQUESTS)) {
                     if (it.seconds >= (Rollup.ROLLUP_LOCK_DURATION_SECONDS / 2)) {

--- a/src/main/kotlin/org/opensearch/indexmanagement/rollup/action/explain/ExplainRollupResponse.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/rollup/action/explain/ExplainRollupResponse.kt
@@ -30,7 +30,7 @@ class ExplainRollupResponse : ActionResponse, ToXContentObject {
         idsToExplain = sin.let {
             val idsToExplain = mutableMapOf<String, ExplainRollup?>()
             val size = it.readVInt()
-            for (i in 0 until size) {
+            repeat(size) { _ ->
                 idsToExplain[it.readString()] = if (sin.readBoolean()) ExplainRollup(it) else null
             }
             idsToExplain.toMap()

--- a/src/main/kotlin/org/opensearch/indexmanagement/rollup/action/index/TransportIndexRollupAction.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/rollup/action/index/TransportIndexRollupAction.kt
@@ -38,6 +38,7 @@ import org.opensearch.tasks.Task
 import org.opensearch.transport.TransportService
 
 // TODO: Field and mappings validations of source and target index, i.e. reject a histogram agg on example_field if its not possible
+@Suppress("LongParameterList")
 class TransportIndexRollupAction @Inject constructor(
     transportService: TransportService,
     val client: Client,

--- a/src/main/kotlin/org/opensearch/indexmanagement/rollup/model/ISMRollup.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/rollup/model/ISMRollup.kt
@@ -92,7 +92,7 @@ data class ISMRollup(
         dimensions = sin.let {
             val dimensionsList = mutableListOf<Dimension>()
             val size = it.readVInt()
-            for (i in 0 until size) {
+            repeat(size) { _ ->
                 val type = it.readEnum(Dimension.Type::class.java)
                 dimensionsList.add(
                     when (requireNotNull(type) { "Dimension type cannot be null" }) {

--- a/src/main/kotlin/org/opensearch/indexmanagement/rollup/model/Rollup.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/rollup/model/Rollup.kt
@@ -134,7 +134,7 @@ data class Rollup(
         dimensions = sin.let {
             val dimensionsList = mutableListOf<Dimension>()
             val size = it.readVInt()
-            for (i in 0 until size) {
+            repeat(size) { _ ->
                 val type = it.readEnum(Dimension.Type::class.java)
                 dimensionsList.add(
                     when (requireNotNull(type) { "Dimension type cannot be null" }) {

--- a/src/main/kotlin/org/opensearch/indexmanagement/rollup/model/RollupMetrics.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/rollup/model/RollupMetrics.kt
@@ -5,7 +5,6 @@
 
 package org.opensearch.indexmanagement.rollup.model
 
-import org.apache.logging.log4j.LogManager
 import org.opensearch.common.io.stream.StreamInput
 import org.opensearch.common.io.stream.StreamOutput
 import org.opensearch.common.io.stream.Writeable
@@ -29,8 +28,6 @@ data class RollupMetrics(
     val metrics: List<Metric>
 ) : ToXContentObject, Writeable {
 
-    private val logger = LogManager.getLogger(javaClass)
-
     init {
         require(metrics.size == metrics.distinctBy { it.type }.size) {
             "Cannot have multiple metrics of the same type in a single rollup metric [$metrics]"
@@ -46,7 +43,7 @@ data class RollupMetrics(
         metrics = sin.let {
             val metricsList = mutableListOf<Metric>()
             val size = it.readVInt()
-            for (i in 0 until size) {
+            repeat(size) { _ ->
                 val type = it.readEnum(Metric.Type::class.java)
                 metricsList.add(
                     when (requireNotNull(type) { "Metric type cannot be null" }) {

--- a/src/main/kotlin/org/opensearch/indexmanagement/rollup/model/metric/Average.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/rollup/model/metric/Average.kt
@@ -14,13 +14,15 @@ import org.opensearch.common.xcontent.XContentParser.Token
 import org.opensearch.common.xcontent.XContentParserUtils.ensureExpectedToken
 
 class Average() : Metric(Type.AVERAGE) {
+
+    @Suppress("UnusedPrivateMember")
     constructor(sin: StreamInput) : this()
 
     override fun toXContent(builder: XContentBuilder, params: ToXContent.Params): XContentBuilder {
         return builder.startObject().startObject(Type.AVERAGE.type).endObject().endObject()
     }
 
-    override fun writeTo(out: StreamOutput) {} // nothing to write
+    override fun writeTo(out: StreamOutput) { /* nothing to write */ }
 
     override fun equals(other: Any?): Boolean {
         if (this === other) return true

--- a/src/main/kotlin/org/opensearch/indexmanagement/rollup/model/metric/Max.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/rollup/model/metric/Max.kt
@@ -14,13 +14,14 @@ import org.opensearch.common.xcontent.XContentParser.Token
 import org.opensearch.common.xcontent.XContentParserUtils.ensureExpectedToken
 
 class Max() : Metric(Type.MAX) {
+    @Suppress("UnusedPrivateMember")
     constructor(sin: StreamInput) : this()
 
     override fun toXContent(builder: XContentBuilder, params: ToXContent.Params): XContentBuilder {
         return builder.startObject().startObject(Type.MAX.type).endObject().endObject()
     }
 
-    override fun writeTo(out: StreamOutput) {} // nothing to write
+    override fun writeTo(out: StreamOutput) { /* nothing to write */ }
 
     override fun equals(other: Any?): Boolean {
         if (this === other) return true

--- a/src/main/kotlin/org/opensearch/indexmanagement/rollup/model/metric/Min.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/rollup/model/metric/Min.kt
@@ -14,13 +14,14 @@ import org.opensearch.common.xcontent.XContentParser.Token
 import org.opensearch.common.xcontent.XContentParserUtils.ensureExpectedToken
 
 class Min() : Metric(Type.MIN) {
+    @Suppress("UnusedPrivateMember")
     constructor(sin: StreamInput) : this()
 
     override fun toXContent(builder: XContentBuilder, params: ToXContent.Params): XContentBuilder {
         return builder.startObject().startObject(Type.MIN.type).endObject().endObject()
     }
 
-    override fun writeTo(out: StreamOutput) {} // nothing to write
+    override fun writeTo(out: StreamOutput) { /* nothing to write */ }
 
     override fun equals(other: Any?): Boolean {
         if (this === other) return true

--- a/src/main/kotlin/org/opensearch/indexmanagement/rollup/model/metric/Sum.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/rollup/model/metric/Sum.kt
@@ -14,13 +14,14 @@ import org.opensearch.common.xcontent.XContentParser.Token
 import org.opensearch.common.xcontent.XContentParserUtils.ensureExpectedToken
 
 class Sum() : Metric(Type.SUM) {
+    @Suppress("UnusedPrivateMember")
     constructor(sin: StreamInput) : this()
 
     override fun toXContent(builder: XContentBuilder, params: ToXContent.Params): XContentBuilder {
         return builder.startObject().startObject(Type.SUM.type).endObject().endObject()
     }
 
-    override fun writeTo(out: StreamOutput) {} // nothing to write
+    override fun writeTo(out: StreamOutput) { /* nothing to write */ }
 
     override fun equals(other: Any?): Boolean {
         if (this === other) return true

--- a/src/main/kotlin/org/opensearch/indexmanagement/rollup/model/metric/ValueCount.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/rollup/model/metric/ValueCount.kt
@@ -14,13 +14,14 @@ import org.opensearch.common.xcontent.XContentParser.Token
 import org.opensearch.common.xcontent.XContentParserUtils.ensureExpectedToken
 
 class ValueCount() : Metric(Type.VALUE_COUNT) {
+    @Suppress("UnusedPrivateMember")
     constructor(sin: StreamInput) : this()
 
     override fun toXContent(builder: XContentBuilder, params: ToXContent.Params): XContentBuilder {
         return builder.startObject().startObject(Type.VALUE_COUNT.type).endObject().endObject()
     }
 
-    override fun writeTo(out: StreamOutput) {} // nothing to write
+    override fun writeTo(out: StreamOutput) { /* nothing to write */ }
 
     override fun equals(other: Any?): Boolean {
         if (this === other) return true

--- a/src/main/kotlin/org/opensearch/indexmanagement/rollup/settings/LegacyOpenDistroRollupSettings.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/rollup/settings/LegacyOpenDistroRollupSettings.kt
@@ -8,6 +8,7 @@ package org.opensearch.indexmanagement.rollup.settings
 import org.opensearch.common.settings.Setting
 import org.opensearch.common.unit.TimeValue
 
+@Suppress("UtilityClassWithPublicConstructor")
 class LegacyOpenDistroRollupSettings {
 
     companion object {

--- a/src/main/kotlin/org/opensearch/indexmanagement/rollup/settings/RollupSettings.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/rollup/settings/RollupSettings.kt
@@ -8,6 +8,7 @@ package org.opensearch.indexmanagement.rollup.settings
 import org.opensearch.common.settings.Setting
 import org.opensearch.common.unit.TimeValue
 
+@Suppress("UtilityClassWithPublicConstructor")
 class RollupSettings {
 
     companion object {

--- a/src/main/kotlin/org/opensearch/indexmanagement/settings/IndexManagementSettings.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/settings/IndexManagementSettings.kt
@@ -6,6 +6,7 @@ package org.opensearch.indexmanagement.settings
 
 import org.opensearch.common.settings.Setting
 
+@Suppress("UtilityClassWithPublicConstructor")
 class IndexManagementSettings {
 
     companion object {

--- a/src/main/kotlin/org/opensearch/indexmanagement/transform/TransformIndexer.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/transform/TransformIndexer.kt
@@ -67,11 +67,11 @@ class TransformIndexer(
         }
     }
 
-    @Suppress("ThrowsCount")
+    @Suppress("ThrowsCount", "RethrowCaughtException")
     suspend fun index(docsToIndex: List<DocWriteRequest<*>>): Long {
         var updatableDocsToIndex = docsToIndex
         var indexTimeInMillis = 0L
-        var nonRetryableFailures = mutableListOf<BulkItemResponse>()
+        val nonRetryableFailures = mutableListOf<BulkItemResponse>()
         try {
             if (updatableDocsToIndex.isNotEmpty()) {
                 val targetIndex = updatableDocsToIndex.first().index()

--- a/src/main/kotlin/org/opensearch/indexmanagement/transform/TransformSearchService.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/transform/TransformSearchService.kt
@@ -64,6 +64,7 @@ class TransformSearchService(
         }
     }
 
+    @Suppress("RethrowCaughtException")
     suspend fun executeCompositeSearch(transform: Transform, afterKey: Map<String, Any>? = null): TransformSearchResult {
         val errorMessage = "Failed to search data in source indices"
         try {

--- a/src/main/kotlin/org/opensearch/indexmanagement/transform/action/explain/ExplainTransformResponse.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/transform/action/explain/ExplainTransformResponse.kt
@@ -25,7 +25,7 @@ class ExplainTransformResponse(val idsToExplain: Map<String, ExplainTransform?>)
         idsToExplain = sin.let {
             val idsToExplain = mutableMapOf<String, ExplainTransform?>()
             val size = it.readVInt()
-            for (i in 0 until size) {
+            repeat(size) { _ ->
                 idsToExplain[it.readString()] = if (sin.readBoolean()) ExplainTransform(it) else null
             }
             idsToExplain.toMap()

--- a/src/main/kotlin/org/opensearch/indexmanagement/transform/action/index/TransportIndexTransformAction.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/transform/action/index/TransportIndexTransformAction.kt
@@ -43,7 +43,7 @@ import org.opensearch.rest.RestStatus
 import org.opensearch.tasks.Task
 import org.opensearch.transport.TransportService
 
-@Suppress("SpreadOperator")
+@Suppress("SpreadOperator", "LongParameterList")
 class TransportIndexTransformAction @Inject constructor(
     transportService: TransportService,
     val client: Client,

--- a/src/main/kotlin/org/opensearch/indexmanagement/transform/action/preview/PreviewTransformResponse.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/transform/action/preview/PreviewTransformResponse.kt
@@ -22,7 +22,7 @@ class PreviewTransformResponse(
         documents = sin.let {
             val documentList = mutableListOf<Map<String, Any>>()
             val size = it.readVInt()
-            for (i in 0 until size) {
+            repeat(size) { _ ->
                 documentList.add(sin.readMap()!!)
             }
             documentList.toList()

--- a/src/main/kotlin/org/opensearch/indexmanagement/transform/model/Transform.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/transform/model/Transform.kt
@@ -187,7 +187,7 @@ data class Transform(
         groups = sin.let {
             val dimensionList = mutableListOf<Dimension>()
             val size = it.readVInt()
-            for (i in 0 until size) {
+            repeat(size) { _ ->
                 val type = it.readEnum(Dimension.Type::class.java)
                 dimensionList.add(
                     when (requireNotNull(type) { "Dimension type cannot be null" }) {

--- a/src/main/kotlin/org/opensearch/indexmanagement/transform/settings/TransformSettings.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/transform/settings/TransformSettings.kt
@@ -8,6 +8,7 @@ package org.opensearch.indexmanagement.transform.settings
 import org.opensearch.common.settings.Setting
 import org.opensearch.common.unit.TimeValue
 
+@Suppress("UtilityClassWithPublicConstructor")
 class TransformSettings {
 
     companion object {

--- a/src/main/kotlin/org/opensearch/indexmanagement/util/IndexUtils.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/util/IndexUtils.kt
@@ -23,6 +23,7 @@ import org.opensearch.indexmanagement.IndexManagementPlugin
 import java.nio.ByteBuffer
 import java.util.Base64
 
+@Suppress("UtilityClassWithPublicConstructor")
 class IndexUtils {
     companion object {
         @Suppress("ObjectPropertyNaming")

--- a/src/main/kotlin/org/opensearch/indexmanagement/util/SecurityUtils.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/util/SecurityUtils.kt
@@ -15,7 +15,7 @@ import org.opensearch.index.query.ExistsQueryBuilder
 import org.opensearch.index.query.TermsQueryBuilder
 import org.opensearch.rest.RestStatus
 
-@Suppress("ReturnCount")
+@Suppress("ReturnCount", "UtilityClassWithPublicConstructor")
 class SecurityUtils {
     companion object {
         const val INTERNAL_REQUEST = "index_management_plugin_internal_user"
@@ -69,6 +69,7 @@ class SecurityUtils {
         /**
          * Check if the requested user has permission on the resource
          */
+        @Suppress("LongParameterList")
         fun <T> userHasPermissionForResource(
             requestedUser: User?,
             resourceUser: User?,

--- a/src/test/kotlin/org/opensearch/indexmanagement/IndexManagementRestTestCase.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/IndexManagementRestTestCase.kt
@@ -90,6 +90,8 @@ abstract class IndexManagementRestTestCase : ODFERestTestCase() {
      * Inserts [docCount] sample documents into [index], optionally waiting [delay] milliseconds
      * in between each insertion
      */
+    // TODO remove this suppression when refactoring is done
+    @Suppress("UnusedPrivateMember")
     protected fun insertSampleData(index: String, docCount: Int, delay: Long = 0, jsonString: String = "{ \"test_field\": \"test_value\" }") {
         for (i in 1..docCount) {
             val request = Request("POST", "/$index/_doc/?refresh=true")

--- a/src/test/kotlin/org/opensearch/indexmanagement/TestHelpers.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/TestHelpers.kt
@@ -48,7 +48,7 @@ fun randomSchedule(): Schedule = if (OpenSearchRestTestCase.randomBoolean()) ran
 
 private fun randomStringList(): List<String> {
     val data = mutableListOf<String>()
-    for (i in 1..OpenSearchRestTestCase.randomIntBetween(10, 10)) {
+    repeat(OpenSearchRestTestCase.randomIntBetween(1, 10)) {
         data.add(OpenSearchRestTestCase.randomAlphaOfLength(10))
     }
 

--- a/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/IndexStateManagementRestTestCase.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/IndexStateManagementRestTestCase.kt
@@ -428,7 +428,7 @@ abstract class IndexStateManagementRestTestCase : IndexManagementRestTestCase() 
     }
 
     // Validate segment count per shard by specifying the min and max it should be
-    @Suppress("UNCHECKED_CAST")
+    @Suppress("UNCHECKED_CAST", "ReturnCount")
     protected fun validateSegmentCount(index: String, min: Int? = null, max: Int? = null): Boolean {
         if (min == null && max == null) throw IllegalArgumentException("Must provide at least a min or max")
         val statsResponse: Map<String, Any> = getShardSegmentStats(index)
@@ -566,6 +566,7 @@ abstract class IndexStateManagementRestTestCase : IndexManagementRestTestCase() 
 
     // Calls explain API for a single concrete index and converts the response into a ManagedIndexMetaData
     // This only works for indices with a ManagedIndexMetaData that has been initialized
+    @Suppress("LoopWithTooManyJumpStatements")
     protected fun getExplainManagedIndexMetaData(indexName: String): ManagedIndexMetaData {
         if (indexName.contains("*") || indexName.contains(",")) {
             throw IllegalArgumentException("This method is only for a single concrete index")

--- a/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/TestHelpers.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/TestHelpers.kt
@@ -255,6 +255,7 @@ fun randomChangePolicy(
 }
 
 // will only return null since we dont want to send actual notifications during integ tests
+@Suppress("FunctionOnlyReturningConstant")
 fun randomErrorNotification(): ErrorNotification? = null
 
 fun randomManagedIndexConfig(
@@ -440,6 +441,7 @@ fun ISMTemplate.toJsonString(): String {
     return this.toXContent(builder, ToXContent.EMPTY_PARAMS).string()
 }
 
+@Suppress("RethrowCaughtException")
 fun <T> wait(
     timeout: Instant = Instant.ofEpochSecond(10),
     block: () -> T

--- a/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/model/ActionTests.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/model/ActionTests.kt
@@ -37,6 +37,8 @@ import java.io.ByteArrayInputStream
 import java.io.ByteArrayOutputStream
 import kotlin.test.assertFailsWith
 
+// TODO remove this suppression when refactoring is done
+@Suppress("UnusedPrivateMember")
 class ActionTests : OpenSearchTestCase() {
 
     fun `test invalid timeout for delete action fails`() {

--- a/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/model/XContentTests.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/model/XContentTests.kt
@@ -39,6 +39,8 @@ import org.opensearch.indexmanagement.spi.indexstatemanagement.model.ManagedInde
 import org.opensearch.test.OpenSearchTestCase
 
 // TODO: fixme - enable tests
+// TODO remove this suppression when refactoring is done
+@Suppress("UnusedPrivateMember")
 class XContentTests : OpenSearchTestCase() {
 
     private fun `test policy parsing`() {

--- a/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/runner/ManagedIndexRunnerTests.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/runner/ManagedIndexRunnerTests.kt
@@ -9,7 +9,6 @@ import com.carrotsearch.randomizedtesting.annotations.ThreadLeakScope
 import org.junit.Before
 import org.mockito.Mockito
 import org.opensearch.Version
-import org.opensearch.action.index.IndexResponse
 import org.opensearch.client.Client
 import org.opensearch.cluster.node.DiscoveryNode
 import org.opensearch.cluster.service.ClusterService
@@ -42,8 +41,6 @@ class ManagedIndexRunnerTests : OpenSearchTestCase() {
     private lateinit var settings: Settings
     private lateinit var discoveryNode: DiscoveryNode
     private lateinit var threadPool: ThreadPool
-
-    private lateinit var indexResponse: IndexResponse
 
     @Before
     @Throws(Exception::class)

--- a/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/WaitForRollupCompletionStepTests.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/WaitForRollupCompletionStepTests.kt
@@ -87,7 +87,7 @@ class WaitForRollupCompletionStepTests : OpenSearchTestCase() {
             updateManagedIndexMetaData.info?.get("message")
         )
         assertEquals("Missing rollup failed action property", true, updateManagedIndexMetaData.actionMetaData?.actionProperties?.hasRollupFailed)
-        assertEquals("Mismatch in cause", WaitForRollupCompletionStep.getJobStoppedMessage(), updateManagedIndexMetaData.info?.get("cause"))
+        assertEquals("Mismatch in cause", WaitForRollupCompletionStep.JOB_STOPPED_MESSAGE, updateManagedIndexMetaData.info?.get("cause"))
     }
 
     fun `test process rollup metadata INIT status`() {

--- a/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/transport/action/getpolicy/GetPolicyResponseTests.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/transport/action/getpolicy/GetPolicyResponseTests.kt
@@ -15,6 +15,8 @@ import org.opensearch.test.OpenSearchTestCase
 import java.time.Instant
 import java.time.temporal.ChronoUnit
 
+// TODO remove this suppression when refactoring is done
+@Suppress("UnusedPrivateMember")
 class GetPolicyResponseTests : OpenSearchTestCase() {
 
     // TODO: fixme - enable the test

--- a/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/transport/action/indexpolicy/IndexPolicyRequestTests.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/transport/action/indexpolicy/IndexPolicyRequestTests.kt
@@ -18,6 +18,8 @@ import org.opensearch.test.OpenSearchTestCase
 import java.time.Instant
 import java.time.temporal.ChronoUnit
 
+// TODO remove this suppression when refactoring is done
+@Suppress("UnusedPrivateMember")
 class IndexPolicyRequestTests : OpenSearchTestCase() {
 
     // TODO: fixme - enable the test

--- a/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/transport/action/indexpolicy/IndexPolicyResponseTests.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/transport/action/indexpolicy/IndexPolicyResponseTests.kt
@@ -16,6 +16,8 @@ import org.opensearch.test.OpenSearchTestCase
 import java.time.Instant
 import java.time.temporal.ChronoUnit
 
+// TODO remove this suppression when refactoring is done
+@Suppress("UnusedPrivateMember")
 class IndexPolicyResponseTests : OpenSearchTestCase() {
 
     // TODO: fixme - enable the test

--- a/src/test/kotlin/org/opensearch/indexmanagement/refreshanalyzer/RefreshSearchAnalyzerActionIT.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/refreshanalyzer/RefreshSearchAnalyzerActionIT.kt
@@ -167,7 +167,7 @@ class RefreshSearchAnalyzerActionIT : IndexManagementRestTestCase() {
     companion object {
 
         fun writeToFile(filePath: String, contents: String) {
-            var path = org.opensearch.common.io.PathUtils.get(filePath)
+            val path = org.opensearch.common.io.PathUtils.get(filePath)
             Files.newBufferedWriter(path, Charset.forName("UTF-8")).use { writer -> writer.write(contents) }
         }
 

--- a/src/test/kotlin/org/opensearch/indexmanagement/refreshanalyzer/RefreshSearchAnalyzerResponseTests.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/refreshanalyzer/RefreshSearchAnalyzerResponseTests.kt
@@ -22,14 +22,14 @@ class RefreshSearchAnalyzerResponseTests : OpenSearchTestCase() {
         val i2s0 = ShardId(index2, "xyz", 0)
         val i2s1 = ShardId(index2, "xyz", 1)
 
-        var response_i1s0 = RefreshSearchAnalyzerShardResponse(i1s0, listOf(syn1, syn2))
-        var response_i1s1 = RefreshSearchAnalyzerShardResponse(i1s1, listOf(syn1, syn2))
-        var response_i2s0 = RefreshSearchAnalyzerShardResponse(i2s0, listOf(syn1))
-        var response_i2s1 = RefreshSearchAnalyzerShardResponse(i2s1, listOf(syn1))
-        var failure_i1s0 = DefaultShardOperationFailedException(index1, 0, Throwable("dummyCause"))
-        var failure_i1s1 = DefaultShardOperationFailedException(index1, 1, Throwable("dummyCause"))
-        var failure_i2s0 = DefaultShardOperationFailedException(index2, 0, Throwable("dummyCause"))
-        var failure_i2s1 = DefaultShardOperationFailedException(index2, 1, Throwable("dummyCause"))
+        val response_i1s0 = RefreshSearchAnalyzerShardResponse(i1s0, listOf(syn1, syn2))
+        val response_i1s1 = RefreshSearchAnalyzerShardResponse(i1s1, listOf(syn1, syn2))
+        val response_i2s0 = RefreshSearchAnalyzerShardResponse(i2s0, listOf(syn1))
+        val response_i2s1 = RefreshSearchAnalyzerShardResponse(i2s1, listOf(syn1))
+        val failure_i1s0 = DefaultShardOperationFailedException(index1, 0, Throwable("dummyCause"))
+        val failure_i1s1 = DefaultShardOperationFailedException(index1, 1, Throwable("dummyCause"))
+        val failure_i2s0 = DefaultShardOperationFailedException(index2, 0, Throwable("dummyCause"))
+        val failure_i2s1 = DefaultShardOperationFailedException(index2, 1, Throwable("dummyCause"))
 
         // Case 1: All shards successful
         var aggregate_response = listOf(response_i1s0, response_i1s1, response_i2s0, response_i2s1)

--- a/src/test/kotlin/org/opensearch/indexmanagement/rollup/TestHelpers.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/rollup/TestHelpers.kt
@@ -38,8 +38,10 @@ import java.util.Locale
 
 fun randomInterval(): String = if (OpenSearchRestTestCase.randomBoolean()) randomFixedInterval() else randomCalendarInterval()
 
+@Suppress("FunctionOnlyReturningConstant")
 fun randomCalendarInterval(): String = "1d"
 
+@Suppress("FunctionOnlyReturningConstant")
 fun randomFixedInterval(): String = "30m"
 
 fun randomFixedDateHistogram(): DateHistogram = OpenSearchRestTestCase.randomAlphaOfLength(10).let {
@@ -85,7 +87,7 @@ fun randomRollupMetrics(): RollupMetrics = OpenSearchRestTestCase.randomAlphaOfL
 
 fun randomRollupDimensions(): List<Dimension> {
     val dimensions = mutableListOf<Dimension>(randomDateHistogram())
-    for (i in 0..OpenSearchRestTestCase.randomInt(10)) {
+    repeat(OpenSearchRestTestCase.randomInt(10) + 1) {
         dimensions.add(if (OpenSearchRestTestCase.randomBoolean()) randomTerms() else randomHistogram())
     }
     return dimensions.toList()

--- a/src/test/kotlin/org/opensearch/indexmanagement/rollup/interceptor/RollupInterceptorIT.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/rollup/interceptor/RollupInterceptorIT.kt
@@ -613,7 +613,7 @@ class RollupInterceptorIT : RollupRestTestCase() {
         refreshAllIndices()
 
         // Term query
-        var req = """
+        val req = """
             {
                 "size": 0,
                 "query": {
@@ -630,12 +630,12 @@ class RollupInterceptorIT : RollupRestTestCase() {
                 }
             }
         """.trimIndent()
-        var rawRes = client().makeRequest("POST", "/source_continuous_rollup_search/_search", emptyMap(), StringEntity(req, ContentType.APPLICATION_JSON))
+        val rawRes = client().makeRequest("POST", "/source_continuous_rollup_search/_search", emptyMap(), StringEntity(req, ContentType.APPLICATION_JSON))
         assertTrue(rawRes.restStatus() == RestStatus.OK)
-        var rollupRes = client().makeRequest("POST", "/target_continuous_rollup_search/_search", emptyMap(), StringEntity(req, ContentType.APPLICATION_JSON))
+        val rollupRes = client().makeRequest("POST", "/target_continuous_rollup_search/_search", emptyMap(), StringEntity(req, ContentType.APPLICATION_JSON))
         assertTrue(rollupRes.restStatus() == RestStatus.OK)
-        var rawAggRes = rawRes.asMap()["aggregations"] as Map<String, Map<String, Any>>
-        var rollupAggRes = rollupRes.asMap()["aggregations"] as Map<String, Map<String, Any>>
+        val rawAggRes = rawRes.asMap()["aggregations"] as Map<String, Map<String, Any>>
+        val rollupAggRes = rollupRes.asMap()["aggregations"] as Map<String, Map<String, Any>>
         assertEquals(
             "Source and rollup index did not return same min results",
             rawAggRes.getValue("min_passenger_count")["value"],

--- a/src/test/kotlin/org/opensearch/indexmanagement/rollup/resthandler/RestDeleteRollupActionIT.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/rollup/resthandler/RestDeleteRollupActionIT.kt
@@ -42,7 +42,7 @@ class RestDeleteRollupActionIT : RollupRestTestCase() {
     fun `test deleting a rollup that doesn't exist and config index doesnt exist`() {
         try {
             deleteIndex(INDEX_MANAGEMENT_INDEX)
-            val res = client().makeRequest("DELETE", "$ROLLUP_JOBS_BASE_URI/foobarbaz")
+            client().makeRequest("DELETE", "$ROLLUP_JOBS_BASE_URI/foobarbaz")
             fail("expected 404 ResponseException")
         } catch (e: ResponseException) {
             assertEquals(RestStatus.NOT_FOUND, e.response.restStatus())

--- a/src/test/kotlin/org/opensearch/indexmanagement/rollup/resthandler/RestExplainRollupActionIT.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/rollup/resthandler/RestExplainRollupActionIT.kt
@@ -68,7 +68,7 @@ class RestExplainRollupActionIT : RollupRestTestCase() {
     @Throws(Exception::class)
     fun `test explain rollup for nonexistent id`() {
         // Creating a rollup so the config index exists
-        createRollup(rollup = randomRollup(), rollupId = "doesnt_exist_some_other_id")
+        createRollup(rollup = randomRollup(), rollupId = "doesnt_exist_some_other_rollup_id")
         val response = client().makeRequest("GET", "$ROLLUP_JOBS_BASE_URI/doesnt_exist/_explain")
         assertNull("Nonexistent rollup didn't return null", response.asMap()["doesnt_exist"])
     }
@@ -76,30 +76,30 @@ class RestExplainRollupActionIT : RollupRestTestCase() {
     @Throws(Exception::class)
     fun `test explain rollup for wildcard id`() {
         // Creating a rollup so the config index exists
-        createRollup(rollup = randomRollup(), rollupId = "wildcard_some_id")
-        createRollup(rollup = randomRollup(), rollupId = "wildcard_some_other_id")
+        createRollup(rollup = randomRollup(), rollupId = "wildcard_some_rollup_id")
+        createRollup(rollup = randomRollup(), rollupId = "wildcard_some_other_rollup_id")
         val response = client().makeRequest("GET", "$ROLLUP_JOBS_BASE_URI/wildcard_some*/_explain")
         // We don't expect there to always be metadata as we are creating random rollups and the job isn't running
         // but we do expect the wildcard some* to expand to the two jobs created above and have non-null values (meaning they exist)
         val map = response.asMap()
-        assertNotNull("Non null wildcard_some_id value wasn't in the response", map["wildcard_some_id"])
-        assertNotNull("Non null wildcard_some_other_id value wasn't in the response", map["wildcard_some_other_id"])
+        assertNotNull("Non null wildcard_some_rollup_id value wasn't in the response", map["wildcard_some_rollup_id"])
+        assertNotNull("Non null wildcard_some_other_rollup_id value wasn't in the response", map["wildcard_some_other_rollup_id"])
     }
 
     @Throws(Exception::class)
     fun `test explain rollup for job that hasnt started`() {
-        createRollup(rollup = randomRollup().copy(metadataID = null), rollupId = "not_started_some_id")
-        val response = client().makeRequest("GET", "$ROLLUP_JOBS_BASE_URI/not_started_some_id/_explain")
-        val expectedMap = mapOf("not_started_some_id" to mapOf("metadata_id" to null, "rollup_metadata" to null))
+        createRollup(rollup = randomRollup().copy(metadataID = null), rollupId = "not_started_some_rollup_id")
+        val response = client().makeRequest("GET", "$ROLLUP_JOBS_BASE_URI/not_started_some_rollup_id/_explain")
+        val expectedMap = mapOf("not_started_some_rollup_id" to mapOf("metadata_id" to null, "rollup_metadata" to null))
         assertEquals("The explain response did not match expected", expectedMap, response.asMap())
     }
 
     @Throws(Exception::class)
     fun `test explain rollup for metadata_id but no metadata`() {
         // This is to test the case of a rollup existing with a metadataID but there being no metadata document
-        createRollup(rollup = randomRollup().copy(metadataID = "some_metadata_id"), rollupId = "no_meta_some_id")
-        val response = client().makeRequest("GET", "$ROLLUP_JOBS_BASE_URI/no_meta_some_id/_explain")
-        val expectedMap = mapOf("no_meta_some_id" to mapOf("metadata_id" to "some_metadata_id", "rollup_metadata" to null))
+        createRollup(rollup = randomRollup().copy(metadataID = "some_metadata_id"), rollupId = "no_meta_some_rollup_id")
+        val response = client().makeRequest("GET", "$ROLLUP_JOBS_BASE_URI/no_meta_some_rollup_id/_explain")
+        val expectedMap = mapOf("no_meta_some_rollup_id" to mapOf("metadata_id" to "some_metadata_id", "rollup_metadata" to null))
         assertEquals("The explain response did not match expected", expectedMap, response.asMap())
     }
 

--- a/src/test/kotlin/org/opensearch/indexmanagement/transform/TestHelpers.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/transform/TestHelpers.kt
@@ -31,7 +31,7 @@ import java.util.Locale
 
 fun randomGroups(): List<Dimension> {
     val dimensions = mutableListOf<Dimension>()
-    for (i in 0..OpenSearchRestTestCase.randomIntBetween(1, 10)) {
+    repeat(OpenSearchRestTestCase.randomIntBetween(1, 10)) {
         dimensions.add(randomDimension())
     }
     return dimensions
@@ -60,7 +60,7 @@ fun randomAggregationBuilder(): AggregationBuilder {
 
 fun randomAggregationFactories(): AggregatorFactories.Builder {
     val factories = AggregatorFactories.builder()
-    for (i in 1..OpenSearchRestTestCase.randomIntBetween(1, 10)) {
+    repeat(OpenSearchRestTestCase.randomIntBetween(1, 10)) {
         factories.addAggregator(randomAggregationBuilder())
     }
     return factories

--- a/src/test/kotlin/org/opensearch/indexmanagement/transform/resthandler/RestExplainTransformActionIT.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/transform/resthandler/RestExplainTransformActionIT.kt
@@ -67,7 +67,7 @@ class RestExplainTransformActionIT : TransformRestTestCase() {
     @Throws(Exception::class)
     fun `test explain transform for nonexistent id`() {
         // Creating a transform so the config index exists
-        createTransform(transform = randomTransform(), transformId = "doesnt_exist_some_other_id")
+        createTransform(transform = randomTransform(), transformId = "doesnt_exist_some_other_transform_id")
         val response = client().makeRequest("GET", "$TRANSFORM_BASE_URI/doesnt_exist/_explain")
         assertNull("Nonexistent transform didn't return null", response.asMap()["doesnt_exist"])
     }
@@ -75,29 +75,29 @@ class RestExplainTransformActionIT : TransformRestTestCase() {
     @Throws(Exception::class)
     fun `test explain transform for wildcard id`() {
         // Creating a transform so the config index exists
-        createTransform(transform = randomTransform(), transformId = "wildcard_some_id")
-        createTransform(transform = randomTransform(), transformId = "wildcard_some_other_id")
+        createTransform(transform = randomTransform(), transformId = "wildcard_some_transform_id")
+        createTransform(transform = randomTransform(), transformId = "wildcard_some_other_transform_id")
         val response = client().makeRequest("GET", "$TRANSFORM_BASE_URI/wildcard_some*/_explain")
         // We don't expect there to always be metadata we are creating random transforms and the job isn't running
         // but we do expect the wildcard some* to expand to the two jobs created above and have non-null values (meaning they exist)
         val map = response.asMap()
-        assertNotNull("Non null wildcard_some_id value wasn't in the response", map["wildcard_some_id"])
-        assertNotNull("Non null wildcard_some_other_id value wasn't in the response", map["wildcard_some_other_id"])
+        assertNotNull("Non null wildcard_some_transform_id value wasn't in the response", map["wildcard_some_transform_id"])
+        assertNotNull("Non null wildcard_some_other_transform_id value wasn't in the response", map["wildcard_some_other_transform_id"])
     }
 
     @Throws(Exception::class)
     fun `test explain transform for job that hasnt started`() {
-        createTransform(transform = randomTransform().copy(metadataId = null), transformId = "not_started_some_id")
-        val response = client().makeRequest("GET", "$TRANSFORM_BASE_URI/not_started_some_id/_explain")
-        val expectedMap = mapOf("not_started_some_id" to mapOf("metadata_id" to null, "transform_metadata" to null))
+        createTransform(transform = randomTransform().copy(metadataId = null), transformId = "not_started_some_transform_id")
+        val response = client().makeRequest("GET", "$TRANSFORM_BASE_URI/not_started_some_transform_id/_explain")
+        val expectedMap = mapOf("not_started_some_transform_id" to mapOf("metadata_id" to null, "transform_metadata" to null))
         assertEquals("The explain response did not match expected", expectedMap, response.asMap())
     }
 
     @Throws(Exception::class)
     fun `test explain transform for new transform attempted to create with metadata id`() {
-        createTransform(transform = randomTransform().copy(metadataId = "some_metadata_id"), transformId = "no_meta_some_id")
-        val response = client().makeRequest("GET", "$TRANSFORM_BASE_URI/no_meta_some_id/_explain")
-        val expectedMap = mapOf("no_meta_some_id" to mapOf("metadata_id" to null, "transform_metadata" to null))
+        createTransform(transform = randomTransform().copy(metadataId = "some_metadata_id"), transformId = "no_meta_some_transform_id")
+        val response = client().makeRequest("GET", "$TRANSFORM_BASE_URI/no_meta_some_transform_id/_explain")
+        val expectedMap = mapOf("no_meta_some_transform_id" to mapOf("metadata_id" to null, "transform_metadata" to null))
         assertEquals("The explain response did not match expected", expectedMap, response.asMap())
     }
 

--- a/src/test/kotlin/org/opensearch/indexmanagement/transform/resthandler/RestPreviewTransformActionIT.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/transform/resthandler/RestPreviewTransformActionIT.kt
@@ -38,6 +38,7 @@ class RestPreviewTransformActionIT : TransformRestTestCase() {
         try {
             indexExists = indexExists(sourceIndex)
         } catch (e: IndexNotFoundException) {
+            // If this exception is thrown, indexExists will be false anyways
         }
         if (!indexExists) {
             generateNYCTaxiData(sourceIndex)

--- a/src/test/kotlin/org/opensearch/indexmanagement/transform/resthandler/RestStartTransformActionIT.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/transform/resthandler/RestStartTransformActionIT.kt
@@ -78,7 +78,7 @@ class RestStartTransformActionIT : TransformRestTestCase() {
     @Throws(Exception::class)
     fun `test starting a failed transform`() {
         val transform = randomTransform().copy(
-            id = "restart_failed_rollup",
+            id = "restart_failed_transform",
             schemaVersion = 1L,
             enabled = true,
             jobSchedule = IntervalSchedule(Instant.now(), 1, ChronoUnit.MINUTES),
@@ -144,7 +144,7 @@ class RestStartTransformActionIT : TransformRestTestCase() {
         generateNYCTaxiData("source_restart_finished_transform")
         assertIndexExists("source_restart_finished_transform")
         val transform = randomTransform().copy(
-            id = "restart_finished_rollup",
+            id = "restart_finished_transform",
             schemaVersion = 1L,
             enabled = true,
             jobSchedule = IntervalSchedule(Instant.now(), 1, ChronoUnit.MINUTES),


### PR DESCRIPTION
*Issue #, if available:*
NA
*Description of changes:*
Cherry-picks three commits -

- Upgrades detekt version to 1.17.1 to enable building
- fixes flaky rollup/transform explain IT and
- fixes additional duplicate ids to fix some tests which have become persistently flaky recently

*CheckList:*
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/index-management/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
