### PR TITLE
Fixes test failures with security enabled

### DIFF
--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/transport/action/explain/TransportExplainAction.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/transport/action/explain/TransportExplainAction.kt
@@ -344,7 +344,7 @@ class TransportExplainAction @Inject constructor(
                         filteredIndices.add(indexNames[current])
                         filteredMetadata.add(indexMetadatas[current])
                         filteredPolicies.add(indexPolicyIDs[current])
-                        enabledStatus[indexNames[current]] = enabledState.getOrDefault(indexNames[current], false)
+                        enabledState[indexNames[current]]?.let { enabledStatus[indexNames[current]] = it }
                         appliedPolicies[indexNames[current]]?.let { filteredAppliedPolicies[indexNames[current]] = it }
                         if (current < indexNames.count() - 1) {
                             // do nothing - skip the index and go to next one


### PR DESCRIPTION
Signed-off-by: Robert Downs <downsrob@amazon.com>

*Issue #, if available:*
NA

*Description of changes:*
Index management tests with security enabled were failing due to a mismatch in the default explain indices response between when security is enabled or disabled. When security was disabled and the index did not exist, the enabledStatus would be null. When security was enabled, the enabled status would default to false due to this code which runs during security filtering: https://github.com/opensearch-project/index-management/blob/e9351ceb5292c096b62964006c86b1a230c41581/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/transport/action/explain/TransportExplainAction.kt#L347
This line was added in this PR https://github.com/opensearch-project/index-management/pull/126 over 6 months ago, so it is strange that these failures haven't surfaced before this, as the behavior should have been the same when testing with security any time since.

The following tests were failing persistently with security enabled before this change:
```
ISMTemplateRestAPIIT.test ism template managing index
RestExplainActionIT.test single index
RestExplainActionIT.test index pattern
RestExplainActionIT.test two indices, one managed one not managed
ManagedIndexCoordinatorIT.test managed index metadata is cleaned up after removing policy
```
After making this change, assembling the plugin and installing it in the previous used test cluster, the tests pass.

*CheckList:*
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/index-management/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
