### PR TITLE
Adds build support for JDK 8 (#297) (#301)

### DIFF
--- a/.github/workflows/test-and-build-workflow.yml
+++ b/.github/workflows/test-and-build-workflow.yml
@@ -19,21 +19,28 @@ jobs:
       fail-fast: false
       # This starts three jobs, setting these environment variables uniquely for the different jobs
       matrix:
+        java: [8, 11, 14]
+        os: [ubuntu-latest, windows-latest, macos-latest]
         include:
-          - os: ubuntu-latest
           - os: windows-latest
             os_build_args: -x integTest -x jacocoTestReport
             working_directory: X:\
             os_java_options: -Xmx4096M
           - os: macos-latest
             os_build_args: -x integTest -x jacocoTestReport
+        # Only testing the LTS java version on mac and windows
+        exclude:
+          - os: windows-latest
+            java: [8, 14]
+          - os: macos-latest
+            java: [8, 14]
     runs-on: ${{ matrix.os }}
     steps:
       # This step uses the setup-java Github action: https://github.com/actions/setup-java
-      - name: Set Up JDK 11
+      - name: Set Up JDK ${{ matrix.java }}
         uses: actions/setup-java@v1
         with:
-          java-version: 11
+          java-version: ${{ matrix.java }}
       # build index management
       - name: Checkout Branch
         uses: actions/checkout@v2

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/forcemerge/WaitForForceMergeStep.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/forcemerge/WaitForForceMergeStep.kt
@@ -59,7 +59,7 @@ class WaitForForceMergeStep(private val action: ForceMergeAction) : Step(name, f
             // Get ActionTimeout if given, otherwise use default timeout of 12 hours
             val timeoutInSeconds: Long = action.configTimeout?.timeout?.seconds ?: FORCE_MERGE_TIMEOUT_IN_SECONDS
 
-            if (timeWaitingForForceMerge.toSeconds() > timeoutInSeconds) {
+            if (timeWaitingForForceMerge.seconds > timeoutInSeconds) {
                 logger.error(
                     "Force merge on [$indexName] timed out with" +
                         " [$shardsStillMergingSegments] shards containing unmerged segments"

--- a/src/test/kotlin/org/opensearch/indexmanagement/IndexManagementRestTestCase.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/IndexManagementRestTestCase.kt
@@ -15,11 +15,11 @@ import org.opensearch.client.RequestOptions
 import org.opensearch.client.Response
 import org.opensearch.client.RestClient
 import org.opensearch.common.Strings
+import org.opensearch.common.io.PathUtils
 import org.opensearch.common.settings.Settings
 import org.opensearch.indexmanagement.indexstatemanagement.util.INDEX_HIDDEN
 import org.opensearch.rest.RestStatus
 import java.nio.file.Files
-import java.nio.file.Path
 import javax.management.MBeanServerInvocationHandler
 import javax.management.ObjectName
 import javax.management.remote.JMXConnectorFactory
@@ -171,7 +171,7 @@ abstract class IndexManagementRestTestCase : ODFERestTestCase() {
                     false
                 )
                 proxy.getExecutionData(false)?.let {
-                    val path = Path.of("$jacocoBuildPath/integTest.exec")
+                    val path = PathUtils.get("$jacocoBuildPath/integTest.exec")
                     Files.write(path, it)
                 }
             }


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/opensearch-project/index-management/issues/200

*Description of changes:*
Backports build support for JDK 8 to 1.3 branch

*CheckList:*
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/index-management/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
