### PR TITLE
Fixes custom action parsing

### DIFF
--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/ISMActionsParser.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/ISMActionsParser.kt
@@ -91,9 +91,9 @@ class ISMActionsParser private constructor() {
                 Action.CUSTOM_ACTION_FIELD -> {
                     // The "custom" wrapper allows extensions to create arbitrary actions without updating the config mappings
                     // We consume the full custom wrapper and parse the action in this step
-                    XContentParserUtils.ensureExpectedToken(XContentParser.Token.START_OBJECT, xcp.nextToken(), xcp)
-                    val customActionType = xcp.currentName()
                     XContentParserUtils.ensureExpectedToken(XContentParser.Token.FIELD_NAME, xcp.nextToken(), xcp)
+                    val customActionType = xcp.currentName()
+                    XContentParserUtils.ensureExpectedToken(XContentParser.Token.START_OBJECT, xcp.nextToken(), xcp)
                     action = parseAction(xcp, totalActions, customActionType)
                     XContentParserUtils.ensureExpectedToken(XContentParser.Token.END_OBJECT, xcp.nextToken(), xcp)
                 }

--- a/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/extension/ISMActionsParserTests.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/extension/ISMActionsParserTests.kt
@@ -72,4 +72,19 @@ class ISMActionsParserTests : OpenSearchTestCase() {
         assertEquals("Round tripping custom action doesn't work", customAction.convertToMap(), parsedCustomAction.convertToMap())
         assertTrue("Custom action did not have custom keyword after parsing", parsedCustomAction.convertToMap().containsKey("custom"))
     }
+
+    fun `test parsing custom action with custom flag`() {
+        val customActionParser = SampleCustomActionParser()
+        ISMActionsParser.instance.addParser(customActionParser, extensionName)
+        val customAction = SampleCustomActionParser.SampleCustomAction(randomInt(), 0)
+        customAction.customAction = true
+
+        val customActionString = "{\"retry\":{\"count\":3,\"backoff\":\"exponential\",\"delay\":\"1m\"},\"custom\": {\"some_custom_action\":{\"some_int_field\":${customAction.someInt}}}}"
+        val parser = XContentType.JSON.xContent().createParser(xContentRegistry(), LoggingDeprecationHandler.INSTANCE, customActionString)
+        parser.nextToken()
+        val parsedCustomAction = ISMActionsParser.instance.parse(parser, 1)
+        assertTrue("Action was not set to be custom after parsing", parsedCustomAction.customAction)
+        assertEquals("Round tripping custom action doesn't work", customAction.convertToMap(), parsedCustomAction.convertToMap())
+        assertTrue("Custom action did not have custom keyword after parsing", parsedCustomAction.convertToMap().containsKey("custom"))
+    }
 }


### PR DESCRIPTION
Signed-off-by: Clay Downs <downsrob@amazon.com>

*Issue #, if available:*
NA

*Description of changes:*
Fixes custom action parsing which was failing due to having the token assertions in the wrong order. Custom parsing was being tested exclusively through unit tests, and there was no unit test for actually parsing an extension action written out with the "custom" wrapper, adds that unit test.

*CheckList:*
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/index-management/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
