### PR TITLE
Changes integ test java version from 14 to 11

### DIFF
--- a/.github/workflows/multi-node-test-workflow.yml
+++ b/.github/workflows/multi-node-test-workflow.yml
@@ -16,10 +16,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # This step uses the setup-java Github action: https://github.com/actions/setup-java
-      - name: Set Up JDK 14
+      - name: Set Up JDK 11
         uses: actions/setup-java@v1
         with:
-          java-version: 14
+          java-version: 11
       # index-management
       - name: Checkout Branch
         uses: actions/checkout@v2
@@ -37,10 +37,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # This step uses the setup-java Github action: https://github.com/actions/setup-java
-      - name: Set Up JDK 14
+      - name: Set Up JDK 11
         uses: actions/setup-java@v1
         with:
-          java-version: 14
+          java-version: 11
       # index-management
       - name: Checkout Branch
         uses: actions/checkout@v2

--- a/.github/workflows/release-workflow.yml
+++ b/.github/workflows/release-workflow.yml
@@ -9,7 +9,7 @@ jobs:
   build:
     strategy:
       matrix:
-        java: [14]
+        java: [11]
     # Job name
     name: Build Index Management with JDK ${{ matrix.java }}
     # This job runs on Linux

--- a/.github/workflows/test-and-build-workflow.yml
+++ b/.github/workflows/test-and-build-workflow.yml
@@ -30,10 +30,10 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       # This step uses the setup-java Github action: https://github.com/actions/setup-java
-      - name: Set Up JDK 14
+      - name: Set Up JDK 11
         uses: actions/setup-java@v1
         with:
-          java-version: 14
+          java-version: 11
       # build index management
       - name: Checkout Branch
         uses: actions/checkout@v2

--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -1,7 +1,7 @@
 - [Developer Guide](#developer-guide)
     - [Forking and Cloning](#forking-and-cloning)
     - [Install Prerequisites](#install-prerequisites)
-        - [JDK 14](#jdk-14)
+        - [JDK 11](#jdk-11)
     - [Setup](#setup)  
     - [Build](#build)
         - [Building from the command line](#building-from-the-command-line)
@@ -19,15 +19,17 @@ Fork this repository on GitHub, and clone locally with `git clone`.
 
 ### Install Prerequisites
 
-#### JDK 14
+#### JDK 11
 
-OpenSearch components build using Java 14 at a minimum. This means you must have a JDK 14 installed with the environment variable `JAVA_HOME` referencing the path to Java home for your JDK 14 installation, e.g. `JAVA_HOME=/usr/lib/jvm/jdk-14`.
+OpenSearch components build using Java 11 at a minimum. This means you must have a JDK 11 installed with the environment variable `JAVA_HOME` referencing the path to Java home for your JDK 11 installation, e.g. `JAVA_HOME=/usr/lib/jvm/jdk-11`.
+
+Download Java 11 from [here](https://adoptium.net/releases.html?variant=openjdk11).
 
 ## Setup
 
 1. Check out this package from version control.
 2. Launch Intellij IDEA, choose **Import Project**, and select the `settings.gradle` file in the root of this package.
-3. To build from the command line, set `JAVA_HOME` to point to a JDK >= 14 before running `./gradlew`.
+3. To build from the command line, set `JAVA_HOME` to point to a JDK >= 11 before running `./gradlew`.
 - Unix System
     1. `export JAVA_HOME=jdk-install-dir`: Replace `jdk-install-dir` with the JAVA_HOME directory of your system.
     2. `export PATH=$JAVA_HOME/bin:$PATH`


### PR DESCRIPTION
Signed-off-by: Robert Downs <downsrob@amazon.com>

*Issue #, if available:*
https://github.com/opensearch-project/index-management/issues/200

*Description of changes:*
Changes the default Java version for CI in GitHub actions from 14 to 11. 
*CheckList:*
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/index-management/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
