### PR TITLE
Adds build support for JDK 8

### DIFF
--- a/.github/workflows/test-and-build-workflow.yml
+++ b/.github/workflows/test-and-build-workflow.yml
@@ -19,21 +19,24 @@ jobs:
       fail-fast: false
       # This starts three jobs, setting these environment variables uniquely for the different jobs
       matrix:
+        java: [8, 11, 14, 17]
         include:
           - os: ubuntu-latest
           - os: windows-latest
             os_build_args: -x integTest -x jacocoTestReport
             working_directory: X:\
             os_java_options: -Xmx4096M
+            java: 11
           - os: macos-latest
             os_build_args: -x integTest -x jacocoTestReport
+            java: 11
     runs-on: ${{ matrix.os }}
     steps:
       # This step uses the setup-java Github action: https://github.com/actions/setup-java
-      - name: Set Up JDK 11
+      - name: Set Up JDK ${{ matrix.java }}
         uses: actions/setup-java@v1
         with:
-          java-version: 11
+          java-version: ${{ matrix.java }}
       # build index management
       - name: Checkout Branch
         uses: actions/checkout@v2

--- a/.github/workflows/test-and-build-workflow.yml
+++ b/.github/workflows/test-and-build-workflow.yml
@@ -19,7 +19,7 @@ jobs:
       fail-fast: false
       # This starts three jobs, setting these environment variables uniquely for the different jobs
       matrix:
-        java: [8, 11, 14, 17]
+        java: [8, 11, 14]
         os: [ubuntu-latest, windows-latest, macos-latest]
         include:
           - os: windows-latest
@@ -31,9 +31,9 @@ jobs:
         # Only testing the LTS java version on mac and windows
         exclude:
           - os: windows-latest
-            java: [8, 14, 17]
+            java: [8, 14]
           - os: macos-latest
-            java: [8, 14, 17]
+            java: [8, 14]
     runs-on: ${{ matrix.os }}
     steps:
       # This step uses the setup-java Github action: https://github.com/actions/setup-java

--- a/.github/workflows/test-and-build-workflow.yml
+++ b/.github/workflows/test-and-build-workflow.yml
@@ -20,16 +20,20 @@ jobs:
       # This starts three jobs, setting these environment variables uniquely for the different jobs
       matrix:
         java: [8, 11, 14, 17]
+        os: [ubuntu-latest, windows-latest, macos-latest]
         include:
-          - os: ubuntu-latest
           - os: windows-latest
             os_build_args: -x integTest -x jacocoTestReport
             working_directory: X:\
             os_java_options: -Xmx4096M
-            java: 11
           - os: macos-latest
             os_build_args: -x integTest -x jacocoTestReport
-            java: 11
+        # Only testing the LTS java version on mac and windows
+        exclude:
+          - os: windows-latest
+            java: [8, 14, 17]
+          - os: macos-latest
+            java: [8, 14, 17]
     runs-on: ${{ matrix.os }}
     steps:
       # This step uses the setup-java Github action: https://github.com/actions/setup-java

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/forcemerge/WaitForForceMergeStep.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/forcemerge/WaitForForceMergeStep.kt
@@ -59,7 +59,7 @@ class WaitForForceMergeStep(private val action: ForceMergeAction) : Step(name, f
             // Get ActionTimeout if given, otherwise use default timeout of 12 hours
             val timeoutInSeconds: Long = action.configTimeout?.timeout?.seconds ?: FORCE_MERGE_TIMEOUT_IN_SECONDS
 
-            if (timeWaitingForForceMerge.toSeconds() > timeoutInSeconds) {
+            if (timeWaitingForForceMerge.seconds > timeoutInSeconds) {
                 logger.error(
                     "Force merge on [$indexName] timed out with" +
                         " [$shardsStillMergingSegments] shards containing unmerged segments"

--- a/src/test/kotlin/org/opensearch/indexmanagement/IndexManagementRestTestCase.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/IndexManagementRestTestCase.kt
@@ -19,7 +19,7 @@ import org.opensearch.common.settings.Settings
 import org.opensearch.indexmanagement.indexstatemanagement.util.INDEX_HIDDEN
 import org.opensearch.rest.RestStatus
 import java.nio.file.Files
-import java.nio.file.Path
+import java.nio.file.Paths
 import javax.management.MBeanServerInvocationHandler
 import javax.management.ObjectName
 import javax.management.remote.JMXConnectorFactory
@@ -171,7 +171,7 @@ abstract class IndexManagementRestTestCase : ODFERestTestCase() {
                     false
                 )
                 proxy.getExecutionData(false)?.let {
-                    val path = Path.of("$jacocoBuildPath/integTest.exec")
+                    val path = Paths.get("$jacocoBuildPath/integTest.exec")
                     Files.write(path, it)
                 }
             }

--- a/src/test/kotlin/org/opensearch/indexmanagement/IndexManagementRestTestCase.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/IndexManagementRestTestCase.kt
@@ -15,6 +15,7 @@ import org.opensearch.client.RequestOptions
 import org.opensearch.client.Response
 import org.opensearch.client.RestClient
 import org.opensearch.common.Strings
+import org.opensearch.common.io.PathUtils
 import org.opensearch.common.settings.Settings
 import org.opensearch.indexmanagement.indexstatemanagement.util.INDEX_HIDDEN
 import org.opensearch.rest.RestStatus
@@ -171,7 +172,7 @@ abstract class IndexManagementRestTestCase : ODFERestTestCase() {
                     false
                 )
                 proxy.getExecutionData(false)?.let {
-                    val path = Paths.get("$jacocoBuildPath/integTest.exec")
+                    val path = PathUtils.get("$jacocoBuildPath/integTest.exec")
                     Files.write(path, it)
                 }
             }

--- a/src/test/kotlin/org/opensearch/indexmanagement/IndexManagementRestTestCase.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/IndexManagementRestTestCase.kt
@@ -20,7 +20,6 @@ import org.opensearch.common.settings.Settings
 import org.opensearch.indexmanagement.indexstatemanagement.util.INDEX_HIDDEN
 import org.opensearch.rest.RestStatus
 import java.nio.file.Files
-import java.nio.file.Paths
 import javax.management.MBeanServerInvocationHandler
 import javax.management.ObjectName
 import javax.management.remote.JMXConnectorFactory


### PR DESCRIPTION
Signed-off-by: Robert Downs <downsrob@amazon.com>

*Issue #, if available:*
https://github.com/opensearch-project/index-management/issues/200

*Description of changes:*
Adds java matrix to test and build workflow. Fixes some compilation errors to allow building with JDK 8.
```
- if (timeWaitingForForceMerge.toSeconds() > timeoutInSeconds) {
+ if (timeWaitingForForceMerge.seconds > timeoutInSeconds) {
```
Duration.toSeconds() was introduced in JDK 9([source](https://docs.oracle.com/javase/9/docs/api/java/time/Duration.html#toSeconds--)), equivalent functionality should be [Duration.getSeconds()](https://docs.oracle.com/javase/9/docs/api/java/time/Duration.html#getSeconds--) which is JDK 8 compatible. Kotlin simplifies this to just .seconds
```
- val path = Path.of("$jacocoBuildPath/integTest.exec")
+ val path = PathUtils.get("$jacocoBuildPath/integTest.exec")
```
Path.of was introduced in JDK 11([source](https://docs.oracle.com/en/java/javase/12/docs/api/java.base/java/nio/file/Path.html#of(java.net.URI))), equivalent JDK 8 functionality would be `Paths.get(...)`, but OpenSearch blocks this, in favor of the [OpenSearch commons `PathUtils.get(..)`](https://github.com/opensearch-project/OpenSearch/blob/31a360fc87419cd3a6d5621754f8ad9e8819f1e8/libs/core/src/main/java/org/opensearch/common/io/PathUtils.java#L62-L74)



*CheckList:*
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/index-management/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
