### PR TITLE
Avoids restricted index warning check in blocked index pattern test

### DIFF
--- a/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/resthandler/RestAddPolicyActionIT.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/resthandler/RestAddPolicyActionIT.kt
@@ -241,6 +241,7 @@ class RestAddPolicyActionIT : IndexStateManagementRestTestCase() {
     /**
      * The util UUID method doesn't work for hidden indices because strict warning check, the following method skips the strict check
      */
+    @Suppress("UNCHECKED_CAST")
     private fun getUuidWithOutStrictChecking(index: String): String {
         val response = client().makeRequest("GET", "/$index/_settings?flat_settings=true")
         val settings = response.entity.content.use { XContentHelper.convertToMap(XContentType.JSON.xContent(), it, true) } as Map<String, Map<String, Map<String, Any?>>>


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/opensearch-project/index-management/issues/258

*Description of changes:*
The index management `test index pattern matching blocked indices` test was failing during the 1.3.0 snapshot distribution build integ tests, as that process uses a client with strict deprecation mode as true, and getting the uuid of a system index through the index settings triggers a deprecation warning. This commit gets the uuid of the system index while explicitly setting the strictDeprecationMode to false in the request [here](https://github.com/opensearch-project/index-management/blob/main/src/test/kotlin/org/opensearch/indexmanagement/TestHelpers.kt#L94).

Using the [test setup described](https://github.com/opensearch-project/index-management/issues/258#issuecomment-1028425845) in the associated issue, I was able to replicate the failure before the change and verified that this change fixes the test failure.

*CheckList:*
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/index-management/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
