### PR TITLE
BugFix: correcting evaluation of the index uuid for deleted indices

### DIFF
--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/ManagedIndexCoordinator.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/ManagedIndexCoordinator.kt
@@ -298,7 +298,7 @@ class ManagedIndexCoordinator(
             val deletedIndices = event.indicesDeleted().map { it.name }
             // Creating a set of index uuids for the deleted index names from all the registered index metadata services
             val allIndicesUuid = indexMetadataProvider.getMultiTypeISMIndexMetadata(indexNames = deletedIndices).map { (_, metadataMapForType) ->
-                metadataMapForType.keys
+                metadataMapForType.values.map { metadata -> metadata.indexUuid }
             }.flatten().toSet()
             // Check if the deleted index uuid is still part of any metadata service in the cluster and has an existing managed index job
             indicesToClean = event.indicesDeleted().filter { it.uuid in managedIndices.keys && !allIndicesUuid.contains(it.uuid) }

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/ManagedIndexCoordinator.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/ManagedIndexCoordinator.kt
@@ -296,9 +296,10 @@ class ManagedIndexCoordinator(
         if (event.indicesDeleted().isNotEmpty()) {
             val managedIndices = getManagedIndices(event.indicesDeleted().map { it.uuid })
             val deletedIndices = event.indicesDeleted().map { it.name }
+            // Creating a set of index uuids for the deleted index names from all the registered index metadata services
             val allIndicesUuid = indexMetadataProvider.getMultiTypeISMIndexMetadata(indexNames = deletedIndices).map { (_, metadataMapForType) ->
-                metadataMapForType.values
-            }
+                metadataMapForType.keys
+            }.flatten().toSet()
             // Check if the deleted index uuid is still part of any metadata service in the cluster and has an existing managed index job
             indicesToClean = event.indicesDeleted().filter { it.uuid in managedIndices.keys && !allIndicesUuid.contains(it.uuid) }
             removeManagedIndexReq = indicesToClean.map { deleteManagedIndexRequest(it.uuid) }


### PR DESCRIPTION
Signed-off-by: Ravi Thaluru <thalurur@users.noreply.github.com>

*Issue #, if available:*
N/A

*Description of changes:*
* When an index is deleted coordinator determines if the managed job related to the deleted index if exists need to be deleted. 
* Correcting the logic around the population of the index UUIDs from all the metadata services registered with the IM.
* We will delete the managed index job of the deleted index if the index UUID is not present in any registered metadata service and it is a managed index


*CheckList:*
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/index-management/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
