### PR TITLE
Enforces extension action parsers have custom flag

### DIFF
--- a/release-notes/opensearch-index-management.release-notes-1.3.0.0.md
+++ b/release-notes/opensearch-index-management.release-notes-1.3.0.0.md
@@ -24,6 +24,7 @@ Compatible with OpenSearch 1.3.0
 * Fixes flaky continuous transforms test ([#276](https://github.com/opensearch-project/index-management/pull/276))
 * Porting additional missing logic ([#275](https://github.com/opensearch-project/index-management/pull/275))
 * Fixes test failures with security enabled ([#292](https://github.com/opensearch-project/index-management/pull/292))
+* Enforces extension action parsers have custom flag ([#306](https://github.com/opensearch-project/index-management/pull/306))
 
 ### Infrastructure
 * Add support for codeowners to repo ([#195](https://github.com/opensearch-project/index-management/pull/195))

--- a/src/main/kotlin/org/opensearch/indexmanagement/IndexManagementPlugin.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/IndexManagementPlugin.kt
@@ -251,7 +251,7 @@ class IndexManagementPlugin : JobSchedulerExtension, NetworkPlugin, ActionPlugin
         indexManagementExtensions.forEach { extension ->
             val extensionName = extension.getExtensionName()
             if (extensionName in extensions) {
-                throw IllegalStateException("Mutliple extensions of IndexManagement have same name $extensionName - not supported")
+                throw IllegalStateException("Multiple extensions of IndexManagement have same name $extensionName - not supported")
             }
             extension.getISMActionParsers().forEach { parser ->
                 ISMActionsParser.instance.addParser(parser, extensionName)

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/ISMActionsParser.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/ISMActionsParser.kt
@@ -50,10 +50,16 @@ class ISMActionsParser private constructor() {
 
     val customActionExtensionMap = mutableMapOf<String, String>()
 
+    /*
+     * This method is used for adding custom action parsers. Action parsers from ISM should be added directly
+     * to the parsers list.
+     */
     fun addParser(parser: ActionParser, extensionName: String) {
         if (parsers.map { it.getActionType() }.contains(parser.getActionType())) {
             throw IllegalArgumentException(getDuplicateActionTypesMessage(parser.getActionType()))
         }
+        // Set the parser as custom to make sure that the custom actions are written with the "custom" wrapper
+        parser.customAction = true
         parsers.add(parser)
         customActionExtensionMap[parser.getActionType()] = extensionName
     }

--- a/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/extension/ISMActionsParserTests.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/extension/ISMActionsParserTests.kt
@@ -31,7 +31,6 @@ class ISMActionsParserTests : OpenSearchTestCase() {
 
     fun `test duplicate action names fail`() {
         val customActionParser = SampleCustomActionParser()
-        customActionParser.customAction = true
         // Duplicate custom parser names should fail
         ISMActionsParser.instance.addParser(customActionParser, extensionName)
         assertFailsWith<IllegalArgumentException>("Expected IllegalArgumentException for duplicate action names") {
@@ -46,7 +45,6 @@ class ISMActionsParserTests : OpenSearchTestCase() {
 
     fun `test custom action parsing`() {
         val customActionParser = SampleCustomActionParser()
-        customActionParser.customAction = true
         ISMActionsParser.instance.addParser(customActionParser, extensionName)
         val customAction = SampleCustomActionParser.SampleCustomAction(randomInt(), 0)
         val builder = XContentFactory.jsonBuilder()
@@ -62,7 +60,6 @@ class ISMActionsParserTests : OpenSearchTestCase() {
 
     fun `test parsing custom action without custom flag`() {
         val customActionParser = SampleCustomActionParser()
-        customActionParser.customAction = true
         ISMActionsParser.instance.addParser(customActionParser, extensionName)
         val customAction = SampleCustomActionParser.SampleCustomAction(randomInt(), 0)
         customAction.customAction = true

--- a/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/transport/action/getpolicy/GetPolicyResponseTests.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/transport/action/getpolicy/GetPolicyResponseTests.kt
@@ -57,7 +57,6 @@ class GetPolicyResponseTests : OpenSearchTestCase() {
     @Suppress("UNCHECKED_CAST")
     fun `test get policy response custom action`() {
         val customActionParser = SampleCustomActionParser()
-        customActionParser.customAction = true
         val extensionName = "testExtension"
         ISMActionsParser.instance.addParser(customActionParser, extensionName)
         val id = "id"

--- a/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/transport/action/indexpolicy/IndexPolicyRequestTests.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/transport/action/indexpolicy/IndexPolicyRequestTests.kt
@@ -111,7 +111,6 @@ class IndexPolicyRequestTests : OpenSearchTestCase() {
 
     fun `test index policy request custom action`() {
         val customActionParser = SampleCustomActionParser()
-        customActionParser.customAction = true
         val extensionName = "testExtension"
         ISMActionsParser.instance.addParser(customActionParser, extensionName)
         val policyID = "policyID"

--- a/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/transport/action/indexpolicy/IndexPolicyResponseTests.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/transport/action/indexpolicy/IndexPolicyResponseTests.kt
@@ -62,7 +62,6 @@ class IndexPolicyResponseTests : OpenSearchTestCase() {
     @Suppress("UNCHECKED_CAST")
     fun `test index policy response custom action`() {
         val customActionParser = SampleCustomActionParser()
-        customActionParser.customAction = true
         val extensionName = "testExtension"
         ISMActionsParser.instance.addParser(customActionParser, extensionName)
         val id = "id"


### PR DESCRIPTION
Signed-off-by: Clay Downs <downsrob@amazon.com>

*Issue #, if available:*
NA
*Description of changes:*
Enforces extension action parsers have custom flag. Before this change, if an extension did not explicitly set in the constructor that the parser was custom, then the custom wrapper would not be used when serializing 

*CheckList:*
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/index-management/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
