### PR TITLE
Fixes flaky continuous transforms test

### DIFF
--- a/src/test/kotlin/org/opensearch/indexmanagement/transform/TransformRunnerIT.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/transform/TransformRunnerIT.kt
@@ -408,6 +408,7 @@ class TransformRunnerIT : TransformRestTestCase() {
             val transformMetadata = getTransformMetadata(job.metadataId!!)
             assertEquals("Transform did not complete iteration or had incorrect number of documents processed", 5000, transformMetadata.stats.documentsProcessed)
             assertEquals("Transform did not complete iteration", null, transformMetadata.afterKey)
+            assertNotNull("Continuous stats were not updated", transformMetadata.continuousStats)
             transformMetadata
         }
 
@@ -732,6 +733,7 @@ class TransformRunnerIT : TransformRestTestCase() {
             val transformMetadata = getTransformMetadata(job.metadataId!!)
             assertEquals("Transform did not complete iteration or had incorrect number of documents processed", 15000, transformMetadata.stats.documentsProcessed)
             assertEquals("Transform did not complete iteration", null, transformMetadata.afterKey)
+            assertNotNull("Continuous stats were not updated", transformMetadata.continuousStats)
             transformMetadata
         }
 
@@ -759,6 +761,7 @@ class TransformRunnerIT : TransformRestTestCase() {
             val transformMetadata = getTransformMetadata(job.metadataId!!)
             assertEquals("Transform did not complete iteration or had incorrect number of documents processed", 15000, transformMetadata.stats.documentsProcessed)
             assertEquals("Transform did not have null afterKey after iteration", null, transformMetadata.afterKey)
+            assertTrue("Timestamp was not updated", transformMetadata.continuousStats!!.lastTimestamp!!.isAfter(firstIterationMetadata.continuousStats!!.lastTimestamp))
             transformMetadata
         }
 
@@ -768,7 +771,6 @@ class TransformRunnerIT : TransformRestTestCase() {
         assertEquals("Not the expected documents processed", 15000L, secondIterationMetadata.stats.documentsProcessed)
         assertEquals("Not the expected indexed time", secondIterationMetadata.stats.indexTimeInMillis, firstIterationMetadata.stats.indexTimeInMillis)
         assertEquals("Not the expected search time", secondIterationMetadata.stats.searchTimeInMillis, firstIterationMetadata.stats.searchTimeInMillis)
-        assertTrue("Timestamp was not updated", secondIterationMetadata.continuousStats!!.lastTimestamp!!.isAfter(firstIterationMetadata.continuousStats!!.lastTimestamp))
 
         disableTransform(transform.id)
     }


### PR DESCRIPTION
Signed-off-by: Robert Downs <downsrob@amazon.com>

*Issue #, if available:*
N/A
*Description of changes:*
```
./gradlew ':integTest' --tests "org.opensearch.indexmanagement.transform.TransformRunnerIT.test continuous transform with wildcard indices" -Dtests.seed=7456CA873D2951BB -Dtests.security.manager=false -Dtests.locale=es-US -Dtests.timezone=Etc/Greenwich -Druntime.java=14
org.opensearch.indexmanagement.transform.TransformRunnerIT > test continuous transform with wildcard indices FAILED
    java.lang.NullPointerException
        at __randomizedtesting.SeedInfo.seed([7456CA873D2951BB:9E30041088F9C85C]:0)
        at java.base/java.time.Instant.compareTo(Instant.java:1255)
        at java.base/java.time.Instant.isAfter(Instant.java:1272)
        at org.opensearch.indexmanagement.transform.TransformRunnerIT.test continuous transform with wildcard indices(TransformRunnerIT.kt:771)
```
Noticed this flaky failure for continuous transforms. Metadata with the transform afterkey set to null was updated before the final step where the ContinuousStats were updated, so a test scenario in which the continuous stats were missing was possible. This change makes the waitFor loop wait for the continuous stats to be present.
*CheckList:*
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/index-management/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
