### PR TITLE
Adds an Alias action

### DIFF
--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/ISMActionsParser.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/ISMActionsParser.kt
@@ -8,6 +8,7 @@ package org.opensearch.indexmanagement.indexstatemanagement
 import org.opensearch.common.io.stream.StreamInput
 import org.opensearch.common.xcontent.XContentParser
 import org.opensearch.common.xcontent.XContentParserUtils
+import org.opensearch.indexmanagement.indexstatemanagement.action.AliasActionParser
 import org.opensearch.indexmanagement.indexstatemanagement.action.AllocationActionParser
 import org.opensearch.indexmanagement.indexstatemanagement.action.CloseActionParser
 import org.opensearch.indexmanagement.indexstatemanagement.action.DeleteActionParser
@@ -33,6 +34,7 @@ class ISMActionsParser private constructor() {
     }
 
     val parsers = mutableListOf(
+        AliasActionParser(),
         AllocationActionParser(),
         CloseActionParser(),
         DeleteActionParser(),

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/action/AliasAction.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/action/AliasAction.kt
@@ -1,0 +1,51 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.indexmanagement.indexstatemanagement.action
+
+import org.opensearch.action.admin.indices.alias.IndicesAliasesRequest
+import org.opensearch.common.io.stream.StreamOutput
+import org.opensearch.common.xcontent.ToXContent
+import org.opensearch.common.xcontent.XContentBuilder
+import org.opensearch.indexmanagement.indexstatemanagement.step.alias.AttemptAliasStep
+import org.opensearch.indexmanagement.spi.indexstatemanagement.Action
+import org.opensearch.indexmanagement.spi.indexstatemanagement.Step
+import org.opensearch.indexmanagement.spi.indexstatemanagement.model.StepContext
+
+class AliasAction(
+    val actions: List<IndicesAliasesRequest.AliasActions>,
+    index: Int
+) : Action(name, index) {
+
+    init {
+        require(actions.isNotEmpty()) { "At least one alias action needs to be specified." }
+    }
+
+    private val attemptAliasStep = AttemptAliasStep(this)
+
+    private val steps = listOf(attemptAliasStep)
+
+    override fun getStepToExecute(context: StepContext): Step {
+        return attemptAliasStep
+    }
+
+    override fun getSteps(): List<Step> = steps
+
+    override fun populateAction(builder: XContentBuilder, params: ToXContent.Params) {
+        builder.startObject(type)
+        builder.field(ACTIONS, actions)
+        builder.endObject()
+    }
+
+    override fun populateAction(out: StreamOutput) {
+        out.writeList(actions)
+        out.writeInt(actionIndex)
+    }
+
+    companion object {
+        const val name = "alias"
+        const val ACTIONS = "actions"
+    }
+}

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/action/AliasActionParser.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/action/AliasActionParser.kt
@@ -1,0 +1,45 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.indexmanagement.indexstatemanagement.action
+
+import org.opensearch.action.admin.indices.alias.IndicesAliasesRequest
+import org.opensearch.common.io.stream.StreamInput
+import org.opensearch.common.xcontent.XContentParser
+import org.opensearch.common.xcontent.XContentParser.Token
+import org.opensearch.common.xcontent.XContentParserUtils.ensureExpectedToken
+import org.opensearch.indexmanagement.indexstatemanagement.action.AliasAction.Companion.ACTIONS
+import org.opensearch.indexmanagement.spi.indexstatemanagement.Action
+import org.opensearch.indexmanagement.spi.indexstatemanagement.ActionParser
+
+class AliasActionParser : ActionParser() {
+    override fun fromStreamInput(sin: StreamInput): Action {
+        val actions = sin.readList(IndicesAliasesRequest::AliasActions)
+        val index = sin.readInt()
+        return AliasAction(actions, index)
+    }
+
+    override fun fromXContent(xcp: XContentParser, index: Int): Action {
+        val actions: MutableList<IndicesAliasesRequest.AliasActions> = mutableListOf()
+
+        ensureExpectedToken(Token.START_OBJECT, xcp.currentToken(), xcp)
+        while (xcp.nextToken() != Token.END_OBJECT) {
+            val fieldName = xcp.currentName()
+            xcp.nextToken()
+            when (fieldName) {
+                ACTIONS -> {
+                    ensureExpectedToken(Token.START_ARRAY, xcp.currentToken(), xcp)
+                    while (xcp.nextToken() != Token.END_ARRAY) {
+                        actions.add(IndicesAliasesRequest.AliasActions.fromXContent(xcp))
+                    }
+                }
+                else -> throw IllegalArgumentException("Invalid field: [$fieldName] found in AliasAction.")
+            }
+        }
+        return AliasAction(actions, index)
+    }
+
+    override fun getActionType(): String = AliasAction.name
+}

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/alias/AttemptAliasStep.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/alias/AttemptAliasStep.kt
@@ -1,0 +1,103 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.indexmanagement.indexstatemanagement.step.alias
+
+import org.apache.logging.log4j.LogManager
+import org.opensearch.action.admin.indices.alias.IndicesAliasesRequest
+import org.opensearch.action.support.master.AcknowledgedResponse
+import org.opensearch.common.Strings
+import org.opensearch.indexmanagement.indexstatemanagement.action.AliasAction
+import org.opensearch.indexmanagement.opensearchapi.convertToMap
+import org.opensearch.indexmanagement.opensearchapi.suspendUntil
+import org.opensearch.indexmanagement.spi.indexstatemanagement.Step
+import org.opensearch.indexmanagement.spi.indexstatemanagement.model.ManagedIndexMetaData
+import org.opensearch.indexmanagement.spi.indexstatemanagement.model.StepMetaData
+import org.opensearch.script.Script
+import org.opensearch.script.ScriptService
+import org.opensearch.script.ScriptType
+import org.opensearch.script.TemplateScript
+
+class AttemptAliasStep(private val action: AliasAction) : Step(name) {
+
+    private val logger = LogManager.getLogger(javaClass)
+    private var stepStatus = StepStatus.STARTING
+    private var info: Map<String, Any>? = null
+
+    override suspend fun execute(): Step {
+        val context = this.context ?: return this
+        val indexName = context.metadata.index
+        try {
+            val request = IndicesAliasesRequest()
+            action.actions.forEach {
+                // Take the indices that were set to be updated on the alias action and join them into a single string
+                // So we don't have to pass each one individually into the script service to be compiled
+                val indices = it.indices().joinToString(",")
+                // Compile them so the user can use the current dynamic index name in the name such as "{{ctx.index}}" in the static policy
+                val indicesScript = Script(ScriptType.INLINE, Script.DEFAULT_TEMPLATE_LANG, indices, mapOf())
+                val compiledIndices = compileTemplate(indicesScript, context.metadata, indices, context.scriptService)
+                // Split them back into individual index names and set back on the AliasActions request
+                val splitIndices = Strings.splitStringByCommaToArray(compiledIndices)
+                it.indices(*splitIndices)
+                request.addAliasAction(it)
+            }
+            val response: AcknowledgedResponse = context.client.admin().indices().suspendUntil { aliases(request, it) }
+            handleResponse(response, indexName)
+        } catch (e: Exception) {
+            handleException(e, indexName)
+        }
+        return this
+    }
+
+    private fun handleException(e: Exception, indexName: String) {
+        val message = getFailedMessage(indexName)
+        logger.error(message, e)
+        stepStatus = StepStatus.FAILED
+        val mutableInfo = mutableMapOf("message" to message)
+        val errorMessage = e.message
+        if (errorMessage != null) mutableInfo["cause"] = errorMessage
+        info = mutableInfo.toMap()
+    }
+
+    private fun handleResponse(response: AcknowledgedResponse, indexName: String) {
+        if (response.isAcknowledged) {
+            stepStatus = StepStatus.COMPLETED
+            info = mapOf("message" to getSuccessMessage(indexName))
+        } else {
+            stepStatus = StepStatus.FAILED
+            info = mapOf("message" to getFailedMessage(indexName))
+        }
+    }
+
+    override fun getUpdatedManagedIndexMetadata(currentMetadata: ManagedIndexMetaData): ManagedIndexMetaData {
+        return currentMetadata.copy(
+            stepMetaData = StepMetaData(name, getStepStartTime(currentMetadata).toEpochMilli(), stepStatus),
+            transitionTo = null,
+            info = info
+        )
+    }
+
+    private fun compileTemplate(
+        template: Script,
+        managedIndexMetaData: ManagedIndexMetaData,
+        defaultValue: String,
+        scriptService: ScriptService
+    ): String {
+        val contextMap = managedIndexMetaData.convertToMap().filterKeys { key -> key in validTopContextFields }
+        val compiledValue = scriptService.compile(template, TemplateScript.CONTEXT)
+            .newInstance(template.params + mapOf("ctx" to contextMap))
+            .execute()
+        return compiledValue.ifBlank { defaultValue }
+    }
+
+    override fun isIdempotent() = true
+
+    companion object {
+        val validTopContextFields = setOf("index")
+        const val name = "attempt_alias"
+        fun getFailedMessage(index: String) = "Failed to update alias [index=$index]"
+        fun getSuccessMessage(index: String) = "Successfully updated alias [index=$index]"
+    }
+}

--- a/src/main/resources/mappings/opendistro-ism-config.json
+++ b/src/main/resources/mappings/opendistro-ism-config.json
@@ -1,6 +1,6 @@
 {
   "_meta" : {
-    "schema_version": 13
+    "schema_version": 14
   },
   "dynamic": "strict",
   "properties": {
@@ -149,6 +149,14 @@
                     },
                     "delay": {
                       "type": "keyword"
+                    }
+                  }
+                },
+                "alias": {
+                  "properties": {
+                    "actions": {
+                      "type": "object",
+                      "enabled": false
                     }
                   }
                 },

--- a/src/test/kotlin/org/opensearch/indexmanagement/IndexManagementRestTestCase.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/IndexManagementRestTestCase.kt
@@ -27,7 +27,7 @@ import javax.management.remote.JMXServiceURL
 
 abstract class IndexManagementRestTestCase : ODFERestTestCase() {
 
-    val configSchemaVersion = 13
+    val configSchemaVersion = 14
     val historySchemaVersion = 4
 
     // Having issues with tests leaking into other tests and mappings being incorrect and they are not caught by any pending task wait check as

--- a/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/TestHelpers.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/TestHelpers.kt
@@ -5,11 +5,13 @@
 
 package org.opensearch.indexmanagement.indexstatemanagement
 
+import org.opensearch.action.admin.indices.alias.IndicesAliasesRequest
 import org.opensearch.common.unit.ByteSizeValue
 import org.opensearch.common.unit.TimeValue
 import org.opensearch.common.xcontent.ToXContent
 import org.opensearch.common.xcontent.XContentFactory
 import org.opensearch.index.seqno.SequenceNumbers
+import org.opensearch.indexmanagement.indexstatemanagement.action.AliasAction
 import org.opensearch.indexmanagement.indexstatemanagement.action.AllocationAction
 import org.opensearch.indexmanagement.indexstatemanagement.action.CloseAction
 import org.opensearch.indexmanagement.indexstatemanagement.action.DeleteAction
@@ -175,6 +177,18 @@ fun randomCloseActionConfig(): CloseAction {
 
 fun randomOpenActionConfig(): OpenAction {
     return OpenAction(index = 0)
+}
+
+fun randomAliasAction(): AliasAction {
+    val actions = List(OpenSearchRestTestCase.randomIntBetween(1, 10)) { randomAliasActions() }
+    return AliasAction(actions = actions, index = 0)
+}
+
+fun randomAliasActions(): IndicesAliasesRequest.AliasActions {
+    val types = listOf(IndicesAliasesRequest.AliasActions.Type.ADD, IndicesAliasesRequest.AliasActions.Type.REMOVE)
+    return IndicesAliasesRequest.AliasActions(OpenSearchRestTestCase.randomSubsetOf(1, types).first())
+        .alias(OpenSearchRestTestCase.randomAlphaOfLength(10))
+        .index(OpenSearchRestTestCase.randomAlphaOfLength(10))
 }
 
 fun randomDestination(type: DestinationType = randomDestinationType()): Destination {
@@ -434,6 +448,11 @@ fun CloseAction.toJsonString(): String {
 }
 
 fun OpenAction.toJsonString(): String {
+    val builder = XContentFactory.jsonBuilder()
+    return this.toXContent(builder, ToXContent.EMPTY_PARAMS).string()
+}
+
+fun AliasAction.toJsonString(): String {
     val builder = XContentFactory.jsonBuilder()
     return this.toXContent(builder, ToXContent.EMPTY_PARAMS).string()
 }

--- a/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/action/AliasActionIT.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/action/AliasActionIT.kt
@@ -1,0 +1,150 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.indexmanagement.indexstatemanagement.action
+
+import org.opensearch.action.admin.indices.alias.IndicesAliasesRequest
+import org.opensearch.indexmanagement.indexstatemanagement.IndexStateManagementRestTestCase
+import org.opensearch.indexmanagement.indexstatemanagement.model.Policy
+import org.opensearch.indexmanagement.indexstatemanagement.model.State
+import org.opensearch.indexmanagement.indexstatemanagement.randomErrorNotification
+import org.opensearch.indexmanagement.indexstatemanagement.step.alias.AttemptAliasStep
+import org.opensearch.indexmanagement.waitFor
+import java.time.Instant
+import java.time.temporal.ChronoUnit
+import java.util.Locale
+
+class AliasActionIT : IndexStateManagementRestTestCase() {
+    private val testIndexName = javaClass.simpleName.toLowerCase(Locale.ROOT)
+
+    fun `test adding alias to index`() {
+        val indexName = "${testIndexName}_index_1"
+        val policyID = "${testIndexName}_testPolicyName_1"
+        val aliasName = "some_alias_to_add"
+        val actions = listOf(IndicesAliasesRequest.AliasActions.add().alias(aliasName).index(indexName))
+        val actionConfig = AliasAction(actions = actions, index = 0)
+        val states = listOf(State("alias", listOf(actionConfig), listOf()))
+
+        val policy = Policy(
+            id = policyID,
+            description = "$testIndexName description",
+            schemaVersion = 1L,
+            lastUpdatedTime = Instant.now().truncatedTo(ChronoUnit.MILLIS),
+            errorNotification = randomErrorNotification(),
+            defaultState = states[0].name,
+            states = states
+        )
+        createPolicy(policy, policyID)
+        createIndex(indexName, policyID)
+        val managedIndexConfig = getExistingManagedIndexConfig(indexName)
+
+        // Change the start time so the job will trigger in 2 seconds.
+        updateManagedIndexConfigStartTime(managedIndexConfig)
+
+        waitFor { assertEquals(policyID, getExplainManagedIndexMetaData(indexName).policyID) }
+
+        waitFor {
+            val alias = getAlias(indexName, "")
+            assertTrue("Alias was already added to index", !alias.containsKey(aliasName))
+        }
+
+        // Need to wait two cycles.
+        // Change the start time so the job will trigger in 2 seconds.
+        updateManagedIndexConfigStartTime(managedIndexConfig)
+
+        waitFor {
+            val info = getExplainManagedIndexMetaData(indexName).info as Map<String, Any?>
+            assertEquals("Alias was not successfully updated", AttemptAliasStep.getSuccessMessage(indexName), info["message"])
+            val alias = getAlias(indexName, "")
+            assertTrue("Alias was not added to index", alias.containsKey(aliasName))
+        }
+    }
+
+    fun `test adding alias to index using ctx`() {
+        val indexName = "${testIndexName}_index_2"
+        val policyID = "${testIndexName}_testPolicyName_2"
+        val aliasName = "some_alias_to_add"
+        val actions = listOf(IndicesAliasesRequest.AliasActions.add().alias(aliasName).index("{{ctx.index}}"))
+        val actionConfig = AliasAction(actions = actions, index = 0)
+        val states = listOf(State("alias", listOf(actionConfig), listOf()))
+
+        val policy = Policy(
+            id = policyID,
+            description = "$testIndexName description",
+            schemaVersion = 1L,
+            lastUpdatedTime = Instant.now().truncatedTo(ChronoUnit.MILLIS),
+            errorNotification = randomErrorNotification(),
+            defaultState = states[0].name,
+            states = states
+        )
+        createPolicy(policy, policyID)
+        createIndex(indexName, policyID)
+        val managedIndexConfig = getExistingManagedIndexConfig(indexName)
+
+        // Change the start time so the job will trigger in 2 seconds.
+        updateManagedIndexConfigStartTime(managedIndexConfig)
+
+        waitFor { assertEquals(policyID, getExplainManagedIndexMetaData(indexName).policyID) }
+
+        waitFor {
+            val alias = getAlias(indexName, "")
+            assertTrue("Alias was already added to index", !alias.containsKey(aliasName))
+        }
+
+        // Need to wait two cycles.
+        // Change the start time so the job will trigger in 2 seconds.
+        updateManagedIndexConfigStartTime(managedIndexConfig)
+
+        waitFor {
+            val info = getExplainManagedIndexMetaData(indexName).info as Map<String, Any?>
+            assertEquals("Alias was not successfully updated", AttemptAliasStep.getSuccessMessage(indexName), info["message"])
+            val alias = getAlias(indexName, "")
+            assertTrue("Alias was not added to index", alias.containsKey(aliasName))
+        }
+    }
+
+    fun `test removing alias from index`() {
+        val indexName = "${testIndexName}_index_3"
+        val policyID = "${testIndexName}_testPolicyName_3"
+        val aliasName = "some_alias_to_remove"
+        val actions = listOf(IndicesAliasesRequest.AliasActions.remove().alias(aliasName).index(indexName))
+        val actionConfig = AliasAction(actions = actions, index = 0)
+        val states = listOf(State("alias", listOf(actionConfig), listOf()))
+
+        val policy = Policy(
+            id = policyID,
+            description = "$testIndexName description",
+            schemaVersion = 1L,
+            lastUpdatedTime = Instant.now().truncatedTo(ChronoUnit.MILLIS),
+            errorNotification = randomErrorNotification(),
+            defaultState = states[0].name,
+            states = states
+        )
+        createPolicy(policy, policyID)
+        createIndex(indexName, policyID, aliasName)
+        val managedIndexConfig = getExistingManagedIndexConfig(indexName)
+
+        // Change the start time so the job will trigger in 2 seconds.
+        updateManagedIndexConfigStartTime(managedIndexConfig)
+
+        waitFor { assertEquals(policyID, getExplainManagedIndexMetaData(indexName).policyID) }
+
+        waitFor {
+            val alias = getAlias(indexName, "")
+            assertTrue("Alias was not added to index", alias.containsKey(aliasName))
+        }
+
+        // Need to wait two cycles.
+        // Change the start time so the job will trigger in 2 seconds.
+        updateManagedIndexConfigStartTime(managedIndexConfig)
+
+        waitFor {
+            val info = getExplainManagedIndexMetaData(indexName).info as Map<String, Any?>
+            assertEquals("Alias was not successfully updated", AttemptAliasStep.getSuccessMessage(indexName), info["message"])
+            val alias = getAlias(indexName, "")
+            assertTrue("Alias was not removed from index", !alias.containsKey(aliasName))
+        }
+    }
+}

--- a/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/model/XContentTests.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/model/XContentTests.kt
@@ -12,6 +12,7 @@ import org.opensearch.indexmanagement.indexstatemanagement.ISMActionsParser
 import org.opensearch.indexmanagement.indexstatemanagement.action.RollupAction
 import org.opensearch.indexmanagement.indexstatemanagement.model.destination.DestinationType
 import org.opensearch.indexmanagement.indexstatemanagement.nonNullRandomConditions
+import org.opensearch.indexmanagement.indexstatemanagement.randomAliasAction
 import org.opensearch.indexmanagement.indexstatemanagement.randomAllocationActionConfig
 import org.opensearch.indexmanagement.indexstatemanagement.randomChangePolicy
 import org.opensearch.indexmanagement.indexstatemanagement.randomCloseActionConfig
@@ -251,6 +252,14 @@ class XContentTests : OpenSearchTestCase() {
         val changePolicyString = changePolicy.toJsonString()
         val parsedChangePolicy = ChangePolicy.parse(parser(changePolicyString))
         assertEquals("Round tripping ChangePolicy doesn't work", changePolicy, parsedChangePolicy)
+    }
+
+    fun `test alias action parsing`() {
+        val aliasAction = randomAliasAction()
+
+        val aliasActionString = aliasAction.toJsonString()
+        val parsedAliasAction = ISMActionsParser.instance.parse(parser(aliasActionString), 0)
+        assertEquals("Round tripping AliasAction doesn't work", aliasAction.convertToMap(), parsedAliasAction.convertToMap())
     }
 
     private fun parser(xc: String): XContentParser {

--- a/src/test/resources/mappings/cached-opendistro-ism-config.json
+++ b/src/test/resources/mappings/cached-opendistro-ism-config.json
@@ -1,6 +1,6 @@
 {
   "_meta" : {
-    "schema_version": 13
+    "schema_version": 14
   },
   "dynamic": "strict",
   "properties": {
@@ -149,6 +149,14 @@
                     },
                     "delay": {
                       "type": "keyword"
+                    }
+                  }
+                },
+                "alias": {
+                  "properties": {
+                    "actions": {
+                      "type": "object",
+                      "enabled": false
                     }
                   }
                 },


### PR DESCRIPTION
Signed-off-by: Drew Baugher <46505179+dbbaughe@users.noreply.github.com>

*Issue #, if available:*
https://github.com/opensearch-project/index-management/issues/35

*Description of changes:*
Adds support for an alias action in ISM.
Gives complete support for all update alias API options by reusing the alias actions parser internally and explicitly not defining the mappings in our config index.

Coming from the GitHub feature request, the use cases people asked for:


1. One use case we have is for indices older than a certain age, we allocate them to a cold node, shrink them, delete the original and create an alias with the original name that points to the shrink index. This keeps our shard count down while not breaking queries for older data.
1.1. As of right now I don't believe this would be doable because we do not know the name of the source index that was used to shrink to this target index. To do so we need to update core to store this information in the IndexMetadata when the shrink operation is performed. This theoretically should be doable though once we release the Shrink action.. in a roundabout kind of way. Essentially once ISM shrinks `foo-index` to `foo-index-shrink` there will be two jobs running. One for `foo-index` and one for `foo-index-shrink`. If we knew what the source index of the shrink was on `foo-index-shrink` then `foo-index-shrink` could call the update alias API and delete the `foo-index` and add that as an alias to itself in a single API call I believe. Since that's not possible for now.. then going the other way the `foo-index` after it successfully executes the Shrink action should be able to do the same thing, it can call the update alias API and delete itself while also setting an alias on the `foo-index-shrink` equal to it's own index name.
1.2
    ```
    PUT foo-index
    PUT foo-index-shrink
    POST /_aliases
    {
      "actions" : [
        { "remove_index": { "index": "foo-index" } },
        { "add" : { "index" : "foo-index-shrink", "alias" : "foo-index" } }
      ]
    }
    ```
2. My use case is when an index foo is shrunk, it becomes shrink-foo. An alias action would allow the new shrunk index to also be aliased to foo so applications don't know the difference. When we moved from x-pack and ILM to ISM, the aliasing had to be handled with custom code outside ES. I'd be just as happy with the alias being an optional setting on the shrink operation. Happy to share details, but what we're doing is pretty basic.
2.1 I'm assuming this is similar to (1) because I don't believe you can add an alias that is a concrete index. So you would need to delete the `foo` index in this example. So if it's the same as (1) then yes, there would be a way once we support Shrink action.
3. my use case is around the shrinking of indices as well. But in general I think it would be great to support adding an alias, especially if we get to the stage where we can roll up indices into single indices then alias them with the ones that were rolled up.
3.1 Should be similar to previous cases where the job that performs the rollup would have to then go and update the target index to have aliases of the source index patterns. The downside being I don't believe this specific policy would be that reusable.. and it wouldn't be possible to go the other way, i.e. a target rollup index comes into being and starts being managed and then figures out which indices it was rolled up from (we might actually store that information in the meta mappings of the rollup target index, so it could be doable in the future). Or if the source index has a wildcard pattern like `log*` then when updating the alias for the target index.. we can't use that and would have to resolve to concrete indices which could be old or become stale.
4. My use case is, If we have an alias for an index with rollover ILM policy, can we remove it from alias after some predefined days, let's say 30 days? I know there is a way to delete an index once its old, but in our case we do not want to delete but want the index to be removed from alias and have the alias switch and point to indices whose age is less than 30 days.
4.1. This should be easily doable with the Alias action, just have a state that gets transitioned into after the index is 30 days old (or 30 days rollover age) and then remove the alias.
5. My use case is: we provide search_alias to search our dataset. We publish new version of dataset every week as a new index (e.g. dataset-yyyy-MM-dd. We want the search_alias always pointing to the latest published dataset. The process is: ingest new data to a new index, once ingestion finish, re-pointing search_alias to the new index, remove old index from the search_alias
5.1 Should be possible, the newly created index can remove the alias from all search-index-* indices and then add the alias it itself in a single call. The main thing would be knowing when ingestion finished for the new index.. which you could just use some absolute time using the transition condition if you know it only takes x amount of time.

*CheckList:*
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/index-management/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
