### PR TITLE
Adds shrink action to ISM

### DIFF
--- a/spi/build.gradle
+++ b/spi/build.gradle
@@ -53,6 +53,7 @@ configurations.all {
 
 dependencies {
     compileOnly "org.opensearch:opensearch:${opensearch_version}"
+    compileOnly "org.opensearch:opensearch-job-scheduler-spi:${job_scheduler_version}"
     compileOnly "org.jetbrains.kotlin:kotlin-stdlib:${kotlin_version}"
     compileOnly "org.jetbrains.kotlin:kotlin-stdlib-common:${kotlin_version}"
     compileOnly "org.jetbrains.kotlin:kotlin-stdlib-jdk8:${kotlin_version}"

--- a/spi/src/main/kotlin/org.opensearch.indexmanagement.spi/indexstatemanagement/model/ShrinkActionProperties.kt
+++ b/spi/src/main/kotlin/org.opensearch.indexmanagement.spi/indexstatemanagement/model/ShrinkActionProperties.kt
@@ -20,7 +20,8 @@ data class ShrinkActionProperties(
     val targetNumShards: Int,
     val lockPrimaryTerm: Long,
     val lockSeqNo: Long,
-    val lockEpochSecond: Long
+    val lockEpochSecond: Long,
+    val lockDurationSecond: Long
 ) : Writeable, ToXContentFragment {
 
     override fun writeTo(out: StreamOutput) {
@@ -30,6 +31,7 @@ data class ShrinkActionProperties(
         out.writeLong(lockPrimaryTerm)
         out.writeLong(lockSeqNo)
         out.writeLong(lockEpochSecond)
+        out.writeLong(lockDurationSecond)
     }
 
     override fun toXContent(builder: XContentBuilder, params: ToXContent.Params): XContentBuilder {
@@ -39,6 +41,7 @@ data class ShrinkActionProperties(
         builder.field(ShrinkProperties.LOCK_SEQ_NO.key, lockSeqNo)
         builder.field(ShrinkProperties.LOCK_PRIMARY_TERM.key, lockPrimaryTerm)
         builder.field(ShrinkProperties.LOCK_EPOCH_SECOND.key, lockEpochSecond)
+        builder.field(ShrinkProperties.LOCK_DURATION_SECOND.key, lockDurationSecond)
         return builder
     }
 
@@ -52,8 +55,9 @@ data class ShrinkActionProperties(
             val lockPrimaryTerm: Long = si.readLong()
             val lockSeqNo: Long = si.readLong()
             val lockEpochSecond: Long = si.readLong()
+            val lockDurationSecond: Long = si.readLong()
 
-            return ShrinkActionProperties(nodeName, targetIndexName, targetNumShards, lockPrimaryTerm, lockSeqNo, lockEpochSecond)
+            return ShrinkActionProperties(nodeName, targetIndexName, targetNumShards, lockPrimaryTerm, lockSeqNo, lockEpochSecond, lockDurationSecond)
         }
 
         fun parse(xcp: XContentParser): ShrinkActionProperties {
@@ -63,6 +67,7 @@ data class ShrinkActionProperties(
             var lockPrimaryTerm: Long? = null
             var lockSeqNo: Long? = null
             var lockEpochSecond: Long? = null
+            var lockDurationSecond: Long? = null
 
             XContentParserUtils.ensureExpectedToken(XContentParser.Token.START_OBJECT, xcp.currentToken(), xcp)
             while (xcp.nextToken() != XContentParser.Token.END_OBJECT) {
@@ -76,6 +81,7 @@ data class ShrinkActionProperties(
                     ShrinkProperties.LOCK_PRIMARY_TERM.key -> lockPrimaryTerm = xcp.longValue()
                     ShrinkProperties.LOCK_SEQ_NO.key -> lockSeqNo = xcp.longValue()
                     ShrinkProperties.LOCK_EPOCH_SECOND.key -> lockEpochSecond = xcp.longValue()
+                    ShrinkProperties.LOCK_DURATION_SECOND.key -> lockDurationSecond = xcp.longValue()
                 }
             }
 
@@ -85,7 +91,8 @@ data class ShrinkActionProperties(
                 requireNotNull(targetNumShards),
                 requireNotNull(lockPrimaryTerm),
                 requireNotNull(lockSeqNo),
-                requireNotNull(lockEpochSecond)
+                requireNotNull(lockEpochSecond),
+                requireNotNull(lockDurationSecond)
             )
         }
     }
@@ -96,6 +103,7 @@ data class ShrinkActionProperties(
         TARGET_NUM_SHARDS("target_num_shards"),
         LOCK_SEQ_NO("lock_seq_no"),
         LOCK_PRIMARY_TERM("lock_primary_term"),
-        LOCK_EPOCH_SECOND("lock_epoch_second")
+        LOCK_EPOCH_SECOND("lock_epoch_second"),
+        LOCK_DURATION_SECOND("lock_duration_second")
     }
 }

--- a/spi/src/main/kotlin/org.opensearch.indexmanagement.spi/indexstatemanagement/model/ShrinkActionProperties.kt
+++ b/spi/src/main/kotlin/org.opensearch.indexmanagement.spi/indexstatemanagement/model/ShrinkActionProperties.kt
@@ -1,0 +1,101 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.indexmanagement.spi.indexstatemanagement.model
+
+import org.opensearch.common.io.stream.StreamInput
+import org.opensearch.common.io.stream.StreamOutput
+import org.opensearch.common.io.stream.Writeable
+import org.opensearch.common.xcontent.ToXContent
+import org.opensearch.common.xcontent.ToXContentFragment
+import org.opensearch.common.xcontent.XContentBuilder
+import org.opensearch.common.xcontent.XContentParser
+import org.opensearch.common.xcontent.XContentParserUtils
+
+data class ShrinkActionProperties(
+    val nodeName: String,
+    val targetIndexName: String,
+    val targetNumShards: Int,
+    val lockPrimaryTerm: Long,
+    val lockSeqNo: Long,
+    val lockEpochSecond: Long
+) : Writeable, ToXContentFragment {
+
+    override fun writeTo(out: StreamOutput) {
+        out.writeString(nodeName)
+        out.writeString(targetIndexName)
+        out.writeInt(targetNumShards)
+        out.writeLong(lockPrimaryTerm)
+        out.writeLong(lockSeqNo)
+        out.writeLong(lockEpochSecond)
+    }
+
+    override fun toXContent(builder: XContentBuilder, params: ToXContent.Params): XContentBuilder {
+        builder.field(ShrinkProperties.NODE_NAME.key, nodeName)
+        builder.field(ShrinkProperties.TARGET_INDEX_NAME.key, targetIndexName)
+        builder.field(ShrinkProperties.TARGET_NUM_SHARDS.key, targetNumShards)
+        builder.field(ShrinkProperties.LOCK_SEQ_NO.key, lockSeqNo)
+        builder.field(ShrinkProperties.LOCK_PRIMARY_TERM.key, lockPrimaryTerm)
+        builder.field(ShrinkProperties.LOCK_EPOCH_SECOND.key, lockEpochSecond)
+        return builder
+    }
+
+    companion object {
+        const val SHRINK_ACTION_PROPERTIES = "shrink_action_properties"
+
+        fun fromStreamInput(si: StreamInput): ShrinkActionProperties {
+            val nodeName: String = si.readString()
+            val targetIndexName: String = si.readString()
+            val targetNumShards: Int = si.readInt()
+            val lockPrimaryTerm: Long = si.readLong()
+            val lockSeqNo: Long = si.readLong()
+            val lockEpochSecond: Long = si.readLong()
+
+            return ShrinkActionProperties(nodeName, targetIndexName, targetNumShards, lockPrimaryTerm, lockSeqNo, lockEpochSecond)
+        }
+
+        fun parse(xcp: XContentParser): ShrinkActionProperties {
+            var nodeName: String? = null
+            var targetIndexName: String? = null
+            var targetNumShards: Int? = null
+            var lockPrimaryTerm: Long? = null
+            var lockSeqNo: Long? = null
+            var lockEpochSecond: Long? = null
+
+            XContentParserUtils.ensureExpectedToken(XContentParser.Token.START_OBJECT, xcp.currentToken(), xcp)
+            while (xcp.nextToken() != XContentParser.Token.END_OBJECT) {
+                val fieldName = xcp.currentName()
+                xcp.nextToken()
+
+                when (fieldName) {
+                    ShrinkProperties.NODE_NAME.key -> nodeName = xcp.text()
+                    ShrinkProperties.TARGET_INDEX_NAME.key -> targetIndexName = xcp.text()
+                    ShrinkProperties.TARGET_NUM_SHARDS.key -> targetNumShards = xcp.intValue()
+                    ShrinkProperties.LOCK_PRIMARY_TERM.key -> lockPrimaryTerm = xcp.longValue()
+                    ShrinkProperties.LOCK_SEQ_NO.key -> lockSeqNo = xcp.longValue()
+                    ShrinkProperties.LOCK_EPOCH_SECOND.key -> lockEpochSecond = xcp.longValue()
+                }
+            }
+
+            return ShrinkActionProperties(
+                requireNotNull(nodeName),
+                requireNotNull(targetIndexName),
+                requireNotNull(targetNumShards),
+                requireNotNull(lockPrimaryTerm),
+                requireNotNull(lockSeqNo),
+                requireNotNull(lockEpochSecond)
+            )
+        }
+    }
+
+    enum class ShrinkProperties(val key: String) {
+        NODE_NAME("node_name"),
+        TARGET_INDEX_NAME("target_index_name"),
+        TARGET_NUM_SHARDS("target_num_shards"),
+        LOCK_SEQ_NO("lock_seq_no"),
+        LOCK_PRIMARY_TERM("lock_primary_term"),
+        LOCK_EPOCH_SECOND("lock_epoch_second")
+    }
+}

--- a/spi/src/main/kotlin/org.opensearch.indexmanagement.spi/indexstatemanagement/model/StepContext.kt
+++ b/spi/src/main/kotlin/org.opensearch.indexmanagement.spi/indexstatemanagement/model/StepContext.kt
@@ -10,6 +10,7 @@ import org.opensearch.cluster.service.ClusterService
 import org.opensearch.common.settings.Settings
 import org.opensearch.common.util.concurrent.ThreadContext
 import org.opensearch.commons.authuser.User
+import org.opensearch.jobscheduler.spi.JobExecutionContext
 import org.opensearch.script.ScriptService
 
 class StepContext(
@@ -20,8 +21,9 @@ class StepContext(
     val user: User?,
     val scriptService: ScriptService,
     val settings: Settings,
+    val jobContext: JobExecutionContext
 ) {
     fun getUpdatedContext(metadata: ManagedIndexMetaData): StepContext {
-        return StepContext(metadata, this.clusterService, this.client, this.threadContext, this.user, this.scriptService, this.settings)
+        return StepContext(metadata, this.clusterService, this.client, this.threadContext, this.user, this.scriptService, this.settings, this.jobContext)
     }
 }

--- a/spi/src/main/kotlin/org.opensearch.indexmanagement.spi/indexstatemanagement/model/StepContext.kt
+++ b/spi/src/main/kotlin/org.opensearch.indexmanagement.spi/indexstatemanagement/model/StepContext.kt
@@ -10,7 +10,7 @@ import org.opensearch.cluster.service.ClusterService
 import org.opensearch.common.settings.Settings
 import org.opensearch.common.util.concurrent.ThreadContext
 import org.opensearch.commons.authuser.User
-import org.opensearch.jobscheduler.spi.JobExecutionContext
+import org.opensearch.jobscheduler.spi.utils.LockService
 import org.opensearch.script.ScriptService
 
 class StepContext(
@@ -21,9 +21,9 @@ class StepContext(
     val user: User?,
     val scriptService: ScriptService,
     val settings: Settings,
-    val jobContext: JobExecutionContext
+    val lockService: LockService
 ) {
     fun getUpdatedContext(metadata: ManagedIndexMetaData): StepContext {
-        return StepContext(metadata, this.clusterService, this.client, this.threadContext, this.user, this.scriptService, this.settings, this.jobContext)
+        return StepContext(metadata, this.clusterService, this.client, this.threadContext, this.user, this.scriptService, this.settings, this.lockService)
     }
 }

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/ISMActionsParser.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/ISMActionsParser.kt
@@ -20,6 +20,7 @@ import org.opensearch.indexmanagement.indexstatemanagement.action.ReadWriteActio
 import org.opensearch.indexmanagement.indexstatemanagement.action.ReplicaCountActionParser
 import org.opensearch.indexmanagement.indexstatemanagement.action.RolloverActionParser
 import org.opensearch.indexmanagement.indexstatemanagement.action.RollupActionParser
+import org.opensearch.indexmanagement.indexstatemanagement.action.ShrinkActionParser
 import org.opensearch.indexmanagement.indexstatemanagement.action.SnapshotActionParser
 import org.opensearch.indexmanagement.spi.indexstatemanagement.Action
 import org.opensearch.indexmanagement.spi.indexstatemanagement.ActionParser
@@ -45,6 +46,7 @@ class ISMActionsParser private constructor() {
         ReplicaCountActionParser(),
         RollupActionParser(),
         RolloverActionParser(),
+        ShrinkActionParser(),
         SnapshotActionParser()
     )
 

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/ManagedIndexRunner.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/ManagedIndexRunner.kt
@@ -220,7 +220,7 @@ object ManagedIndexRunner :
             if (lock == null) {
                 logger.debug("Could not acquire lock [${lock?.lockId}] for ${job.index}")
             } else {
-                runManagedIndexConfig(job)
+                runManagedIndexConfig(job, context)
                 // Release lock
                 val released: Boolean = context.lockService.suspendUntil { release(lock, it) }
                 if (!released) {
@@ -231,7 +231,7 @@ object ManagedIndexRunner :
     }
 
     @Suppress("ReturnCount", "ComplexMethod", "LongMethod", "ComplexCondition", "NestedBlockDepth")
-    private suspend fun runManagedIndexConfig(managedIndexConfig: ManagedIndexConfig) {
+    private suspend fun runManagedIndexConfig(managedIndexConfig: ManagedIndexConfig, jobContext: JobExecutionContext) {
         logger.debug("Run job for index ${managedIndexConfig.index}")
         // doing a check of local cluster health as we do not want to overload master node with potentially a lot of calls
         if (clusterIsRed()) {
@@ -304,7 +304,7 @@ object ManagedIndexRunner :
 
         val state = policy.getStateToExecute(managedIndexMetaData)
         val action: Action? = state?.getActionToExecute(managedIndexMetaData, indexMetadataProvider)
-        val stepContext = StepContext(managedIndexMetaData, clusterService, client, threadPool.threadContext, policy.user, scriptService, settings)
+        val stepContext = StepContext(managedIndexMetaData, clusterService, client, threadPool.threadContext, policy.user, scriptService, settings, jobContext)
         val step: Step? = action?.getStepToExecute(stepContext)
         val currentActionMetaData = action?.getUpdatedActionMetadata(managedIndexMetaData, state.name)
 

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/ManagedIndexRunner.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/ManagedIndexRunner.kt
@@ -304,7 +304,9 @@ object ManagedIndexRunner :
 
         val state = policy.getStateToExecute(managedIndexMetaData)
         val action: Action? = state?.getActionToExecute(managedIndexMetaData, indexMetadataProvider)
-        val stepContext = StepContext(managedIndexMetaData, clusterService, client, threadPool.threadContext, policy.user, scriptService, settings, jobContext)
+        val stepContext = StepContext(
+            managedIndexMetaData, clusterService, client, threadPool.threadContext, policy.user, scriptService, settings, jobContext.lockService
+        )
         val step: Step? = action?.getStepToExecute(stepContext)
         val currentActionMetaData = action?.getUpdatedActionMetadata(managedIndexMetaData, state.name)
 

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/action/ShrinkAction.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/action/ShrinkAction.kt
@@ -40,6 +40,9 @@ class ShrinkAction(
         } else if (numNewShards != null) {
             require(numNewShards > 0) { "Shrink action numNewShards must be greater than 0." }
         }
+        if (targetIndexSuffix != null) {
+            require(!targetIndexSuffix.contains('*') && !targetIndexSuffix.contains('?')) { "Target index suffix must not contain wildcards." }
+        }
     }
 
     private val attemptMoveShardsStep = AttemptMoveShardsStep(this)
@@ -71,6 +74,9 @@ class ShrinkAction(
                 AttemptShrinkStep.name -> waitForShrinkStep
                 else -> stepNameToStep[currentStep]!!
             }
+        } else if (currentStepStatus == Step.StepStatus.FAILED) {
+            // If we failed at any point, retries should start from the beginning
+            return attemptMoveShardsStep
         }
         // step not completed
         return stepNameToStep[currentStep]!!

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/action/ShrinkAction.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/action/ShrinkAction.kt
@@ -36,7 +36,9 @@ class ShrinkAction(
         if (maxShardSize != null) {
             require(maxShardSize.bytes > 0) { "Shrink action maxShardSize must be greater than 0." }
         } else if (percentageOfSourceShards != null) {
-            require(percentageOfSourceShards > 0.0 && percentageOfSourceShards < 1.0) { "Percentage of source shards must be between 0.0 and 1.0 exclusively" }
+            require(percentageOfSourceShards > 0.0 && percentageOfSourceShards < 1.0) {
+                "Percentage of source shards must be between 0.0 and 1.0 exclusively"
+            }
         } else if (numNewShards != null) {
             require(numNewShards > 0) { "Shrink action numNewShards must be greater than 0." }
         }
@@ -116,5 +118,7 @@ class ShrinkAction(
         const val TARGET_INDEX_SUFFIX_FIELD = "target_index_suffix"
         const val ALIASES_FIELD = "aliases"
         const val FORCE_UNSAFE_FIELD = "force_unsafe"
+        const val LOCK_RESOURCE_TYPE = "shrink"
+        const val LOCK_RESOURCE_NAME = "node_name"
     }
 }

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/action/ShrinkAction.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/action/ShrinkAction.kt
@@ -1,0 +1,139 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.indexmanagement.indexstatemanagement.action
+
+import org.opensearch.action.admin.indices.alias.Alias
+import org.opensearch.common.io.stream.StreamOutput
+import org.opensearch.common.unit.ByteSizeValue
+import org.opensearch.common.xcontent.ToXContent
+import org.opensearch.common.xcontent.XContentBuilder
+import org.opensearch.indexmanagement.indexstatemanagement.step.shrink.AttemptMoveShardsStep
+import org.opensearch.indexmanagement.indexstatemanagement.step.shrink.AttemptShrinkStep
+import org.opensearch.indexmanagement.indexstatemanagement.step.shrink.WaitForMoveShardsStep
+import org.opensearch.indexmanagement.indexstatemanagement.step.shrink.WaitForShrinkStep
+import org.opensearch.indexmanagement.opensearchapi.aliasesField
+import org.opensearch.indexmanagement.spi.indexstatemanagement.Action
+import org.opensearch.indexmanagement.spi.indexstatemanagement.Step
+import org.opensearch.indexmanagement.spi.indexstatemanagement.model.StepContext
+
+@Suppress("LongParameterList")
+class ShrinkAction(
+    val numNewShards: Int?,
+    val maxShardSize: ByteSizeValue?,
+    val percentageDecrease: Double?,
+    val targetIndexSuffix: String?,
+    val aliases: List<Alias>?,
+    val forceUnsafe: Boolean?,
+    index: Int
+) : Action(name, index) {
+    init {
+        /* The numbers associated with each shard config are all k % mod 3 == 1.
+         * Because of the % 3 == 1 property, we can check if more than one shard configs are specified by
+         * modding the sum by 3. Any sum % 3 != 1 is a sum of more than one of the configs and thus invalid.
+         * We can then check the error message by checking the sum against each unique sum combination.
+         */
+        val maxShardSizeNotNull = if (maxShardSize != null) MAX_SHARD_NOT_NULL else 0
+        val percentageDecreaseNotNull = if (percentageDecrease != null) PERCENTAGE_DECREASE_NOT_NULL else 0
+        val numNewShardsNotNull = if (numNewShards != null) NUM_SHARDS_NOT_NULL else 0
+        val numSet = maxShardSizeNotNull + percentageDecreaseNotNull + numNewShardsNotNull
+        require(numSet % NUM_SHARD_CONFIGS == 1) {
+            when (numSet) {
+                MAX_SHARD_NOT_NULL + PERCENTAGE_DECREASE_NOT_NULL ->
+                    "Cannot specify both maximum shard size and percentage decrease. Please pick one."
+                MAX_SHARD_NOT_NULL + NUM_SHARDS_NOT_NULL ->
+                    "Cannot specify both maximum shard size and number of new shards. Please pick one."
+                PERCENTAGE_DECREASE_NOT_NULL + NUM_SHARDS_NOT_NULL ->
+                    "Cannot specify both percentage decrease and number of new shards. Please pick one."
+                MAX_SHARD_NOT_NULL + PERCENTAGE_DECREASE_NOT_NULL + NUM_SHARDS_NOT_NULL ->
+                    "Cannot specify maximum shard size, percentage decrease, and number of new shards. Please pick one."
+                // Never executes this code block.
+                else -> ""
+            }
+        }
+        if (percentageDecreaseNotNull != 0) {
+            require(percentageDecrease!!.compareTo(0.0) == 1 && percentageDecrease.compareTo(1.0) == -1) {
+                "Percentage decrease must be between 0.0 and 1.0 exclusively"
+            }
+        }
+        if (maxShardSizeNotNull != 0) {
+            require(maxShardSize!!.bytes > 0) { "The max_shard_size must be greater than 0." }
+        }
+    }
+
+    private val attemptMoveShardsStep = AttemptMoveShardsStep(this)
+    private val waitForMoveShardsStep = WaitForMoveShardsStep(this)
+    private val attemptShrinkStep = AttemptShrinkStep(this)
+    private val waitForShrinkStep = WaitForShrinkStep(this)
+
+    private val stepNameToStep: LinkedHashMap<String, Step> = linkedMapOf(
+        AttemptMoveShardsStep.name to attemptMoveShardsStep,
+        WaitForMoveShardsStep.name to waitForMoveShardsStep,
+        AttemptShrinkStep.name to attemptShrinkStep,
+        WaitForShrinkStep.name to waitForShrinkStep
+    )
+    override fun getSteps(): List<Step> = listOf(attemptMoveShardsStep, waitForMoveShardsStep, attemptShrinkStep, waitForShrinkStep)
+
+    @SuppressWarnings("ReturnCount")
+    override fun getStepToExecute(context: StepContext): Step {
+        val stepMetaData = context.metadata.stepMetaData ?: return attemptMoveShardsStep
+        val currentStep = stepMetaData.name
+
+        // If the current step is not from this action, assume it is from another action.
+        if (!stepNameToStep.containsKey(currentStep)) return attemptMoveShardsStep
+
+        val currentStepStatus = stepMetaData.stepStatus
+        if (currentStepStatus == Step.StepStatus.COMPLETED) {
+            return when (currentStep) {
+                AttemptMoveShardsStep.name -> waitForMoveShardsStep
+                WaitForMoveShardsStep.name -> attemptShrinkStep
+                AttemptShrinkStep.name -> waitForShrinkStep
+                else -> stepNameToStep[currentStep]!!
+            }
+        }
+        // step not completed
+        return stepNameToStep[currentStep]!!
+    }
+
+    override fun populateAction(builder: XContentBuilder, params: ToXContent.Params) {
+        builder.startObject(type)
+        if (numNewShards != null) builder.field(NUM_NEW_SHARDS_FIELD, numNewShards)
+        if (maxShardSize != null) builder.field(MAX_SHARD_SIZE_FIELD, maxShardSize.stringRep)
+        if (percentageDecrease != null) builder.field(PERCENTAGE_DECREASE_FIELD, percentageDecrease)
+        if (targetIndexSuffix != null) builder.field(TARGET_INDEX_SUFFIX_FIELD, targetIndexSuffix)
+        if (aliases != null) { builder.aliasesField(aliases) }
+        if (forceUnsafe != null) builder.field(FORCE_UNSAFE_FIELD, forceUnsafe)
+        builder.endObject()
+    }
+
+    override fun populateAction(out: StreamOutput) {
+        out.writeOptionalInt(numNewShards)
+        out.writeOptionalWriteable(maxShardSize)
+        out.writeOptionalDouble(percentageDecrease)
+        out.writeOptionalString(targetIndexSuffix)
+        if (aliases != null) {
+            out.writeBoolean(true)
+            out.writeList(aliases)
+        } else {
+            out.writeBoolean(false)
+        }
+        out.writeOptionalBoolean(forceUnsafe)
+        out.writeInt(actionIndex)
+    }
+
+    companion object {
+        const val name = "shrink"
+        const val NUM_NEW_SHARDS_FIELD = "num_new_shards"
+        const val PERCENTAGE_DECREASE_FIELD = "percentage_decrease"
+        const val MAX_SHARD_SIZE_FIELD = "max_shard_size"
+        const val TARGET_INDEX_SUFFIX_FIELD = "target_index_suffix"
+        const val ALIASES_FIELD = "aliases"
+        const val FORCE_UNSAFE_FIELD = "force_unsafe"
+        const val MAX_SHARD_NOT_NULL = 1
+        const val PERCENTAGE_DECREASE_NOT_NULL = 4
+        const val NUM_SHARDS_NOT_NULL = 7
+        const val NUM_SHARD_CONFIGS = 3
+    }
+}

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/action/ShrinkAction.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/action/ShrinkAction.kt
@@ -23,20 +23,20 @@ import org.opensearch.indexmanagement.spi.indexstatemanagement.model.StepContext
 class ShrinkAction(
     val numNewShards: Int?,
     val maxShardSize: ByteSizeValue?,
-    val percentageDecrease: Double?,
+    val percentageOfSourceShards: Double?,
     val targetIndexSuffix: String?,
     val aliases: List<Alias>?,
     val forceUnsafe: Boolean?,
     index: Int
 ) : Action(name, index) {
     init {
-        val numSet = arrayOf(maxShardSize != null, percentageDecrease != null, numNewShards != null).count { it }
+        val numSet = arrayOf(maxShardSize != null, percentageOfSourceShards != null, numNewShards != null).count { it }
         require(numSet == 1) { "Exactly one option specifying the number of shards to shrink to must be used." }
 
         if (maxShardSize != null) {
             require(maxShardSize.bytes > 0) { "Shrink action maxShardSize must be greater than 0." }
-        } else if (percentageDecrease != null) {
-            require(percentageDecrease > 0.0 && percentageDecrease < 1.0) { "Percentage decrease must be between 0.0 and 1.0 exclusively" }
+        } else if (percentageOfSourceShards != null) {
+            require(percentageOfSourceShards > 0.0 && percentageOfSourceShards < 1.0) { "Percentage of source shards must be between 0.0 and 1.0 exclusively" }
         } else if (numNewShards != null) {
             require(numNewShards > 0) { "Shrink action numNewShards must be greater than 0." }
         }
@@ -80,7 +80,7 @@ class ShrinkAction(
         builder.startObject(type)
         if (numNewShards != null) builder.field(NUM_NEW_SHARDS_FIELD, numNewShards)
         if (maxShardSize != null) builder.field(MAX_SHARD_SIZE_FIELD, maxShardSize.stringRep)
-        if (percentageDecrease != null) builder.field(PERCENTAGE_DECREASE_FIELD, percentageDecrease)
+        if (percentageOfSourceShards != null) builder.field(PERCENTAGE_OF_SOURCE_SHARDS_FIELD, percentageOfSourceShards)
         if (targetIndexSuffix != null) builder.field(TARGET_INDEX_SUFFIX_FIELD, targetIndexSuffix)
         if (aliases != null) { builder.aliasesField(aliases) }
         if (forceUnsafe != null) builder.field(FORCE_UNSAFE_FIELD, forceUnsafe)
@@ -90,7 +90,7 @@ class ShrinkAction(
     override fun populateAction(out: StreamOutput) {
         out.writeOptionalInt(numNewShards)
         out.writeOptionalWriteable(maxShardSize)
-        out.writeOptionalDouble(percentageDecrease)
+        out.writeOptionalDouble(percentageOfSourceShards)
         out.writeOptionalString(targetIndexSuffix)
         if (aliases != null) {
             out.writeBoolean(true)
@@ -105,7 +105,7 @@ class ShrinkAction(
     companion object {
         const val name = "shrink"
         const val NUM_NEW_SHARDS_FIELD = "num_new_shards"
-        const val PERCENTAGE_DECREASE_FIELD = "percentage_decrease"
+        const val PERCENTAGE_OF_SOURCE_SHARDS_FIELD = "percentage_of_source_shards"
         const val MAX_SHARD_SIZE_FIELD = "max_shard_size"
         const val TARGET_INDEX_SUFFIX_FIELD = "target_index_suffix"
         const val ALIASES_FIELD = "aliases"

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/action/ShrinkActionParser.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/action/ShrinkActionParser.kt
@@ -1,0 +1,78 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.indexmanagement.indexstatemanagement.action
+
+import org.opensearch.action.admin.indices.alias.Alias
+import org.opensearch.common.io.stream.StreamInput
+import org.opensearch.common.unit.ByteSizeValue
+import org.opensearch.common.xcontent.XContentParser
+import org.opensearch.common.xcontent.XContentParserUtils.ensureExpectedToken
+import org.opensearch.indexmanagement.indexstatemanagement.action.ShrinkAction.Companion.ALIASES_FIELD
+import org.opensearch.indexmanagement.indexstatemanagement.action.ShrinkAction.Companion.FORCE_UNSAFE_FIELD
+import org.opensearch.indexmanagement.indexstatemanagement.action.ShrinkAction.Companion.MAX_SHARD_SIZE_FIELD
+import org.opensearch.indexmanagement.indexstatemanagement.action.ShrinkAction.Companion.NUM_NEW_SHARDS_FIELD
+import org.opensearch.indexmanagement.indexstatemanagement.action.ShrinkAction.Companion.PERCENTAGE_DECREASE_FIELD
+import org.opensearch.indexmanagement.indexstatemanagement.action.ShrinkAction.Companion.TARGET_INDEX_SUFFIX_FIELD
+import org.opensearch.indexmanagement.spi.indexstatemanagement.Action
+import org.opensearch.indexmanagement.spi.indexstatemanagement.ActionParser
+
+class ShrinkActionParser : ActionParser() {
+    override fun fromStreamInput(sin: StreamInput): Action {
+        val numNewShards = sin.readOptionalInt()
+        val maxShardSize = sin.readOptionalWriteable(::ByteSizeValue)
+        val percentageDecrease = sin.readOptionalDouble()
+        val targetIndexSuffix = sin.readOptionalString()
+        val aliases = if (sin.readBoolean()) sin.readList(::Alias) else null
+        val forceUnsafe = sin.readOptionalBoolean()
+        val index = sin.readInt()
+
+        return ShrinkAction(numNewShards, maxShardSize, percentageDecrease, targetIndexSuffix, aliases, forceUnsafe, index)
+    }
+
+    @Suppress("NestedBlockDepth")
+    override fun fromXContent(xcp: XContentParser, index: Int): Action {
+        var numNewShards: Int? = null
+        var maxShardSize: ByteSizeValue? = null
+        var percentageDecrease: Double? = null
+        var targetIndexSuffix: String? = null
+        var aliases: List<Alias>? = null
+        var forceUnsafe: Boolean? = null
+
+        ensureExpectedToken(XContentParser.Token.START_OBJECT, xcp.currentToken(), xcp)
+        while (xcp.nextToken() != XContentParser.Token.END_OBJECT) {
+            val fieldName = xcp.currentName()
+            xcp.nextToken()
+
+            when (fieldName) {
+                NUM_NEW_SHARDS_FIELD -> numNewShards = xcp.intValue()
+                MAX_SHARD_SIZE_FIELD -> maxShardSize = ByteSizeValue.parseBytesSizeValue(xcp.textOrNull(), MAX_SHARD_SIZE_FIELD)
+                PERCENTAGE_DECREASE_FIELD -> percentageDecrease = xcp.doubleValue()
+                TARGET_INDEX_SUFFIX_FIELD -> targetIndexSuffix = xcp.textOrNull()
+                ALIASES_FIELD -> {
+                    if (xcp.currentToken() != XContentParser.Token.VALUE_NULL) {
+                        aliases = mutableListOf()
+                        when (xcp.currentToken()) {
+                            XContentParser.Token.START_OBJECT -> {
+                                while (xcp.nextToken() != XContentParser.Token.END_OBJECT) {
+                                    aliases.add(Alias.fromXContent(xcp))
+                                }
+                            }
+                            else -> ensureExpectedToken(XContentParser.Token.START_ARRAY, xcp.currentToken(), xcp)
+                        }
+                    }
+                }
+                FORCE_UNSAFE_FIELD -> forceUnsafe = xcp.booleanValue()
+                else -> throw IllegalArgumentException("Invalid field: [$fieldName] found in ShrinkAction.")
+            }
+        }
+
+        return ShrinkAction(numNewShards, maxShardSize, percentageDecrease, targetIndexSuffix, aliases, forceUnsafe, index)
+    }
+
+    override fun getActionType(): String {
+        return ShrinkAction.name
+    }
+}

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/action/ShrinkActionParser.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/action/ShrinkActionParser.kt
@@ -54,14 +54,12 @@ class ShrinkActionParser : ActionParser() {
                 TARGET_INDEX_TEMPLATE_FIELD -> targetIndexTemplate = Script.parse(xcp, Script.DEFAULT_TEMPLATE_LANG)
                 ALIASES_FIELD -> {
                     if (xcp.currentToken() != XContentParser.Token.VALUE_NULL) {
+                        ensureExpectedToken(XContentParser.Token.START_ARRAY, xcp.currentToken(), xcp)
                         aliases = mutableListOf()
-                        when (xcp.currentToken()) {
-                            XContentParser.Token.START_OBJECT -> {
-                                while (xcp.nextToken() != XContentParser.Token.END_OBJECT) {
-                                    aliases.add(Alias.fromXContent(xcp))
-                                }
-                            }
-                            else -> ensureExpectedToken(XContentParser.Token.START_ARRAY, xcp.currentToken(), xcp)
+                        while (xcp.nextToken() != XContentParser.Token.END_ARRAY) {
+                            ensureExpectedToken(XContentParser.Token.FIELD_NAME, xcp.nextToken(), xcp)
+                            aliases.add(Alias.fromXContent(xcp))
+                            ensureExpectedToken(XContentParser.Token.END_OBJECT, xcp.nextToken(), xcp)
                         }
                     }
                 }

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/action/ShrinkActionParser.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/action/ShrinkActionParser.kt
@@ -14,7 +14,7 @@ import org.opensearch.indexmanagement.indexstatemanagement.action.ShrinkAction.C
 import org.opensearch.indexmanagement.indexstatemanagement.action.ShrinkAction.Companion.FORCE_UNSAFE_FIELD
 import org.opensearch.indexmanagement.indexstatemanagement.action.ShrinkAction.Companion.MAX_SHARD_SIZE_FIELD
 import org.opensearch.indexmanagement.indexstatemanagement.action.ShrinkAction.Companion.NUM_NEW_SHARDS_FIELD
-import org.opensearch.indexmanagement.indexstatemanagement.action.ShrinkAction.Companion.PERCENTAGE_DECREASE_FIELD
+import org.opensearch.indexmanagement.indexstatemanagement.action.ShrinkAction.Companion.PERCENTAGE_OF_SOURCE_SHARDS_FIELD
 import org.opensearch.indexmanagement.indexstatemanagement.action.ShrinkAction.Companion.TARGET_INDEX_SUFFIX_FIELD
 import org.opensearch.indexmanagement.spi.indexstatemanagement.Action
 import org.opensearch.indexmanagement.spi.indexstatemanagement.ActionParser
@@ -23,20 +23,20 @@ class ShrinkActionParser : ActionParser() {
     override fun fromStreamInput(sin: StreamInput): Action {
         val numNewShards = sin.readOptionalInt()
         val maxShardSize = sin.readOptionalWriteable(::ByteSizeValue)
-        val percentageDecrease = sin.readOptionalDouble()
+        val percentageOfSourceShards = sin.readOptionalDouble()
         val targetIndexSuffix = sin.readOptionalString()
         val aliases = if (sin.readBoolean()) sin.readList(::Alias) else null
         val forceUnsafe = sin.readOptionalBoolean()
         val index = sin.readInt()
 
-        return ShrinkAction(numNewShards, maxShardSize, percentageDecrease, targetIndexSuffix, aliases, forceUnsafe, index)
+        return ShrinkAction(numNewShards, maxShardSize, percentageOfSourceShards, targetIndexSuffix, aliases, forceUnsafe, index)
     }
 
     @Suppress("NestedBlockDepth")
     override fun fromXContent(xcp: XContentParser, index: Int): Action {
         var numNewShards: Int? = null
         var maxShardSize: ByteSizeValue? = null
-        var percentageDecrease: Double? = null
+        var percentageOfSourceShards: Double? = null
         var targetIndexSuffix: String? = null
         var aliases: List<Alias>? = null
         var forceUnsafe: Boolean? = null
@@ -49,7 +49,7 @@ class ShrinkActionParser : ActionParser() {
             when (fieldName) {
                 NUM_NEW_SHARDS_FIELD -> numNewShards = xcp.intValue()
                 MAX_SHARD_SIZE_FIELD -> maxShardSize = ByteSizeValue.parseBytesSizeValue(xcp.textOrNull(), MAX_SHARD_SIZE_FIELD)
-                PERCENTAGE_DECREASE_FIELD -> percentageDecrease = xcp.doubleValue()
+                PERCENTAGE_OF_SOURCE_SHARDS_FIELD -> percentageOfSourceShards = xcp.doubleValue()
                 TARGET_INDEX_SUFFIX_FIELD -> targetIndexSuffix = xcp.textOrNull()
                 ALIASES_FIELD -> {
                     if (xcp.currentToken() != XContentParser.Token.VALUE_NULL) {
@@ -69,7 +69,7 @@ class ShrinkActionParser : ActionParser() {
             }
         }
 
-        return ShrinkAction(numNewShards, maxShardSize, percentageDecrease, targetIndexSuffix, aliases, forceUnsafe, index)
+        return ShrinkAction(numNewShards, maxShardSize, percentageOfSourceShards, targetIndexSuffix, aliases, forceUnsafe, index)
     }
 
     override fun getActionType(): String {

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/action/ShrinkActionParser.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/action/ShrinkActionParser.kt
@@ -48,9 +48,9 @@ class ShrinkActionParser : ActionParser() {
 
             when (fieldName) {
                 NUM_NEW_SHARDS_FIELD -> numNewShards = xcp.intValue()
-                MAX_SHARD_SIZE_FIELD -> maxShardSize = ByteSizeValue.parseBytesSizeValue(xcp.textOrNull(), MAX_SHARD_SIZE_FIELD)
+                MAX_SHARD_SIZE_FIELD -> maxShardSize = ByteSizeValue.parseBytesSizeValue(xcp.text(), MAX_SHARD_SIZE_FIELD)
                 PERCENTAGE_OF_SOURCE_SHARDS_FIELD -> percentageOfSourceShards = xcp.doubleValue()
-                TARGET_INDEX_SUFFIX_FIELD -> targetIndexSuffix = xcp.textOrNull()
+                TARGET_INDEX_SUFFIX_FIELD -> targetIndexSuffix = xcp.text()
                 ALIASES_FIELD -> {
                     if (xcp.currentToken() != XContentParser.Token.VALUE_NULL) {
                         aliases = mutableListOf()

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/shrink/AttemptMoveShardsStep.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/shrink/AttemptMoveShardsStep.kt
@@ -1,0 +1,352 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.indexmanagement.indexstatemanagement.step.shrink
+
+import org.apache.logging.log4j.LogManager
+import org.opensearch.action.admin.cluster.health.ClusterHealthRequest
+import org.opensearch.action.admin.cluster.health.ClusterHealthResponse
+import org.opensearch.action.admin.cluster.node.stats.NodesStatsRequest
+import org.opensearch.action.admin.cluster.node.stats.NodesStatsResponse
+import org.opensearch.action.admin.cluster.reroute.ClusterRerouteRequest
+import org.opensearch.action.admin.cluster.reroute.ClusterRerouteResponse
+import org.opensearch.action.admin.indices.stats.IndicesStatsRequest
+import org.opensearch.action.admin.indices.stats.IndicesStatsResponse
+import org.opensearch.action.support.master.AcknowledgedResponse
+import org.opensearch.cluster.metadata.IndexMetadata
+import org.opensearch.cluster.routing.allocation.command.MoveAllocationCommand
+import org.opensearch.cluster.routing.allocation.decider.Decision
+import org.opensearch.common.collect.Tuple
+import org.opensearch.common.settings.Settings
+import org.opensearch.common.unit.ByteSizeValue
+import org.opensearch.indexmanagement.indexstatemanagement.action.ShrinkAction
+import org.opensearch.indexmanagement.indexstatemanagement.util.getActionStartTime
+import org.opensearch.indexmanagement.indexstatemanagement.util.getShrinkLockModel
+import org.opensearch.indexmanagement.indexstatemanagement.util.issueUpdateSettingsRequest
+import org.opensearch.indexmanagement.opensearchapi.suspendUntil
+import org.opensearch.indexmanagement.spi.indexstatemanagement.Step
+import org.opensearch.indexmanagement.spi.indexstatemanagement.model.ActionProperties
+import org.opensearch.indexmanagement.spi.indexstatemanagement.model.ManagedIndexMetaData
+import org.opensearch.indexmanagement.spi.indexstatemanagement.model.ShrinkActionProperties
+import org.opensearch.indexmanagement.spi.indexstatemanagement.model.StepContext
+import org.opensearch.indexmanagement.spi.indexstatemanagement.model.StepMetaData
+import org.opensearch.jobscheduler.repackage.com.cronutils.utils.VisibleForTesting
+import org.opensearch.jobscheduler.spi.JobExecutionContext
+import org.opensearch.jobscheduler.spi.LockModel
+import java.lang.Exception
+import java.time.Duration
+import java.time.Instant
+import java.util.PriorityQueue
+import kotlin.collections.ArrayList
+import kotlin.collections.HashMap
+import kotlin.collections.HashSet
+import kotlin.math.ceil
+import kotlin.math.floor
+import kotlin.math.min
+import kotlin.math.sqrt
+
+@SuppressWarnings("TooManyFunctions")
+class AttemptMoveShardsStep(private val action: ShrinkAction) : Step(name) {
+    private val logger = LogManager.getLogger(javaClass)
+    private var stepStatus = StepStatus.STARTING
+    private var info: Map<String, Any>? = null
+    private var shrinkActionProperties: ShrinkActionProperties? = null
+
+    @Suppress("TooGenericExceptionCaught", "ComplexMethod", "ReturnCount", "LongMethod")
+    override suspend fun execute(): Step {
+        val context = this.context ?: return this
+        val client = context.client
+        val indexName = context.metadata.index
+        try {
+            checkTimeOut(context.metadata)
+            // check whether the target index name is available.
+            val indexNameSuffix = action.targetIndexSuffix ?: DEFAULT_TARGET_SUFFIX
+            val shrinkTargetIndexName = indexName + indexNameSuffix
+            val indexExists = context.clusterService.state().metadata.indices.containsKey(shrinkTargetIndexName)
+            if (indexExists) {
+                info = mapOf("message" to getIndexExistsMessage(shrinkTargetIndexName))
+                stepStatus = StepStatus.FAILED
+                return this
+            }
+
+            // get cluster health
+            val healthReq = ClusterHealthRequest().indices(indexName).waitForGreenStatus()
+            val response: ClusterHealthResponse = client.admin().cluster().suspendUntil { health(healthReq, it) }
+            // check status of cluster health
+            if (response.isTimedOut) {
+                info = mapOf("message" to FAILURE_MESSAGE)
+                stepStatus = StepStatus.CONDITION_NOT_MET
+                return this
+            }
+
+            // force_unsafe check
+            val numReplicas = context.clusterService.state().metadata.indices[indexName].numberOfReplicas
+            val shouldFailForceUnsafeCheck = numReplicas == 0 && ((action.forceUnsafe != null && !action.forceUnsafe) || (action.forceUnsafe == null))
+            if (shouldFailForceUnsafeCheck) {
+                info = mapOf("message" to UNSAFE_FAILURE_MESSAGE)
+                stepStatus = StepStatus.FAILED
+                return this
+            }
+            // Get the number of primary shards in the index -- all will be active because index health is green
+            val numOriginalShards = context.clusterService.state().metadata.indices[indexName].numberOfShards
+            if (numOriginalShards == 1) {
+                info = mapOf("message" to ONE_PRIMARY_SHARD_FAILURE_MESSAGE)
+                stepStatus = StepStatus.FAILED
+                return this
+            }
+            // Get the size of the index
+            val statsRequest = IndicesStatsRequest().indices(indexName)
+            val statsResponse: IndicesStatsResponse = client.admin().indices().suspendUntil {
+                stats(statsRequest, it)
+            }
+            val statsStore = statsResponse.total.store
+            if (statsStore == null) {
+                info = mapOf("message" to FAILURE_MESSAGE)
+                stepStatus = StepStatus.FAILED
+                return this
+            }
+            val indexSize = statsStore.sizeInBytes
+
+            // get the number of shards that the target index will have
+            val numTargetShards = getNumTargetShards(numOriginalShards, indexSize)
+            // get the nodes with enough memory
+            val suitableNodes = findSuitableNodes(context, statsResponse, indexSize, bufferPercentage, numOriginalShards)
+            // iterate through the nodes and try to acquire a lock on those nodes
+            val lock = acquireLockOnNode(context.jobContext, suitableNodes)
+            if (lock == null) {
+                logger.info("$indexName could not find available node to shrink onto.")
+                info = mapOf("message" to NO_AVAILABLE_NODES_MESSAGE)
+                stepStatus = StepStatus.CONDITION_NOT_MET
+                return this
+            }
+            // move the shards
+            val nodeName = lock.resource[RESOURCE_NAME] as String
+            shrinkActionProperties = ShrinkActionProperties(
+                nodeName,
+                shrinkTargetIndexName,
+                numTargetShards,
+                lock.primaryTerm,
+                lock.seqNo,
+                lock.lockTime.epochSecond
+            )
+            setToReadOnlyAndMoveIndexToNode(context, nodeName)
+            info = mapOf("message" to getSuccessMessage(nodeName))
+            stepStatus = StepStatus.COMPLETED
+            return this
+        } catch (e: Exception) {
+            info = mapOf("message" to FAILURE_MESSAGE, "cause" to "{${e.message}}")
+            stepStatus = StepStatus.FAILED
+            return this
+        }
+    }
+
+    private suspend fun setToReadOnlyAndMoveIndexToNode(stepContext: StepContext, node: String) {
+        val updateSettings = Settings.builder()
+            .put(IndexMetadata.SETTING_BLOCKS_WRITE, true)
+            .put(ROUTING_SETTING, node)
+            .build()
+        issueUpdateAndUnlockIfFail(stepContext, updateSettings, UPDATE_FAILED_MESSAGE)
+    }
+
+    private suspend fun issueUpdateAndUnlockIfFail(stepContext: StepContext, settings: Settings, failureMessage: String) {
+        val jobContext = stepContext.jobContext
+        try {
+            val response: AcknowledgedResponse = issueUpdateSettingsRequest(stepContext.client, stepContext.metadata, settings)
+            if (!response.isAcknowledged) {
+                stepStatus = StepStatus.FAILED
+                info = mapOf("message" to failureMessage)
+            }
+        } catch (e: Exception) {
+            handleException(e, failureMessage)
+            val copyProperties = shrinkActionProperties
+            if (copyProperties != null) {
+                val lock = getShrinkLockModel(
+                    copyProperties.nodeName,
+                    jobContext.jobIndexName,
+                    jobContext.jobId,
+                    copyProperties.lockEpochSecond,
+                    copyProperties.lockPrimaryTerm,
+                    copyProperties.lockSeqNo
+                )
+                jobContext.lockService.suspendUntil<Boolean> { release(lock, it) }
+            }
+        }
+    }
+
+    private suspend fun acquireLockOnNode(jobContext: JobExecutionContext, suitableNodes: List<String>): LockModel? {
+        var lock: LockModel? = null
+        for (node in suitableNodes) {
+            val nodeResourceObject: HashMap<String, String> = HashMap()
+            nodeResourceObject[RESOURCE_NAME] = node
+            val lockTime = action.configTimeout?.timeout?.seconds ?: MOVE_SHARDS_TIMEOUT_IN_SECONDS
+            lock = jobContext.lockService.suspendUntil<LockModel> {
+                acquireLockOnResource(jobContext, lockTime, RESOURCE_TYPE, nodeResourceObject as Map<String, Any>?, it)
+            }
+            if (lock != null) {
+                return lock
+            }
+        }
+        return lock
+    }
+
+    @VisibleForTesting
+    @SuppressWarnings("NestedBlockDepth", "ComplexMethod")
+    private suspend fun findSuitableNodes(
+        stepContext: StepContext,
+        indicesStatsResponse: IndicesStatsResponse,
+        indexSize: Long,
+        buffer: Long,
+        numOriginalShards: Int
+    ): List<String> {
+        val nodesStatsReq = NodesStatsRequest().addMetric(OS_METRIC)
+        val nodeStatsResponse: NodesStatsResponse = stepContext.client.admin().cluster().suspendUntil { nodesStats(nodesStatsReq, it) }
+        val nodesList = nodeStatsResponse.nodes
+        val comparator = kotlin.Comparator { o1: Tuple<Long, String>, o2: Tuple<Long, String> -> o1.v1().compareTo(o2.v1()) }
+        val nodesWithSpace = PriorityQueue(comparator)
+        for (node in nodesList) {
+            val osStats = node.os
+            if (osStats != null) {
+                val memLeftInNode = osStats.mem.free.bytes
+                val totalNodeMem = osStats.mem.total.bytes
+                val bufferSize = ByteSizeValue(buffer * totalNodeMem)
+                val requiredBytes = (2 * indexSize) + bufferSize.bytes
+                if (memLeftInNode > requiredBytes) {
+                    val memLeftAfterTransfer: Long = memLeftInNode - requiredBytes
+                    nodesWithSpace.add(Tuple(memLeftAfterTransfer, node.node.name))
+                }
+            }
+        }
+        val suitableNodes: ArrayList<String> = ArrayList()
+        for (sizeNodeTuple in nodesWithSpace) {
+            val nodeName = sizeNodeTuple.v2()
+            val movableShardIds = HashSet<Int>()
+            for (shard in indicesStatsResponse.shards) {
+                val shardId = shard.shardRouting.shardId()
+                val currentShardNode = stepContext.clusterService.state().nodes[shard.shardRouting.currentNodeId()]
+                if (currentShardNode.name.equals(nodeName)) {
+                    movableShardIds.add(shardId.id)
+                } else {
+                    val indexName = stepContext.metadata.index
+                    val allocationCommand = MoveAllocationCommand(indexName, shardId.id, currentShardNode.name, nodeName)
+                    val rerouteRequest = ClusterRerouteRequest().explain(true).dryRun(true).add(allocationCommand)
+
+                    val clusterRerouteResponse: ClusterRerouteResponse =
+                        stepContext.client.admin().cluster().suspendUntil { reroute(rerouteRequest, it) }
+                    val filteredExplanations = clusterRerouteResponse.explanations.explanations().filter {
+                        it.decisions().type().equals(Decision.Type.YES)
+                    }
+                    if (filteredExplanations.isNotEmpty()) {
+                        movableShardIds.add(shardId.id)
+                    }
+                }
+            }
+            if (movableShardIds.size >= numOriginalShards) {
+                suitableNodes.add(sizeNodeTuple.v2())
+            }
+        }
+        return suitableNodes
+    }
+
+    @SuppressWarnings("ReturnCount")
+    private fun getNumTargetShards(numOriginalShards: Int, indexSize: Long): Int {
+        // case where user specifies a certain number of shards in the target index
+        if (action.numNewShards != null) return getGreatestFactorLessThan(numOriginalShards, action.numNewShards)
+
+        // case where user specifies a percentage decrease in the number of shards in the target index
+        if (action.percentageDecrease != null) {
+            val numTargetShards = floor((action.percentageDecrease) * numOriginalShards).toInt()
+            return getGreatestFactorLessThan(numOriginalShards, numTargetShards)
+        }
+        // case where the user specifies a max shard size in the target index
+        val maxShardSizeInBytes = action.maxShardSize!!.bytes
+        // ensures that numTargetShards is never less than 1
+        val minNumTargetShards = ceil(indexSize / maxShardSizeInBytes.toDouble()).toInt()
+        return getMinFactorGreaterThan(numOriginalShards, minNumTargetShards)
+    }
+
+    @SuppressWarnings("ReturnCount")
+    private fun getGreatestFactorLessThan(n: Int, k: Int): Int {
+        if (k >= n) return n
+        val bound: Int = min(floor(sqrt(n.toDouble())).toInt(), k)
+        var greatestFactor = 1
+        for (i in 2..bound + 1) {
+            if (n % i == 0) {
+                val complement: Int = n / i
+                if (complement <= k) {
+                    return complement
+                } else {
+                    greatestFactor = i
+                }
+            }
+        }
+        return greatestFactor
+    }
+
+    @SuppressWarnings("ReturnCount")
+    private fun getMinFactorGreaterThan(n: Int, k: Int): Int {
+        if (k >= n) {
+            return n
+        }
+        for (i in k..n + 1) {
+            if (n % i == 0) return i
+        }
+        return n
+    }
+
+    private fun handleException(e: Exception, message: String) {
+        logger.error(message, e)
+        stepStatus = StepStatus.FAILED
+        val mutableInfo = mutableMapOf("message" to message)
+        val errorMessage = e.message
+        if (errorMessage != null) mutableInfo["cause"] = errorMessage
+        info = mutableInfo.toMap()
+    }
+
+    private fun checkTimeOut(managedIndexMetadata: ManagedIndexMetaData) {
+        val timeFromActionStarted: Duration = Duration.between(getActionStartTime(managedIndexMetadata), Instant.now())
+        val timeOutInSeconds = action.configTimeout?.timeout?.seconds ?: MOVE_SHARDS_TIMEOUT_IN_SECONDS
+        // Get ActionTimeout if given, otherwise use default timeout of 12 hours
+        if (timeFromActionStarted.toSeconds() > timeOutInSeconds) {
+            info = mapOf("message" to TIMEOUT_MESSAGE)
+            stepStatus = StepStatus.FAILED
+        }
+    }
+
+    override fun getUpdatedManagedIndexMetadata(currentMetadata: ManagedIndexMetaData): ManagedIndexMetaData {
+        val currentActionMetaData = currentMetadata.actionMetaData
+        return currentMetadata.copy(
+            actionMetaData = currentActionMetaData?.copy(
+                actionProperties = ActionProperties(
+                    shrinkActionProperties = shrinkActionProperties
+                )
+            ),
+            stepMetaData = StepMetaData(name, getStepStartTime(currentMetadata).toEpochMilli(), stepStatus),
+            transitionTo = null,
+            info = info
+        )
+    }
+
+    override fun isIdempotent() = true
+
+    companion object {
+        const val OS_METRIC = "os"
+        const val ROUTING_SETTING = "index.routing.allocation.require._name"
+        const val RESOURCE_NAME = "node_name"
+        const val DEFAULT_TARGET_SUFFIX = "_shrunken"
+        const val bufferPercentage = 0.05.toLong()
+        const val MOVE_SHARDS_TIMEOUT_IN_SECONDS = 43200L // 12hrs in seconds
+        const val name = "attempt_move_shards_step"
+        const val RESOURCE_TYPE = "shrink"
+        const val TIMEOUT_MESSAGE = "Timed out waiting for finding node."
+        const val UPDATE_FAILED_MESSAGE = "Shrink failed because settings could not be updated.."
+        const val NO_AVAILABLE_NODES_MESSAGE =
+            "There are no available nodes for to move to to execute a shrink. Delaying until node becomes available."
+        const val UNSAFE_FAILURE_MESSAGE = "Shrink failed because index has no replicas and force_unsafe is not set to true."
+        const val ONE_PRIMARY_SHARD_FAILURE_MESSAGE = "Shrink failed because index only has one primary shard."
+        const val FAILURE_MESSAGE = "Shrink failed to start moving shards."
+        fun getSuccessMessage(node: String) = "Successfully started moving the shards to $node."
+        fun getIndexExistsMessage(newIndex: String) = "Shrink failed because $newIndex already exists."
+    }
+}

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/shrink/AttemptShrinkStep.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/shrink/AttemptShrinkStep.kt
@@ -52,7 +52,7 @@ class AttemptShrinkStep(private val action: ShrinkAction) : Step(name) {
             cleanupAndFail(WaitForMoveShardsStep.METADATA_FAILURE_MESSAGE)
             return this
         }
-        val lock = renewShrinkLock(localShrinkActionProperties, context.jobContext, logger)
+        val lock = renewShrinkLock(localShrinkActionProperties, context.lockService, logger)
         if (lock == null) {
             logger.error("Shrink action failed to renew lock on node [${localShrinkActionProperties.nodeName}]")
             cleanupAndFail("Failed to renew lock on node [${localShrinkActionProperties.nodeName}]")
@@ -97,7 +97,7 @@ class AttemptShrinkStep(private val action: ShrinkAction) : Step(name) {
             logger.error("Shrink action failed while trying to clean up routing and readonly setting after a failure: $e")
         }
         try {
-            releaseShrinkLock(shrinkActionProperties!!, context!!.jobContext, logger)
+            releaseShrinkLock(shrinkActionProperties!!, context!!.lockService, logger)
         } catch (e: Exception) {
             logger.error("Shrink action failed while trying to release the node lock after a failure: $e")
         }

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/shrink/AttemptShrinkStep.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/shrink/AttemptShrinkStep.kt
@@ -18,7 +18,7 @@ import org.opensearch.common.settings.Settings
 import org.opensearch.indexmanagement.indexstatemanagement.action.ShrinkAction
 import org.opensearch.indexmanagement.indexstatemanagement.action.ShrinkAction.Companion.getSecurityFailureMessage
 import org.opensearch.indexmanagement.indexstatemanagement.util.INDEX_NUMBER_OF_SHARDS
-import org.opensearch.indexmanagement.indexstatemanagement.util.clearReadOnlyAndRouting
+import org.opensearch.indexmanagement.indexstatemanagement.util.resetReadOnlyAndRouting
 import org.opensearch.indexmanagement.indexstatemanagement.util.getNodeFreeMemoryAfterShrink
 import org.opensearch.indexmanagement.indexstatemanagement.util.isIndexGreen
 import org.opensearch.indexmanagement.indexstatemanagement.util.releaseShrinkLock
@@ -92,7 +92,7 @@ class AttemptShrinkStep(private val action: ShrinkAction) : Step(name) {
         stepStatus = StepStatus.FAILED
         // Non-null assertion !! is used to throw an exception on null which would just be caught and logged
         try {
-            clearReadOnlyAndRouting(context!!.metadata.index, context!!.client)
+            resetReadOnlyAndRouting(context!!.metadata.index, context!!.client, shrinkActionProperties!!.originalIndexSettings)
         } catch (e: Exception) {
             logger.error("Shrink action failed while trying to clean up routing and readonly setting after a failure: $e")
         }

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/shrink/AttemptShrinkStep.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/shrink/AttemptShrinkStep.kt
@@ -1,0 +1,100 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.indexmanagement.indexstatemanagement.step.shrink
+
+import org.apache.logging.log4j.LogManager
+import org.opensearch.action.admin.cluster.health.ClusterHealthRequest
+import org.opensearch.action.admin.cluster.health.ClusterHealthResponse
+import org.opensearch.action.admin.indices.shrink.ResizeRequest
+import org.opensearch.action.admin.indices.shrink.ResizeResponse
+import org.opensearch.common.settings.Settings
+import org.opensearch.indexmanagement.indexstatemanagement.action.ShrinkAction
+import org.opensearch.indexmanagement.indexstatemanagement.util.INDEX_NUMBER_OF_SHARDS
+import org.opensearch.indexmanagement.indexstatemanagement.util.releaseShrinkLock
+import org.opensearch.indexmanagement.opensearchapi.suspendUntil
+import org.opensearch.indexmanagement.spi.indexstatemanagement.Step
+import org.opensearch.indexmanagement.spi.indexstatemanagement.model.ManagedIndexMetaData
+import org.opensearch.indexmanagement.spi.indexstatemanagement.model.StepMetaData
+import org.opensearch.transport.RemoteTransportException
+import java.lang.Exception
+
+class AttemptShrinkStep(private val action: ShrinkAction) : Step(name) {
+    private val logger = LogManager.getLogger(javaClass)
+    private var stepStatus = StepStatus.STARTING
+    private var info: Map<String, Any>? = null
+
+    @Suppress("TooGenericExceptionCaught", "ComplexMethod", "ReturnCount")
+    override suspend fun execute(): AttemptShrinkStep {
+        val context = this.context ?: return this
+        val indexName = context.metadata.index
+        val actionMetadata = context.metadata.actionMetaData
+        val shrinkActionProperties = actionMetadata?.actionProperties?.shrinkActionProperties
+        if (shrinkActionProperties == null) {
+            info = mapOf("message" to "Metadata not properly populated")
+            stepStatus = StepStatus.FAILED
+            return this
+        }
+        try {
+            val healthReq = ClusterHealthRequest().indices(indexName).waitForGreenStatus()
+            val response: ClusterHealthResponse = context.client.admin().cluster().suspendUntil { health(healthReq, it) }
+            // check status of cluster health
+            if (response.isTimedOut) {
+                stepStatus = StepStatus.CONDITION_NOT_MET
+                info = mapOf("message" to INDEX_HEALTH_NOT_GREEN_MESSAGE)
+                return this
+            }
+            val targetIndexName = shrinkActionProperties.targetIndexName
+            val aliases = action.aliases
+            val req = ResizeRequest(targetIndexName, indexName)
+            req.targetIndexRequest.settings(
+                Settings.builder()
+                    .put(AttemptMoveShardsStep.ROUTING_SETTING, shrinkActionProperties.nodeName)
+                    .put(INDEX_NUMBER_OF_SHARDS, shrinkActionProperties.targetNumShards)
+                    .build()
+            )
+            aliases?.forEach { req.targetIndexRequest.alias(it) }
+            val resizeResponse: ResizeResponse = context.client.admin().indices().suspendUntil { resizeIndex(req, it) }
+            if (!resizeResponse.isAcknowledged) {
+                info = mapOf("message" to FAILURE_MESSAGE)
+                releaseShrinkLock(shrinkActionProperties, context.jobContext, logger)
+                stepStatus = StepStatus.FAILED
+                return this
+            }
+            info = mapOf("message" to getSuccessMessage(targetIndexName))
+            stepStatus = StepStatus.COMPLETED
+            return this
+        } catch (e: RemoteTransportException) {
+            info = mapOf("message" to FAILURE_MESSAGE)
+            releaseShrinkLock(shrinkActionProperties, context.jobContext, logger)
+            stepStatus = StepStatus.FAILED
+            return this
+        } catch (e: Exception) {
+            releaseShrinkLock(shrinkActionProperties, context.jobContext, logger)
+            info = mapOf("message" to FAILURE_MESSAGE, "cause" to "{${e.message}}")
+            stepStatus = StepStatus.FAILED
+            return this
+        }
+    }
+
+    override fun getUpdatedManagedIndexMetadata(currentMetadata: ManagedIndexMetaData): ManagedIndexMetaData {
+        val currentActionMetaData = currentMetadata.actionMetaData
+        return currentMetadata.copy(
+            actionMetaData = currentActionMetaData?.copy(),
+            stepMetaData = StepMetaData(name, getStepStartTime(currentMetadata).toEpochMilli(), stepStatus),
+            transitionTo = null,
+            info = info
+        )
+    }
+
+    override fun isIdempotent() = false
+
+    companion object {
+        const val name = "attempt_shrink_step"
+        const val FAILURE_MESSAGE = "Shrink failed when sending shrink request."
+        const val INDEX_HEALTH_NOT_GREEN_MESSAGE = "Shrink delayed because index health is not green."
+        fun getSuccessMessage(newIndex: String) = "Shrink started. $newIndex currently being populated."
+    }
+}

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/shrink/AttemptShrinkStep.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/shrink/AttemptShrinkStep.kt
@@ -6,17 +6,18 @@
 package org.opensearch.indexmanagement.indexstatemanagement.step.shrink
 
 import org.apache.logging.log4j.LogManager
-import org.opensearch.action.admin.cluster.health.ClusterHealthRequest
-import org.opensearch.action.admin.cluster.health.ClusterHealthResponse
 import org.opensearch.action.admin.indices.shrink.ResizeRequest
 import org.opensearch.action.admin.indices.shrink.ResizeResponse
 import org.opensearch.common.settings.Settings
 import org.opensearch.indexmanagement.indexstatemanagement.action.ShrinkAction
 import org.opensearch.indexmanagement.indexstatemanagement.util.INDEX_NUMBER_OF_SHARDS
+import org.opensearch.indexmanagement.indexstatemanagement.util.isIndexGreen
 import org.opensearch.indexmanagement.indexstatemanagement.util.releaseShrinkLock
 import org.opensearch.indexmanagement.opensearchapi.suspendUntil
 import org.opensearch.indexmanagement.spi.indexstatemanagement.Step
 import org.opensearch.indexmanagement.spi.indexstatemanagement.model.ManagedIndexMetaData
+import org.opensearch.indexmanagement.spi.indexstatemanagement.model.ShrinkActionProperties
+import org.opensearch.indexmanagement.spi.indexstatemanagement.model.StepContext
 import org.opensearch.indexmanagement.spi.indexstatemanagement.model.StepMetaData
 import org.opensearch.transport.RemoteTransportException
 import java.lang.Exception
@@ -33,37 +34,19 @@ class AttemptShrinkStep(private val action: ShrinkAction) : Step(name) {
         val actionMetadata = context.metadata.actionMetaData
         val shrinkActionProperties = actionMetadata?.actionProperties?.shrinkActionProperties
         if (shrinkActionProperties == null) {
-            info = mapOf("message" to "Metadata not properly populated")
+            info = mapOf("message" to "Shrink action properties are null, metadata was not properly populated")
             stepStatus = StepStatus.FAILED
             return this
         }
         try {
-            val healthReq = ClusterHealthRequest().indices(indexName).waitForGreenStatus()
-            val response: ClusterHealthResponse = context.client.admin().cluster().suspendUntil { health(healthReq, it) }
-            // check status of cluster health
-            if (response.isTimedOut) {
+            if (!isIndexGreen(context.client, indexName)) {
                 stepStatus = StepStatus.CONDITION_NOT_MET
                 info = mapOf("message" to INDEX_HEALTH_NOT_GREEN_MESSAGE)
                 return this
             }
-            val targetIndexName = shrinkActionProperties.targetIndexName
-            val aliases = action.aliases
-            val req = ResizeRequest(targetIndexName, indexName)
-            req.targetIndexRequest.settings(
-                Settings.builder()
-                    .put(AttemptMoveShardsStep.ROUTING_SETTING, shrinkActionProperties.nodeName)
-                    .put(INDEX_NUMBER_OF_SHARDS, shrinkActionProperties.targetNumShards)
-                    .build()
-            )
-            aliases?.forEach { req.targetIndexRequest.alias(it) }
-            val resizeResponse: ResizeResponse = context.client.admin().indices().suspendUntil { resizeIndex(req, it) }
-            if (!resizeResponse.isAcknowledged) {
-                info = mapOf("message" to FAILURE_MESSAGE)
-                releaseShrinkLock(shrinkActionProperties, context.jobContext, logger)
-                stepStatus = StepStatus.FAILED
-                return this
-            }
-            info = mapOf("message" to getSuccessMessage(targetIndexName))
+            // If the resize index api fails, the step will be set to failed and resizeIndex will return false
+            if (!resizeIndex(indexName, shrinkActionProperties, context)) return this
+            info = mapOf("message" to getSuccessMessage(shrinkActionProperties.targetIndexName))
             stepStatus = StepStatus.COMPLETED
             return this
         } catch (e: RemoteTransportException) {
@@ -77,6 +60,26 @@ class AttemptShrinkStep(private val action: ShrinkAction) : Step(name) {
             stepStatus = StepStatus.FAILED
             return this
         }
+    }
+
+    private suspend fun resizeIndex(sourceIndex: String, shrinkActionProperties: ShrinkActionProperties, context: StepContext): Boolean {
+        val targetIndex = shrinkActionProperties.targetIndexName
+        val req = ResizeRequest(targetIndex, sourceIndex)
+        req.targetIndexRequest.settings(
+            Settings.builder()
+                .put(AttemptMoveShardsStep.ROUTING_SETTING, shrinkActionProperties.nodeName)
+                .put(INDEX_NUMBER_OF_SHARDS, shrinkActionProperties.targetNumShards)
+                .build()
+        )
+        action.aliases?.forEach { req.targetIndexRequest.alias(it) }
+        val resizeResponse: ResizeResponse = context.client.admin().indices().suspendUntil { resizeIndex(req, it) }
+        if (!resizeResponse.isAcknowledged) {
+            info = mapOf("message" to FAILURE_MESSAGE)
+            releaseShrinkLock(shrinkActionProperties, context.jobContext, logger)
+            stepStatus = StepStatus.FAILED
+            return false
+        }
+        return true
     }
 
     override fun getUpdatedManagedIndexMetadata(currentMetadata: ManagedIndexMetaData): ManagedIndexMetaData {

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/shrink/WaitForMoveShardsStep.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/shrink/WaitForMoveShardsStep.kt
@@ -1,0 +1,149 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.indexmanagement.indexstatemanagement.step.shrink
+
+import org.apache.logging.log4j.LogManager
+import org.opensearch.action.admin.indices.stats.IndicesStatsRequest
+import org.opensearch.action.admin.indices.stats.IndicesStatsResponse
+import org.opensearch.action.admin.indices.stats.ShardStats
+import org.opensearch.index.shard.ShardId
+import org.opensearch.indexmanagement.indexstatemanagement.action.ShrinkAction
+import org.opensearch.indexmanagement.indexstatemanagement.util.getActionStartTime
+import org.opensearch.indexmanagement.indexstatemanagement.util.releaseShrinkLock
+import org.opensearch.indexmanagement.opensearchapi.suspendUntil
+import org.opensearch.indexmanagement.spi.indexstatemanagement.Step
+import org.opensearch.indexmanagement.spi.indexstatemanagement.model.ManagedIndexMetaData
+import org.opensearch.indexmanagement.spi.indexstatemanagement.model.ShrinkActionProperties
+import org.opensearch.indexmanagement.spi.indexstatemanagement.model.StepContext
+import org.opensearch.indexmanagement.spi.indexstatemanagement.model.StepMetaData
+import org.opensearch.transport.RemoteTransportException
+import java.lang.Exception
+import java.time.Duration
+import java.time.Instant
+
+class WaitForMoveShardsStep(private val action: ShrinkAction) : Step(name) {
+    private val logger = LogManager.getLogger(javaClass)
+    private var stepStatus = StepStatus.STARTING
+    private var info: Map<String, Any>? = null
+
+    @Suppress("TooGenericExceptionCaught", "ComplexMethod", "ReturnCount", "NestedBlockDepth")
+    override suspend fun execute(): WaitForMoveShardsStep {
+        val context = this.context ?: return this
+        val indexName = context.metadata.index
+        val actionMetadata = context.metadata.actionMetaData
+        val shrinkActionProperties = actionMetadata?.actionProperties?.shrinkActionProperties
+        if (shrinkActionProperties == null) {
+            info = mapOf("message" to "Metadata not properly populated")
+            stepStatus = StepStatus.FAILED
+            return this
+        }
+        try {
+            val indexStatsRequests: IndicesStatsRequest = IndicesStatsRequest().indices(indexName)
+            val response: IndicesStatsResponse = context.client.admin().indices().suspendUntil { stats(indexStatsRequests, it) }
+            val numPrimaryShards = context.clusterService.state().metadata.indices[indexName].numberOfShards
+            val nodeToMoveOnto = shrinkActionProperties.nodeName
+            var numShardsOnNode = 0
+            val shardToCheckpointSetMap: MutableMap<ShardId, MutableSet<Long>> = mutableMapOf()
+            for (shard: ShardStats in response.shards) {
+                val seqNoStats = shard.seqNoStats
+                val routingInfo = shard.shardRouting
+                if (seqNoStats != null) {
+                    val checkpoint = seqNoStats.localCheckpoint
+                    val shardId = shard.shardRouting.shardId()
+                    val checkpointsOfShard = shardToCheckpointSetMap.getOrDefault(shardId, mutableSetOf())
+                    checkpointsOfShard.add(checkpoint)
+                    shardToCheckpointSetMap[shardId] = checkpointsOfShard
+                }
+                // TODO: Test if we can make this appear / if we can, fail the action.
+                shardToCheckpointSetMap.entries.forEach {
+                    (_, checkpointSet) ->
+                    if (checkpointSet.size > 1) {
+                        logger.warn("There are shards with varying local checkpoints")
+                    }
+                }
+                val nodeIdShardIsOn = routingInfo.currentNodeId()
+                val nodeShardIsOn = context.clusterService.state().nodes()[nodeIdShardIsOn].name
+                if (nodeShardIsOn.equals(nodeToMoveOnto) && routingInfo.started()) {
+                    numShardsOnNode++
+                }
+            }
+            if (numShardsOnNode >= numPrimaryShards) {
+                info = mapOf("message" to getSuccessMessage(nodeToMoveOnto))
+                stepStatus = StepStatus.COMPLETED
+                return this
+            }
+            val numShardsLeft = numPrimaryShards - numShardsOnNode
+            checkTimeOut(context, shrinkActionProperties, numShardsLeft, nodeToMoveOnto)
+            return this
+        } catch (e: RemoteTransportException) {
+            releaseShrinkLock(shrinkActionProperties, context.jobContext, logger)
+            info = mapOf("message" to FAILURE_MESSAGE)
+            stepStatus = StepStatus.FAILED
+            return this
+        } catch (e: Exception) {
+            releaseShrinkLock(shrinkActionProperties, context.jobContext, logger)
+            info = mapOf("message" to FAILURE_MESSAGE, "cause" to "{${e.message}}")
+            stepStatus = StepStatus.FAILED
+            return this
+        }
+    }
+
+    override fun getUpdatedManagedIndexMetadata(currentMetadata: ManagedIndexMetaData): ManagedIndexMetaData {
+        // Saving maxNumSegments in ActionProperties after the force merge operation has begun so that if a ChangePolicy occurred
+        // in between this step and WaitForForceMergeStep, a cached segment count expected from the operation is available
+        val currentActionMetaData = currentMetadata.actionMetaData
+        return currentMetadata.copy(
+            actionMetaData = currentActionMetaData?.copy(),
+            stepMetaData = StepMetaData(name, getStepStartTime(currentMetadata).toEpochMilli(), stepStatus),
+            transitionTo = null,
+            info = info
+        )
+    }
+
+    private suspend fun checkTimeOut(
+        stepContext: StepContext,
+        shrinkActionProperties: ShrinkActionProperties,
+        numShardsLeft: Int,
+        nodeToMoveOnto: String
+    ) {
+        val managedIndexMetadata = stepContext.metadata
+        val indexName = managedIndexMetadata.index
+        val timeFromActionStarted: Duration = Duration.between(getActionStartTime(managedIndexMetadata), Instant.now())
+        val timeOutInSeconds = action.configTimeout?.timeout?.seconds ?: MOVE_SHARDS_TIMEOUT_IN_SECONDS
+        // Get ActionTimeout if given, otherwise use default timeout of 12 hours
+        stepStatus = if (timeFromActionStarted.toSeconds() > timeOutInSeconds) {
+            logger.debug(
+                "Move shards failing on [$indexName] because" +
+                    " [$numShardsLeft] shards still needing to be moved"
+            )
+            if (managedIndexMetadata.actionMetaData?.actionProperties?.shrinkActionProperties != null) {
+                releaseShrinkLock(shrinkActionProperties, stepContext.jobContext, logger)
+            }
+            info = mapOf("message" to getTimeoutFailure(nodeToMoveOnto))
+            StepStatus.FAILED
+        } else {
+            logger.debug(
+                "Move shards still running on [$indexName] with" +
+                    " [$numShardsLeft] shards still needing to be moved"
+            )
+            info = mapOf("message" to getTimeoutDelay(nodeToMoveOnto))
+            StepStatus.CONDITION_NOT_MET
+        }
+    }
+
+    override fun isIdempotent() = true
+
+    companion object {
+        const val name = "wait_for_move_shards_step"
+        fun getSuccessMessage(node: String) = "The shards successfully moved to $node."
+        fun getTimeoutFailure(node: String) = "Shrink failed because it took to long to move shards to $node"
+        fun getTimeoutDelay(node: String) = "Shrink delayed because it took to long to move shards to $node"
+        const val FAILURE_MESSAGE = "Shrink failed when waiting for shards to move."
+        const val MOVE_SHARDS_TIMEOUT_IN_SECONDS = 43200L // 12hrs in seconds
+        const val RESOURCE_NAME = "node_name"
+        const val RESOURCE_TYPE = "shrink"
+    }
+}

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/shrink/WaitForMoveShardsStep.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/shrink/WaitForMoveShardsStep.kt
@@ -13,7 +13,7 @@ import org.opensearch.action.admin.indices.stats.IndicesStatsResponse
 import org.opensearch.action.admin.indices.stats.ShardStats
 import org.opensearch.indexmanagement.indexstatemanagement.action.ShrinkAction
 import org.opensearch.indexmanagement.indexstatemanagement.action.ShrinkAction.Companion.getSecurityFailureMessage
-import org.opensearch.indexmanagement.indexstatemanagement.util.clearReadOnlyAndRouting
+import org.opensearch.indexmanagement.indexstatemanagement.util.resetReadOnlyAndRouting
 import org.opensearch.indexmanagement.indexstatemanagement.util.getActionStartTime
 import org.opensearch.indexmanagement.indexstatemanagement.util.releaseShrinkLock
 import org.opensearch.indexmanagement.indexstatemanagement.util.renewShrinkLock
@@ -109,7 +109,7 @@ class WaitForMoveShardsStep(private val action: ShrinkAction) : Step(name) {
         stepStatus = StepStatus.FAILED
         // Non-null assertion !! is used to throw an exception on null which would just be caught and logged
         try {
-            clearReadOnlyAndRouting(context!!.metadata.index, context!!.client)
+            resetReadOnlyAndRouting(context!!.metadata.index, context!!.client, shrinkActionProperties!!.originalIndexSettings)
         } catch (e: Exception) {
             logger.error("Shrink action failed while trying to clean up routing and readonly setting after a failure: $e")
         }

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/shrink/WaitForMoveShardsStep.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/shrink/WaitForMoveShardsStep.kt
@@ -48,7 +48,7 @@ class WaitForMoveShardsStep(private val action: ShrinkAction) : Step(name) {
             cleanupAndFail(METADATA_FAILURE_MESSAGE)
             return this
         }
-        val lock = renewShrinkLock(localShrinkActionProperties, context.jobContext, logger)
+        val lock = renewShrinkLock(localShrinkActionProperties, context.lockService, logger)
         if (lock == null) {
             logger.error("Shrink action failed to renew lock on node [${localShrinkActionProperties.nodeName}]")
             cleanupAndFail("Failed to renew lock on node [${localShrinkActionProperties.nodeName}]")
@@ -114,7 +114,7 @@ class WaitForMoveShardsStep(private val action: ShrinkAction) : Step(name) {
             logger.error("Shrink action failed while trying to clean up routing and readonly setting after a failure: $e")
         }
         try {
-            releaseShrinkLock(shrinkActionProperties!!, context!!.jobContext, logger)
+            releaseShrinkLock(shrinkActionProperties!!, context!!.lockService, logger)
         } catch (e: Exception) {
             logger.error("Shrink action failed while trying to release the node lock after a failure: $e")
         }

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/shrink/WaitForShrinkStep.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/shrink/WaitForShrinkStep.kt
@@ -6,19 +6,21 @@
 package org.opensearch.indexmanagement.indexstatemanagement.step.shrink
 
 import org.apache.logging.log4j.LogManager
+import org.opensearch.action.admin.indices.delete.DeleteIndexRequest
 import org.opensearch.action.admin.indices.stats.IndicesStatsRequest
 import org.opensearch.action.admin.indices.stats.IndicesStatsResponse
 import org.opensearch.action.support.master.AcknowledgedResponse
 import org.opensearch.client.Client
 import org.opensearch.common.settings.Settings
 import org.opensearch.indexmanagement.indexstatemanagement.action.ShrinkAction
+import org.opensearch.indexmanagement.indexstatemanagement.util.clearReadOnlyAndRouting
 import org.opensearch.indexmanagement.indexstatemanagement.util.getActionStartTime
 import org.opensearch.indexmanagement.indexstatemanagement.util.issueUpdateSettingsRequest
 import org.opensearch.indexmanagement.indexstatemanagement.util.releaseShrinkLock
+import org.opensearch.indexmanagement.indexstatemanagement.util.renewShrinkLock
 import org.opensearch.indexmanagement.opensearchapi.suspendUntil
 import org.opensearch.indexmanagement.spi.indexstatemanagement.Step
 import org.opensearch.indexmanagement.spi.indexstatemanagement.model.ManagedIndexMetaData
-import org.opensearch.indexmanagement.spi.indexstatemanagement.model.ShrinkActionProperties
 import org.opensearch.indexmanagement.spi.indexstatemanagement.model.StepContext
 import org.opensearch.indexmanagement.spi.indexstatemanagement.model.StepMetaData
 import org.opensearch.transport.RemoteTransportException
@@ -36,8 +38,12 @@ class WaitForShrinkStep(private val action: ShrinkAction) : Step(name) {
         val actionMetadata = context.metadata.actionMetaData
         val shrinkActionProperties = actionMetadata?.actionProperties?.shrinkActionProperties
         if (shrinkActionProperties == null) {
-            info = mapOf("message" to "Shrink action properties are null, metadata was not properly populated")
-            stepStatus = StepStatus.FAILED
+            cleanupAndFail(WaitForMoveShardsStep.METADATA_FAILURE_MESSAGE)
+            return this
+        }
+        val lock = renewShrinkLock(shrinkActionProperties, context.jobContext, logger)
+        if (lock == null) {
+            cleanupAndFail("Failed to renew lock on node [${shrinkActionProperties.nodeName}]")
             return this
         }
         try {
@@ -45,38 +51,62 @@ class WaitForShrinkStep(private val action: ShrinkAction) : Step(name) {
             val numPrimaryShardsStarted = getNumPrimaryShardsStarted(context.client, targetIndex)
             val numPrimaryShards = context.clusterService.state().metadata.indices[targetIndex].numberOfShards
             if (numPrimaryShards != shrinkActionProperties.targetNumShards || numPrimaryShardsStarted != shrinkActionProperties.targetNumShards) {
-                checkTimeOut(context, shrinkActionProperties, targetIndex)
+                checkTimeOut(context, targetIndex)
                 return this
             }
 
             // Clear source and target allocation, if either fails the step will be set to failed and the function will return false
-            if (!clearAllocationSettings(context, targetIndex, shrinkActionProperties)) return this
-            if (!clearAllocationSettings(context, context.metadata.index, shrinkActionProperties)) return this
+            if (!clearAllocationSettings(context, targetIndex)) return this
+            if (!clearAllocationSettings(context, context.metadata.index)) return this
 
             releaseShrinkLock(shrinkActionProperties, context.jobContext, logger)
             stepStatus = StepStatus.COMPLETED
             info = mapOf("message" to SUCCESS_MESSAGE)
             return this
         } catch (e: RemoteTransportException) {
-            releaseShrinkLock(shrinkActionProperties, context.jobContext, logger)
-            info = mapOf("message" to getFailureMessage(shrinkActionProperties.targetIndexName))
-            stepStatus = StepStatus.FAILED
+            cleanupAndFail(getFailureMessage(shrinkActionProperties.targetIndexName))
             return this
         } catch (e: Exception) {
-            releaseShrinkLock(shrinkActionProperties, context.jobContext, logger)
-            info = mapOf("message" to GENERIC_FAILURE_MESSAGE, "cause" to "{${e.message}}")
-            stepStatus = StepStatus.FAILED
+            cleanupAndFail(GENERIC_FAILURE_MESSAGE, e.message)
             return this
         }
     }
 
-    private suspend fun clearAllocationSettings(context: StepContext, index: String, shrinkActionProperties: ShrinkActionProperties): Boolean {
+    // Sets the action to failed, clears the readonly and allocation settings on the source index, deletes the target index, and releases the shrink lock
+    private suspend fun cleanupAndFail(message: String, cause: String? = null) {
+        info = if (cause == null) mapOf("message" to message) else mapOf("message" to message, "cause" to cause)
+        stepStatus = StepStatus.FAILED
+        val context = this.context ?: return
+        // Using a try/catch for each cleanup action as we should clean up as much as possible despite any failures
+        try {
+            clearReadOnlyAndRouting(context.metadata.index, context.client)
+        } catch (e: Exception) {
+            logger.error("Shrink action failed while trying to clean up routing and readonly setting after a failure: $e")
+        }
+        val shrinkActionProperties = context.metadata.actionMetaData?.actionProperties?.shrinkActionProperties ?: return
+        try {
+            // TODO CLAY use plugin permissions when cleaning up
+            // Delete the target index
+            val deleteRequest = DeleteIndexRequest(shrinkActionProperties.targetIndexName)
+            val response: AcknowledgedResponse = context.client.admin().indices().suspendUntil { delete(deleteRequest, it) }
+            if (!response.isAcknowledged) {
+                logger.error("Shrink action failed to delete target index during cleanup after a failure")
+            }
+        } catch (e: Exception) {
+            logger.error("Shrink action failed while trying to delete the target index after a failure: $e")
+        }
+        try {
+            releaseShrinkLock(shrinkActionProperties, context.jobContext, logger)
+        } catch (e: Exception) {
+            logger.error("Shrink action failed while trying to release the node lock after a failure: $e")
+        }
+    }
+
+    private suspend fun clearAllocationSettings(context: StepContext, index: String): Boolean {
         val allocationSettings = Settings.builder().putNull(AttemptMoveShardsStep.ROUTING_SETTING).build()
         val response: AcknowledgedResponse = issueUpdateSettingsRequest(context.client, index, allocationSettings)
         if (!response.isAcknowledged) {
-            releaseShrinkLock(shrinkActionProperties, context.jobContext, logger)
-            stepStatus = StepStatus.FAILED
-            info = mapOf("message" to getFailureMessage(index))
+            cleanupAndFail(getFailureMessage(index))
             return false
         }
         return true
@@ -88,25 +118,16 @@ class WaitForShrinkStep(private val action: ShrinkAction) : Step(name) {
         return targetStatsResponse.shards.filter { it.shardRouting.started() && it.shardRouting.primary() }.size
     }
 
-    private suspend fun checkTimeOut(stepContext: StepContext, shrinkActionProperties: ShrinkActionProperties, targetIndex: String) {
+    private suspend fun checkTimeOut(stepContext: StepContext, targetIndex: String) {
         val managedIndexMetadata = stepContext.metadata
-        val indexName = managedIndexMetadata.index
         val timeFromActionStarted: Duration = Duration.between(getActionStartTime(managedIndexMetadata), Instant.now())
         val timeOutInSeconds = action.configTimeout?.timeout?.seconds ?: WaitForMoveShardsStep.MOVE_SHARDS_TIMEOUT_IN_SECONDS
         // Get ActionTimeout if given, otherwise use default timeout of 12 hours
-        stepStatus = if (timeFromActionStarted.toSeconds() > timeOutInSeconds) {
-            logger.error(
-                "Shards of $indexName have still not started."
-            )
-            releaseShrinkLock(shrinkActionProperties, stepContext.jobContext, logger)
-            info = mapOf("message" to getFailureMessage(targetIndex))
-            StepStatus.FAILED
+        if (timeFromActionStarted.toSeconds() > timeOutInSeconds) {
+            cleanupAndFail(getFailureMessage(targetIndex))
         } else {
-            logger.debug(
-                "Shards of $indexName have still not started."
-            )
             info = mapOf("message" to getDelayedMessage(targetIndex))
-            StepStatus.CONDITION_NOT_MET
+            stepStatus = StepStatus.CONDITION_NOT_MET
         }
     }
 

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/shrink/WaitForShrinkStep.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/shrink/WaitForShrinkStep.kt
@@ -52,7 +52,7 @@ class WaitForShrinkStep(private val action: ShrinkAction) : Step(name) {
             cleanupAndFail(WaitForMoveShardsStep.METADATA_FAILURE_MESSAGE)
             return this
         }
-        val lock = renewShrinkLock(localShrinkActionProperties, context.jobContext, logger)
+        val lock = renewShrinkLock(localShrinkActionProperties, context.lockService, logger)
         if (lock == null) {
             logger.error("Shrink action failed to renew lock on node [${localShrinkActionProperties.nodeName}]")
             cleanupAndFail("Failed to renew lock on node [${localShrinkActionProperties.nodeName}]")
@@ -73,7 +73,7 @@ class WaitForShrinkStep(private val action: ShrinkAction) : Step(name) {
             if (!clearAllocationSettings(context, targetIndex)) return this
             if (!clearAllocationSettings(context, context.metadata.index)) return this
 
-            deleteShrinkLock(localShrinkActionProperties, context.jobContext, logger)
+            deleteShrinkLock(localShrinkActionProperties, context.lockService, logger)
             stepStatus = StepStatus.COMPLETED
             info = mapOf("message" to SUCCESS_MESSAGE)
             return this
@@ -117,7 +117,7 @@ class WaitForShrinkStep(private val action: ShrinkAction) : Step(name) {
             logger.error("Shrink action failed while trying to delete the target index after a failure: $e")
         }
         try {
-            releaseShrinkLock(shrinkActionProperties!!, context!!.jobContext, logger)
+            releaseShrinkLock(shrinkActionProperties!!, context!!.lockService, logger)
         } catch (e: Exception) {
             logger.error("Shrink action failed while trying to release the node lock after a failure: $e")
         }

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/shrink/WaitForShrinkStep.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/shrink/WaitForShrinkStep.kt
@@ -1,0 +1,129 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.indexmanagement.indexstatemanagement.step.shrink
+
+import org.apache.logging.log4j.LogManager
+import org.opensearch.action.admin.indices.settings.put.UpdateSettingsRequest
+import org.opensearch.action.admin.indices.stats.IndicesStatsRequest
+import org.opensearch.action.admin.indices.stats.IndicesStatsResponse
+import org.opensearch.action.admin.indices.stats.ShardStats
+import org.opensearch.action.support.master.AcknowledgedResponse
+import org.opensearch.common.settings.Settings
+import org.opensearch.indexmanagement.indexstatemanagement.action.ShrinkAction
+import org.opensearch.indexmanagement.indexstatemanagement.util.getActionStartTime
+import org.opensearch.indexmanagement.indexstatemanagement.util.issueUpdateSettingsRequest
+import org.opensearch.indexmanagement.indexstatemanagement.util.releaseShrinkLock
+import org.opensearch.indexmanagement.opensearchapi.suspendUntil
+import org.opensearch.indexmanagement.spi.indexstatemanagement.Step
+import org.opensearch.indexmanagement.spi.indexstatemanagement.model.ManagedIndexMetaData
+import org.opensearch.indexmanagement.spi.indexstatemanagement.model.ShrinkActionProperties
+import org.opensearch.indexmanagement.spi.indexstatemanagement.model.StepContext
+import org.opensearch.indexmanagement.spi.indexstatemanagement.model.StepMetaData
+import org.opensearch.transport.RemoteTransportException
+import java.time.Duration
+import java.time.Instant
+
+class WaitForShrinkStep(private val action: ShrinkAction) : Step(name) {
+    private val logger = LogManager.getLogger(javaClass)
+    private var stepStatus = StepStatus.STARTING
+    private var info: Map<String, Any>? = null
+
+    @Suppress("TooGenericExceptionCaught", "ComplexMethod", "ReturnCount", "LongMethod")
+    override suspend fun execute(): WaitForShrinkStep {
+        val context = this.context ?: return this
+        val actionMetadata = context.metadata.actionMetaData
+        val shrinkActionProperties = actionMetadata?.actionProperties?.shrinkActionProperties
+        if (shrinkActionProperties == null) {
+            info = mapOf("message" to "Metadata not properly populated")
+            stepStatus = StepStatus.FAILED
+            return this
+        }
+        try {
+            val targetIndex = shrinkActionProperties.targetIndexName
+            val targetIndexStatsRequests: IndicesStatsRequest = IndicesStatsRequest().indices(targetIndex)
+            val targetStatsResponse: IndicesStatsResponse = context.client.admin().indices().suspendUntil { stats(targetIndexStatsRequests, it) }
+            var numShardsStarted = 0
+            for (shard: ShardStats in targetStatsResponse.shards) {
+                if (shard.shardRouting.started()) {
+                    numShardsStarted++
+                }
+            }
+            if (numShardsStarted < shrinkActionProperties.targetNumShards) {
+                checkTimeOut(context, shrinkActionProperties, targetIndex)
+                return this
+            }
+            val allocationSettings = Settings.builder().putNull(AttemptMoveShardsStep.ROUTING_SETTING).build()
+            val response: AcknowledgedResponse = context.client.admin().indices().suspendUntil {
+                updateSettings(UpdateSettingsRequest(allocationSettings, targetIndex), it)
+            }
+            if (!response.isAcknowledged) {
+                releaseShrinkLock(shrinkActionProperties, context.jobContext, logger)
+                stepStatus = StepStatus.FAILED
+                info = mapOf("message" to getFailureMessage(targetIndex))
+                return this
+            }
+            issueUpdateSettingsRequest(context.client, context.metadata, allocationSettings)
+            releaseShrinkLock(shrinkActionProperties, context.jobContext, logger)
+            stepStatus = StepStatus.COMPLETED
+            info = mapOf("message" to SUCCESS_MESSAGE)
+            return this
+        } catch (e: RemoteTransportException) {
+            releaseShrinkLock(shrinkActionProperties, context.jobContext, logger)
+            info = mapOf("message" to getFailureMessage(shrinkActionProperties.targetIndexName))
+            stepStatus = StepStatus.FAILED
+            return this
+        } catch (e: Exception) {
+            releaseShrinkLock(shrinkActionProperties, context.jobContext, logger)
+            info = mapOf("message" to GENERIC_FAILURE_MESSAGE, "cause" to "{${e.message}}")
+            stepStatus = StepStatus.FAILED
+            return this
+        }
+    }
+
+    private suspend fun checkTimeOut(stepContext: StepContext, shrinkActionProperties: ShrinkActionProperties, targetIndex: String) {
+        val managedIndexMetadata = stepContext.metadata
+        val indexName = managedIndexMetadata.index
+        val timeFromActionStarted: Duration = Duration.between(getActionStartTime(managedIndexMetadata), Instant.now())
+        val timeOutInSeconds = action.configTimeout?.timeout?.seconds ?: WaitForMoveShardsStep.MOVE_SHARDS_TIMEOUT_IN_SECONDS
+        // Get ActionTimeout if given, otherwise use default timeout of 12 hours
+        stepStatus = if (timeFromActionStarted.toSeconds() > timeOutInSeconds) {
+            logger.error(
+                "Shards of $indexName have still not started."
+            )
+            releaseShrinkLock(shrinkActionProperties, stepContext.jobContext, logger)
+            info = mapOf("message" to getFailureMessage(targetIndex))
+            StepStatus.FAILED
+        } else {
+            logger.debug(
+                "Shards of $indexName have still not started."
+            )
+            info = mapOf("message" to getDelayedMessage(targetIndex))
+            StepStatus.CONDITION_NOT_MET
+        }
+    }
+
+    override fun getUpdatedManagedIndexMetadata(currentMetadata: ManagedIndexMetaData): ManagedIndexMetaData {
+        // Saving maxNumSegments in ActionProperties after the force merge operation has begun so that if a ChangePolicy occurred
+        // in between this step and WaitForForceMergeStep, a cached segment count expected from the operation is available
+        val currentActionMetaData = currentMetadata.actionMetaData
+        return currentMetadata.copy(
+            actionMetaData = currentActionMetaData?.copy(),
+            stepMetaData = StepMetaData(name, getStepStartTime(currentMetadata).toEpochMilli(), stepStatus),
+            transitionTo = null,
+            info = info
+        )
+    }
+
+    override fun isIdempotent() = true
+
+    companion object {
+        const val name = "wait_for_shrink_step"
+        const val SUCCESS_MESSAGE = "Shrink finished successfully."
+        const val GENERIC_FAILURE_MESSAGE = "Shrink failed while waiting for shards to start."
+        fun getDelayedMessage(newIndex: String) = "Shrink delayed because $newIndex shards not in started state."
+        fun getFailureMessage(newIndex: String) = "Shrink failed while waiting for $newIndex shards to start."
+    }
+}

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/util/ManagedIndexUtils.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/util/ManagedIndexUtils.kt
@@ -7,10 +7,10 @@
 @file:JvmName("ManagedIndexUtils")
 package org.opensearch.indexmanagement.indexstatemanagement.util
 
-//import inet.ipaddr.IPAddressString
+// import inet.ipaddr.IPAddressString
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
-//import org.apache.logging.log4j.LogManager
+// import org.apache.logging.log4j.LogManager
 import org.apache.logging.log4j.Logger
 import org.opensearch.action.delete.DeleteRequest
 import org.opensearch.action.get.GetRequest
@@ -19,7 +19,7 @@ import org.opensearch.action.index.IndexRequest
 import org.opensearch.action.search.SearchRequest
 import org.opensearch.action.support.WriteRequest
 import org.opensearch.action.update.UpdateRequest
-//import org.opensearch.alerting.destination.message.BaseMessage
+// import org.opensearch.alerting.destination.message.BaseMessage
 import org.opensearch.client.Client
 import org.opensearch.common.unit.ByteSizeValue
 import org.opensearch.common.unit.TimeValue

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/util/StepUtils.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/util/StepUtils.kt
@@ -1,0 +1,83 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.indexmanagement.indexstatemanagement.util
+
+import org.apache.logging.log4j.Logger
+import org.opensearch.action.admin.indices.settings.put.UpdateSettingsRequest
+import org.opensearch.action.support.master.AcknowledgedResponse
+import org.opensearch.client.Client
+import org.opensearch.common.settings.Settings
+import org.opensearch.indexmanagement.indexstatemanagement.step.shrink.WaitForMoveShardsStep
+import org.opensearch.indexmanagement.opensearchapi.suspendUntil
+import org.opensearch.indexmanagement.spi.indexstatemanagement.model.ManagedIndexMetaData
+import org.opensearch.indexmanagement.spi.indexstatemanagement.model.ShrinkActionProperties
+import org.opensearch.jobscheduler.spi.JobExecutionContext
+import org.opensearch.jobscheduler.spi.LockModel
+import java.time.Instant
+
+suspend fun issueUpdateSettingsRequest(client: Client, managedIndexMetaData: ManagedIndexMetaData, settings: Settings): AcknowledgedResponse {
+    return client.admin()
+        .indices()
+        .suspendUntil { updateSettings(UpdateSettingsRequest(settings, managedIndexMetaData.index), it) }
+}
+
+suspend fun releaseShrinkLock(
+    shrinkActionProperties: ShrinkActionProperties,
+    jobExecutionContext: JobExecutionContext,
+    logger: Logger
+) {
+    val lock: LockModel = getShrinkLockModel(shrinkActionProperties, jobExecutionContext)
+    val released: Boolean = jobExecutionContext.lockService.suspendUntil { release(lock, it) }
+    if (!released) {
+        logger.warn("Lock not released on failure")
+    }
+}
+
+fun getShrinkLockModel(
+    shrinkActionProperties: ShrinkActionProperties,
+    jobExecutionContext: JobExecutionContext
+): LockModel {
+    return getShrinkLockModel(
+        shrinkActionProperties.nodeName,
+        jobExecutionContext.jobIndexName,
+        jobExecutionContext.jobId,
+        shrinkActionProperties.lockEpochSecond,
+        shrinkActionProperties.lockPrimaryTerm,
+        shrinkActionProperties.lockSeqNo
+    )
+}
+
+@SuppressWarnings("LongParameterList")
+fun getShrinkLockModel(
+    nodeName: String,
+    jobIndexName: String,
+    jobId: String,
+    lockEpochSecond: Long,
+    lockPrimaryTerm: Long,
+    lockSeqNo: Long
+): LockModel {
+    val resource: HashMap<String, String> = HashMap()
+    resource[WaitForMoveShardsStep.RESOURCE_NAME] = nodeName
+    val lockCreationInstant: Instant = Instant.ofEpochSecond(lockEpochSecond)
+    return LockModel(
+        jobIndexName,
+        jobId,
+        WaitForMoveShardsStep.RESOURCE_TYPE,
+        resource as Map<String, Any>?,
+        lockCreationInstant,
+        WaitForMoveShardsStep.MOVE_SHARDS_TIMEOUT_IN_SECONDS,
+        false,
+        lockSeqNo,
+        lockPrimaryTerm
+    )
+}
+
+fun getActionStartTime(managedIndexMetaData: ManagedIndexMetaData): Instant {
+    val actionMetadata = managedIndexMetaData.actionMetaData
+    // Return the action start time, or if that is null return now
+    actionMetadata?.startTime?.let { return Instant.ofEpochMilli(it) }
+    return Instant.now()
+}

--- a/src/main/kotlin/org/opensearch/indexmanagement/opensearchapi/OpenSearchExtensions.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/opensearchapi/OpenSearchExtensions.kt
@@ -16,6 +16,7 @@ import org.apache.logging.log4j.Logger
 import org.opensearch.ExceptionsHelper
 import org.opensearch.OpenSearchException
 import org.opensearch.action.ActionListener
+import org.opensearch.action.admin.indices.alias.Alias
 import org.opensearch.action.bulk.BackoffPolicy
 import org.opensearch.action.get.GetResponse
 import org.opensearch.action.search.SearchResponse
@@ -39,6 +40,7 @@ import org.opensearch.common.xcontent.XContentType
 import org.opensearch.commons.InjectSecurity
 import org.opensearch.commons.authuser.User
 import org.opensearch.index.seqno.SequenceNumbers
+import org.opensearch.indexmanagement.indexstatemanagement.action.ShrinkAction
 import org.opensearch.indexmanagement.indexstatemanagement.model.ISMTemplate
 import org.opensearch.indexmanagement.indexstatemanagement.model.Policy
 import org.opensearch.indexmanagement.util.NO_ID
@@ -78,6 +80,12 @@ fun XContentParser.instant(): Instant? {
             null // unreachable
         }
     }
+}
+
+fun XContentBuilder.aliasesField(aliases: List<Alias>): XContentBuilder {
+    val builder = this.startObject(ShrinkAction.ALIASES_FIELD)
+    aliases.forEach { it.toXContent(builder, ToXContent.EMPTY_PARAMS) }
+    return builder.endObject()
 }
 
 fun XContentBuilder.optionalTimeField(name: String, instant: Instant?): XContentBuilder {

--- a/src/main/kotlin/org/opensearch/indexmanagement/opensearchapi/OpenSearchExtensions.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/opensearchapi/OpenSearchExtensions.kt
@@ -83,9 +83,13 @@ fun XContentParser.instant(): Instant? {
 }
 
 fun XContentBuilder.aliasesField(aliases: List<Alias>): XContentBuilder {
-    val builder = this.startObject(ShrinkAction.ALIASES_FIELD)
-    aliases.forEach { it.toXContent(builder, ToXContent.EMPTY_PARAMS) }
-    return builder.endObject()
+    val builder = this.startArray(ShrinkAction.ALIASES_FIELD)
+    aliases.forEach {
+        builder.startObject()
+        it.toXContent(builder, ToXContent.EMPTY_PARAMS)
+        builder.endObject()
+    }
+    return builder.endArray()
 }
 
 fun XContentBuilder.optionalTimeField(name: String, instant: Instant?): XContentBuilder {

--- a/src/main/resources/mappings/opendistro-ism-config.json
+++ b/src/main/resources/mappings/opendistro-ism-config.json
@@ -441,8 +441,9 @@
                     "percentage_of_source_shards": {
                       "type": "double"
                     },
-                    "target_index_suffix": {
-                      "type": "text"
+                    "target_index_name_template": {
+                      "type": "object",
+                      "enabled": false
                     },
                     "aliases": {
                       "type": "object",

--- a/src/main/resources/mappings/opendistro-ism-config.json
+++ b/src/main/resources/mappings/opendistro-ism-config.json
@@ -438,7 +438,7 @@
                     "max_shard_size": {
                       "type": "keyword"
                     },
-                    "percentage_decrease": {
+                    "percentage_of_source_shards": {
                       "type": "double"
                     },
                     "target_index_suffix": {

--- a/src/main/resources/mappings/opendistro-ism-config.json
+++ b/src/main/resources/mappings/opendistro-ism-config.json
@@ -1,6 +1,6 @@
 {
   "_meta" : {
-    "schema_version": 13
+    "schema_version": 14
   },
   "dynamic": "strict",
   "properties": {
@@ -430,6 +430,29 @@
                     }
                   }
                 },
+                "shrink": {
+                  "properties": {
+                    "num_new_shards": {
+                      "type": "integer"
+                    },
+                    "max_shard_size": {
+                      "type": "keyword"
+                    },
+                    "percentage_decrease": {
+                      "type": "double"
+                    },
+                    "target_index_suffix": {
+                      "type": "text"
+                    },
+                    "aliases": {
+                      "type": "object",
+                      "enabled": false
+                    },
+                    "force_unsafe": {
+                      "type": "boolean"
+                    }
+                  }
+                },
                 "custom": {
                   "enabled": false,
                   "type":  "object"
@@ -733,6 +756,10 @@
                 },
                 "has_rollup_failed": {
                   "type": "boolean"
+                },
+                "shrink_action_properties": {
+                  "type": "object",
+                  "enabled": false
                 }
               }
             }

--- a/src/main/resources/mappings/opendistro-ism-history.json
+++ b/src/main/resources/mappings/opendistro-ism-history.json
@@ -1,6 +1,6 @@
 {
   "_meta" : {
-    "schema_version": 4
+    "schema_version": 5
   },
   "dynamic": "strict",
   "properties": {
@@ -108,6 +108,10 @@
                 },
                 "has_rollup_failed": {
                   "type": "boolean"
+                },
+                "shrink_action_properties": {
+                  "type": "object",
+                  "enabled": false
                 }
               }
             }

--- a/src/test/kotlin/org/opensearch/indexmanagement/IndexManagementRestTestCase.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/IndexManagementRestTestCase.kt
@@ -27,8 +27,8 @@ import javax.management.remote.JMXServiceURL
 
 abstract class IndexManagementRestTestCase : ODFERestTestCase() {
 
-    val configSchemaVersion = 13
-    val historySchemaVersion = 4
+    val configSchemaVersion = 14
+    val historySchemaVersion = 5
 
     // Having issues with tests leaking into other tests and mappings being incorrect and they are not caught by any pending task wait check as
     // they do not go through the pending task queue. Ideally this should probably be written in a way to wait for the

--- a/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/TestHelpers.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/TestHelpers.kt
@@ -60,6 +60,7 @@ import org.opensearch.test.rest.OpenSearchRestTestCase
 import java.time.Instant
 import java.time.ZoneId
 import java.time.temporal.ChronoUnit
+import kotlin.math.abs
 
 fun randomPolicy(
     id: String = OpenSearchRestTestCase.randomAlphaOfLength(10),
@@ -149,7 +150,7 @@ fun randomShrinkAction(
 ): ShrinkAction {
     if (numNewShards == null && maxShardSize == null && percentageDecrease == null) {
         when (randomInt(2)) {
-            0 -> return ShrinkAction(randomInt(), null, null, targetIndexSuffix, aliases, forceUnsafe, 0)
+            0 -> return ShrinkAction(abs(randomInt()) + 1, null, null, targetIndexSuffix, aliases, forceUnsafe, 0)
             1 -> return ShrinkAction(null, randomByteSizeValue(), null, targetIndexSuffix, aliases, forceUnsafe, 0)
             2 -> return ShrinkAction(null, null, randomDoubleBetween(0.0, 1.0, true), targetIndexSuffix, aliases, forceUnsafe, 0)
         }

--- a/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/TestHelpers.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/TestHelpers.kt
@@ -143,19 +143,19 @@ fun randomRolloverActionConfig(
 fun randomShrinkAction(
     numNewShards: Int? = null,
     maxShardSize: ByteSizeValue? = null,
-    percentageDecrease: Double? = null,
+    percentageOfSourceShards: Double? = null,
     targetIndexSuffix: String? = if (randomBoolean()) randomAlphaOfLength(10) else null,
     aliases: List<Alias>? = if (randomBoolean()) randomList(10) { randomAlias() } else null,
     forceUnsafe: Boolean? = if (randomBoolean()) randomBoolean() else null
 ): ShrinkAction {
-    if (numNewShards == null && maxShardSize == null && percentageDecrease == null) {
+    if (numNewShards == null && maxShardSize == null && percentageOfSourceShards == null) {
         when (randomInt(2)) {
             0 -> return ShrinkAction(abs(randomInt()) + 1, null, null, targetIndexSuffix, aliases, forceUnsafe, 0)
             1 -> return ShrinkAction(null, randomByteSizeValue(), null, targetIndexSuffix, aliases, forceUnsafe, 0)
             2 -> return ShrinkAction(null, null, randomDoubleBetween(0.0, 1.0, true), targetIndexSuffix, aliases, forceUnsafe, 0)
         }
     }
-    return ShrinkAction(numNewShards, maxShardSize, percentageDecrease, targetIndexSuffix, aliases, forceUnsafe, 0)
+    return ShrinkAction(numNewShards, maxShardSize, percentageOfSourceShards, targetIndexSuffix, aliases, forceUnsafe, 0)
 }
 
 fun randomReadOnlyActionConfig(): ReadOnlyAction {

--- a/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/TestHelpers.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/TestHelpers.kt
@@ -140,22 +140,23 @@ fun randomRolloverActionConfig(
     )
 }
 
+@Suppress("ReturnCount")
 fun randomShrinkAction(
     numNewShards: Int? = null,
     maxShardSize: ByteSizeValue? = null,
     percentageOfSourceShards: Double? = null,
-    targetIndexSuffix: String? = if (randomBoolean()) randomAlphaOfLength(10) else null,
+    targetIndexTemplate: Script? = if (randomBoolean()) randomTemplateScript(randomAlphaOfLength(10)) else null,
     aliases: List<Alias>? = if (randomBoolean()) randomList(10) { randomAlias() } else null,
     forceUnsafe: Boolean? = if (randomBoolean()) randomBoolean() else null
 ): ShrinkAction {
     if (numNewShards == null && maxShardSize == null && percentageOfSourceShards == null) {
         when (randomInt(2)) {
-            0 -> return ShrinkAction(abs(randomInt()) + 1, null, null, targetIndexSuffix, aliases, forceUnsafe, 0)
-            1 -> return ShrinkAction(null, randomByteSizeValue(), null, targetIndexSuffix, aliases, forceUnsafe, 0)
-            2 -> return ShrinkAction(null, null, randomDoubleBetween(0.0, 1.0, true), targetIndexSuffix, aliases, forceUnsafe, 0)
+            0 -> return ShrinkAction(abs(randomInt()) + 1, null, null, targetIndexTemplate, aliases, forceUnsafe, 0)
+            1 -> return ShrinkAction(null, randomByteSizeValue(), null, targetIndexTemplate, aliases, forceUnsafe, 0)
+            2 -> return ShrinkAction(null, null, randomDoubleBetween(0.0, 1.0, true), targetIndexTemplate, aliases, forceUnsafe, 0)
         }
     }
-    return ShrinkAction(numNewShards, maxShardSize, percentageOfSourceShards, targetIndexSuffix, aliases, forceUnsafe, 0)
+    return ShrinkAction(numNewShards, maxShardSize, percentageOfSourceShards, targetIndexTemplate, aliases, forceUnsafe, 0)
 }
 
 fun randomReadOnlyActionConfig(): ReadOnlyAction {

--- a/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/TestHelpers.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/TestHelpers.kt
@@ -5,10 +5,12 @@
 
 package org.opensearch.indexmanagement.indexstatemanagement
 
+import org.opensearch.action.admin.indices.alias.Alias
 import org.opensearch.common.unit.ByteSizeValue
 import org.opensearch.common.unit.TimeValue
 import org.opensearch.common.xcontent.ToXContent
 import org.opensearch.common.xcontent.XContentFactory
+import org.opensearch.index.RandomCreateIndexGenerator.randomAlias
 import org.opensearch.index.seqno.SequenceNumbers
 import org.opensearch.indexmanagement.indexstatemanagement.action.AllocationAction
 import org.opensearch.indexmanagement.indexstatemanagement.action.CloseAction
@@ -22,6 +24,7 @@ import org.opensearch.indexmanagement.indexstatemanagement.action.ReadWriteActio
 import org.opensearch.indexmanagement.indexstatemanagement.action.ReplicaCountAction
 import org.opensearch.indexmanagement.indexstatemanagement.action.RolloverAction
 import org.opensearch.indexmanagement.indexstatemanagement.action.RollupAction
+import org.opensearch.indexmanagement.indexstatemanagement.action.ShrinkAction
 import org.opensearch.indexmanagement.indexstatemanagement.action.SnapshotAction
 import org.opensearch.indexmanagement.indexstatemanagement.model.ChangePolicy
 import org.opensearch.indexmanagement.indexstatemanagement.model.Conditions
@@ -48,6 +51,11 @@ import org.opensearch.jobscheduler.spi.schedule.IntervalSchedule
 import org.opensearch.jobscheduler.spi.schedule.Schedule
 import org.opensearch.script.Script
 import org.opensearch.script.ScriptType
+import org.opensearch.test.OpenSearchTestCase.randomAlphaOfLength
+import org.opensearch.test.OpenSearchTestCase.randomBoolean
+import org.opensearch.test.OpenSearchTestCase.randomDoubleBetween
+import org.opensearch.test.OpenSearchTestCase.randomInt
+import org.opensearch.test.OpenSearchTestCase.randomList
 import org.opensearch.test.rest.OpenSearchRestTestCase
 import java.time.Instant
 import java.time.ZoneId
@@ -129,6 +137,24 @@ fun randomRolloverActionConfig(
         minPrimaryShardSize = minPrimaryShardSize,
         index = 0
     )
+}
+
+fun randomShrinkAction(
+    numNewShards: Int? = null,
+    maxShardSize: ByteSizeValue? = null,
+    percentageDecrease: Double? = null,
+    targetIndexSuffix: String? = if (randomBoolean()) randomAlphaOfLength(10) else null,
+    aliases: List<Alias>? = if (randomBoolean()) randomList(10) { randomAlias() } else null,
+    forceUnsafe: Boolean? = if (randomBoolean()) randomBoolean() else null
+): ShrinkAction {
+    if (numNewShards == null && maxShardSize == null && percentageDecrease == null) {
+        when (randomInt(2)) {
+            0 -> return ShrinkAction(randomInt(), null, null, targetIndexSuffix, aliases, forceUnsafe, 0)
+            1 -> return ShrinkAction(null, randomByteSizeValue(), null, targetIndexSuffix, aliases, forceUnsafe, 0)
+            2 -> return ShrinkAction(null, null, randomDoubleBetween(0.0, 1.0, true), targetIndexSuffix, aliases, forceUnsafe, 0)
+        }
+    }
+    return ShrinkAction(numNewShards, maxShardSize, percentageDecrease, targetIndexSuffix, aliases, forceUnsafe, 0)
 }
 
 fun randomReadOnlyActionConfig(): ReadOnlyAction {
@@ -374,6 +400,11 @@ fun ReadOnlyAction.toJsonString(): String {
 }
 
 fun ReadWriteAction.toJsonString(): String {
+    val builder = XContentFactory.jsonBuilder()
+    return this.toXContent(builder, ToXContent.EMPTY_PARAMS).string()
+}
+
+fun ShrinkAction.toJsonString(): String {
     val builder = XContentFactory.jsonBuilder()
     return this.toXContent(builder, ToXContent.EMPTY_PARAMS).string()
 }

--- a/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/action/ShrinkActionIT.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/action/ShrinkActionIT.kt
@@ -1,0 +1,389 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.indexmanagement.indexstatemanagement.action
+
+import org.apache.logging.log4j.LogManager
+import org.opensearch.common.settings.Settings
+import org.opensearch.common.unit.ByteSizeValue
+import org.opensearch.indexmanagement.indexstatemanagement.IndexStateManagementRestTestCase
+import org.opensearch.indexmanagement.indexstatemanagement.model.Policy
+import org.opensearch.indexmanagement.indexstatemanagement.model.State
+import org.opensearch.indexmanagement.indexstatemanagement.randomErrorNotification
+import org.opensearch.indexmanagement.indexstatemanagement.step.shrink.AttemptMoveShardsStep
+import org.opensearch.indexmanagement.indexstatemanagement.step.shrink.AttemptShrinkStep
+import org.opensearch.indexmanagement.indexstatemanagement.step.shrink.WaitForMoveShardsStep
+import org.opensearch.indexmanagement.indexstatemanagement.step.shrink.WaitForShrinkStep
+import org.opensearch.indexmanagement.spi.indexstatemanagement.Step
+import org.opensearch.indexmanagement.waitFor
+import java.time.Instant
+import java.time.temporal.ChronoUnit
+import java.util.Locale
+
+class ShrinkActionIT : IndexStateManagementRestTestCase() {
+    private val testIndexName = javaClass.simpleName.toLowerCase(Locale.ROOT)
+    fun `test basic workflow number of shards`() {
+        val logger = LogManager.getLogger(::ShrinkActionIT)
+        val indexName = "${testIndexName}_index_1"
+        val policyID = "${testIndexName}_testPolicyName_1"
+
+        // Create a Policy with one State that only preforms a force_merge Action
+        val shrinkAction = ShrinkAction(
+            numNewShards = 1,
+            maxShardSize = null,
+            percentageDecrease = null,
+            targetIndexSuffix = "_shrink_test",
+            aliases = null,
+            forceUnsafe = true,
+            index = 0
+        )
+        val states = listOf(State("ShrinkState", listOf(shrinkAction), listOf()))
+
+        val policy = Policy(
+            id = policyID,
+            description = "$testIndexName description",
+            schemaVersion = 11L,
+            lastUpdatedTime = Instant.now().truncatedTo(ChronoUnit.MILLIS),
+            errorNotification = randomErrorNotification(),
+            defaultState = states[0].name,
+            states = states
+        )
+
+        createPolicy(policy, policyID)
+        createIndex(indexName, policyID, null, "0", "3", "")
+
+        insertSampleData(indexName, 3)
+
+        // Will change the startTime each execution so that it triggers in 2 seconds
+        // First execution: Policy is initialized
+        val managedIndexConfig = getExistingManagedIndexConfig(indexName)
+
+        updateManagedIndexConfigStartTime(managedIndexConfig)
+        waitFor { assertEquals(policyID, getExplainManagedIndexMetaData(indexName).policyID) }
+        logger.info("before attempt move shards")
+        // Starts AttemptMoveShardsStep
+        updateManagedIndexConfigStartTime(managedIndexConfig)
+
+        val targetIndexName = indexName + shrinkAction.targetIndexSuffix
+        waitFor {
+            assertEquals(targetIndexName, getExplainManagedIndexMetaData(indexName).actionMetaData!!.actionProperties!!.shrinkActionProperties!!.targetIndexName)
+            assertEquals("true", getIndexBlocksWriteSetting(indexName))
+            assertNotNull("Couldn't find node to shrink onto.", getExplainManagedIndexMetaData(indexName).actionMetaData!!.actionProperties!!.shrinkActionProperties!!.nodeName)
+            val settings = getFlatSettings(indexName)
+            val nodeToShrink = getExplainManagedIndexMetaData(indexName).actionMetaData!!.actionProperties!!.shrinkActionProperties!!.nodeName
+            assertTrue(settings.containsKey("index.routing.allocation.require._name"))
+            assertEquals(nodeToShrink, settings["index.routing.allocation.require._name"])
+            assertEquals(
+                AttemptMoveShardsStep.getSuccessMessage(nodeToShrink),
+                getExplainManagedIndexMetaData(indexName).info?.get("message")
+            )
+        }
+        val nodeToShrink = getExplainManagedIndexMetaData(indexName).actionMetaData!!.actionProperties!!.shrinkActionProperties!!.nodeName
+        // starts WaitForMoveShardsStep
+        updateManagedIndexConfigStartTime(managedIndexConfig)
+        waitFor {
+            assertEquals(
+                WaitForMoveShardsStep.getSuccessMessage(nodeToShrink),
+                getExplainManagedIndexMetaData(indexName).info?.get("message")
+            )
+        }
+        // Wait for move should finish before this. Starts AttemptShrinkStep
+        updateManagedIndexConfigStartTime(managedIndexConfig)
+        val instant: Instant = Instant.ofEpochSecond(50)
+        waitFor(instant) {
+            // assertTrue("Target index is not created", indexExists(targetIndexName))
+            assertEquals(Step.StepStatus.COMPLETED, getExplainManagedIndexMetaData(indexName).stepMetaData?.stepStatus)
+            assertEquals(
+                AttemptShrinkStep.getSuccessMessage(targetIndexName),
+                getExplainManagedIndexMetaData(indexName).info?.get("message")
+            )
+        }
+
+        // starts WaitForShrinkStep
+        updateManagedIndexConfigStartTime(managedIndexConfig)
+        waitFor {
+            // one primary and one replica
+            assertTrue(getIndexShards(targetIndexName).size == 2)
+            assertEquals(
+                WaitForShrinkStep.SUCCESS_MESSAGE,
+                getExplainManagedIndexMetaData(indexName).info?.get("message")
+            )
+        }
+    }
+
+    fun `test basic workflow max shard size`() {
+        val logger = LogManager.getLogger(::ShrinkActionIT)
+        val indexName = "${testIndexName}_index_1"
+        val policyID = "${testIndexName}_testPolicyName_1"
+        val testMaxShardSize: ByteSizeValue = ByteSizeValue.parseBytesSizeValue("1GB", "test")
+        // Create a Policy with one State that only preforms a force_merge Action
+        val shrinkAction = ShrinkAction(
+            numNewShards = null,
+            maxShardSize = testMaxShardSize,
+            percentageDecrease = null,
+            targetIndexSuffix = "_shrink_test",
+            aliases = null,
+            forceUnsafe = true,
+            index = 0
+        )
+        val states = listOf(State("ShrinkState", listOf(shrinkAction), listOf()))
+
+        val policy = Policy(
+            id = policyID,
+            description = "$testIndexName description",
+            schemaVersion = 11L,
+            lastUpdatedTime = Instant.now().truncatedTo(ChronoUnit.MILLIS),
+            errorNotification = randomErrorNotification(),
+            defaultState = states[0].name,
+            states = states
+        )
+
+        createPolicy(policy, policyID)
+        createIndex(indexName, policyID, null, "0", "3", "")
+
+        insertSampleData(indexName, 3)
+
+        // Will change the startTime each execution so that it triggers in 2 seconds
+        // First execution: Policy is initialized
+        val managedIndexConfig = getExistingManagedIndexConfig(indexName)
+
+        updateManagedIndexConfigStartTime(managedIndexConfig)
+        waitFor { assertEquals(policyID, getExplainManagedIndexMetaData(indexName).policyID) }
+        logger.info("before attempt move shards")
+        // Starts AttemptMoveShardsStep
+        updateManagedIndexConfigStartTime(managedIndexConfig)
+
+        val targetIndexName = indexName + shrinkAction.targetIndexSuffix
+        waitFor {
+            assertEquals(targetIndexName, getExplainManagedIndexMetaData(indexName).actionMetaData!!.actionProperties!!.shrinkActionProperties!!.targetIndexName)
+            assertEquals("true", getIndexBlocksWriteSetting(indexName))
+            assertNotNull("Couldn't find node to shrink onto.", getExplainManagedIndexMetaData(indexName).actionMetaData!!.actionProperties!!.shrinkActionProperties!!.nodeName)
+            val settings = getFlatSettings(indexName)
+            val nodeToShrink = getExplainManagedIndexMetaData(indexName).actionMetaData!!.actionProperties!!.shrinkActionProperties!!.nodeName
+            assertTrue(settings.containsKey("index.routing.allocation.require._name"))
+            assertEquals(nodeToShrink, settings["index.routing.allocation.require._name"])
+            assertEquals(
+                AttemptMoveShardsStep.getSuccessMessage(nodeToShrink),
+                getExplainManagedIndexMetaData(indexName).info?.get("message")
+            )
+        }
+        val nodeToShrink = getExplainManagedIndexMetaData(indexName).actionMetaData!!.actionProperties!!.shrinkActionProperties!!.nodeName
+        // starts WaitForMoveShardsStep
+        updateManagedIndexConfigStartTime(managedIndexConfig)
+        waitFor {
+            assertEquals(
+                WaitForMoveShardsStep.getSuccessMessage(nodeToShrink),
+                getExplainManagedIndexMetaData(indexName).info?.get("message")
+            )
+        }
+        // Wait for move should finish before this. Starts AttemptShrinkStep
+        updateManagedIndexConfigStartTime(managedIndexConfig)
+        waitFor(Instant.ofEpochSecond(50)) {
+            assertTrue("Target index is not created", indexExists(targetIndexName))
+            assertEquals(
+                AttemptShrinkStep.getSuccessMessage(targetIndexName),
+                getExplainManagedIndexMetaData(indexName).info?.get("message")
+            )
+        }
+
+        // starts WaitForShrinkStep
+        updateManagedIndexConfigStartTime(managedIndexConfig)
+        waitFor {
+            // one primary and one replica
+            assertTrue(getIndexShards(targetIndexName).size == 2)
+            assertEquals(
+                WaitForShrinkStep.SUCCESS_MESSAGE,
+                getExplainManagedIndexMetaData(indexName).info?.get("message")
+            )
+        }
+    }
+
+    fun `test basic workflow percentage decrease`() {
+        val indexName = "${testIndexName}_index_1"
+        val policyID = "${testIndexName}_testPolicyName_1"
+        // Create a Policy with one State that only preforms a force_merge Action
+        val shrinkAction = ShrinkAction(
+            numNewShards = null,
+            maxShardSize = null,
+            percentageDecrease = 0.5,
+            targetIndexSuffix = "_shrink_test",
+            aliases = null,
+            forceUnsafe = true,
+            index = 0
+        )
+        val states = listOf(State("ShrinkState", listOf(shrinkAction), listOf()))
+
+        val policy = Policy(
+            id = policyID,
+            description = "$testIndexName description",
+            schemaVersion = 11L,
+            lastUpdatedTime = Instant.now().truncatedTo(ChronoUnit.MILLIS),
+            errorNotification = randomErrorNotification(),
+            defaultState = states[0].name,
+            states = states
+        )
+
+        createPolicy(policy, policyID)
+        createIndex(indexName, policyID, null, "0", "3", "")
+
+        insertSampleData(indexName, 3)
+
+        // Will change the startTime each execution so that it triggers in 2 seconds
+        // First execution: Policy is initialized
+        val managedIndexConfig = getExistingManagedIndexConfig(indexName)
+
+        updateManagedIndexConfigStartTime(managedIndexConfig)
+        waitFor { assertEquals(policyID, getExplainManagedIndexMetaData(indexName).policyID) }
+        // Starts AttemptMoveShardsStep
+        updateManagedIndexConfigStartTime(managedIndexConfig)
+
+        val targetIndexName = indexName + shrinkAction.targetIndexSuffix
+        waitFor {
+            assertEquals(targetIndexName, getExplainManagedIndexMetaData(indexName).actionMetaData!!.actionProperties!!.shrinkActionProperties!!.targetIndexName)
+            assertEquals("true", getIndexBlocksWriteSetting(indexName))
+            assertNotNull("Couldn't find node to shrink onto.", getExplainManagedIndexMetaData(indexName).actionMetaData!!.actionProperties!!.shrinkActionProperties!!.nodeName)
+            val settings = getFlatSettings(indexName)
+            val nodeToShrink = getExplainManagedIndexMetaData(indexName).actionMetaData!!.actionProperties!!.shrinkActionProperties!!.nodeName
+            assertTrue(settings.containsKey("index.routing.allocation.require._name"))
+            assertEquals(nodeToShrink, settings["index.routing.allocation.require._name"])
+            assertEquals(
+                AttemptMoveShardsStep.getSuccessMessage(nodeToShrink),
+                getExplainManagedIndexMetaData(indexName).info?.get("message")
+            )
+        }
+
+        val nodeToShrink = getExplainManagedIndexMetaData(indexName).actionMetaData!!.actionProperties!!.shrinkActionProperties!!.nodeName
+
+        // starts WaitForMoveShardsStep
+        updateManagedIndexConfigStartTime(managedIndexConfig)
+        waitFor {
+            assertEquals(
+                WaitForMoveShardsStep.getSuccessMessage(nodeToShrink),
+                getExplainManagedIndexMetaData(indexName).info?.get("message")
+            )
+        }
+        // Wait for move should finish before this. Starts AttemptShrinkStep
+        updateManagedIndexConfigStartTime(managedIndexConfig)
+        waitFor(Instant.ofEpochSecond(50)) {
+            assertTrue("Target index is not created", indexExists(targetIndexName))
+            assertEquals(
+                AttemptShrinkStep.getSuccessMessage(targetIndexName),
+                getExplainManagedIndexMetaData(indexName).info?.get("message")
+            )
+        }
+
+        // starts WaitForShrinkStep
+        updateManagedIndexConfigStartTime(managedIndexConfig)
+        waitFor {
+            // one primary and one replica
+            assertTrue(getIndexShards(targetIndexName).size == 2)
+            assertEquals(
+                WaitForShrinkStep.SUCCESS_MESSAGE,
+                getExplainManagedIndexMetaData(indexName).info?.get("message")
+            )
+        }
+    }
+
+    fun `test allocation block picks correct node`() {
+        val logger = LogManager.getLogger(::ShrinkActionIT)
+        val nodes = getNodes()
+        if (nodes.size > 1) {
+            val indexName = "${testIndexName}_index_1"
+            val policyID = "${testIndexName}_testPolicyName_1"
+            // Create a Policy with one State that only preforms a force_merge Action
+            val shrinkAction = ShrinkAction(
+                numNewShards = null,
+                maxShardSize = null,
+                percentageDecrease = 0.5,
+                targetIndexSuffix = "_shrink_test",
+                aliases = null,
+                forceUnsafe = true,
+                index = 0
+            )
+            val states = listOf(State("ShrinkState", listOf(shrinkAction), listOf()))
+
+            val policy = Policy(
+                id = policyID,
+                description = "$testIndexName description",
+                schemaVersion = 11L,
+                lastUpdatedTime = Instant.now().truncatedTo(ChronoUnit.MILLIS),
+                errorNotification = randomErrorNotification(),
+                defaultState = states[0].name,
+                states = states
+            )
+            createPolicy(policy, policyID)
+            createIndex(indexName, policyID, null, "0", "3", "")
+            val excludedNode = nodes.iterator().next()
+            logger.info("Excluded node: $excludedNode")
+            updateIndexSettings(
+                indexName,
+                Settings.builder().put("index.routing.allocation.exclude._name", excludedNode)
+            )
+            insertSampleData(indexName, 3)
+            // Will change the startTime each execution so that it triggers in 2 seconds
+            // First execution: Policy is initialized
+            val managedIndexConfig = getExistingManagedIndexConfig(indexName)
+            logger.info("index settings: \n ${getFlatSettings(indexName)}")
+
+            updateManagedIndexConfigStartTime(managedIndexConfig)
+            waitFor { assertEquals(policyID, getExplainManagedIndexMetaData(indexName).policyID) }
+            // Starts AttemptMoveShardsStep
+            updateManagedIndexConfigStartTime(managedIndexConfig)
+            val targetIndexName = indexName + shrinkAction.targetIndexSuffix
+            waitFor {
+                assertEquals(
+                    targetIndexName,
+                    getExplainManagedIndexMetaData(indexName).actionMetaData!!.actionProperties!!.shrinkActionProperties!!.targetIndexName
+                )
+                assertEquals("true", getIndexBlocksWriteSetting(indexName))
+                val nodeName =
+                    getExplainManagedIndexMetaData(indexName).actionMetaData!!.actionProperties!!.shrinkActionProperties!!.nodeName
+                assertNotNull("Couldn't find node to shrink onto.", nodeName)
+                assertNotEquals(nodeName, excludedNode)
+                val settings = getFlatSettings(indexName)
+                val nodeToShrink =
+                    getExplainManagedIndexMetaData(indexName).actionMetaData!!.actionProperties!!.shrinkActionProperties!!.nodeName
+                assertTrue(settings.containsKey("index.routing.allocation.require._name"))
+                assertEquals(nodeToShrink, settings["index.routing.allocation.require._name"])
+                assertEquals(
+                    AttemptMoveShardsStep.getSuccessMessage(nodeToShrink),
+                    getExplainManagedIndexMetaData(indexName).info?.get("message")
+                )
+            }
+
+            val nodeToShrink =
+                getExplainManagedIndexMetaData(indexName).actionMetaData!!.actionProperties!!.shrinkActionProperties!!.nodeName
+
+            // starts WaitForMoveShardsStep
+            updateManagedIndexConfigStartTime(managedIndexConfig)
+            waitFor {
+                assertEquals(
+                    WaitForMoveShardsStep.getSuccessMessage(nodeToShrink),
+                    getExplainManagedIndexMetaData(indexName).info?.get("message")
+                )
+            }
+            // Wait for move should finish before this. Starts AttemptShrinkStep
+            updateManagedIndexConfigStartTime(managedIndexConfig)
+            waitFor(Instant.ofEpochSecond(50)) {
+                assertTrue("Target index is not created", indexExists(targetIndexName))
+                assertEquals(
+                    AttemptShrinkStep.getSuccessMessage(targetIndexName),
+                    getExplainManagedIndexMetaData(indexName).info?.get("message")
+                )
+            }
+
+            // starts WaitForShrinkStep
+            updateManagedIndexConfigStartTime(managedIndexConfig)
+            waitFor {
+                // one primary and one replica
+                assertTrue(getIndexShards(targetIndexName).size == 2)
+                assertEquals(
+                    WaitForShrinkStep.SUCCESS_MESSAGE,
+                    getExplainManagedIndexMetaData(indexName).info?.get("message")
+                )
+            }
+        }
+    }
+}

--- a/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/action/ShrinkActionIT.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/action/ShrinkActionIT.kt
@@ -298,6 +298,7 @@ class ShrinkActionIT : IndexStateManagementRestTestCase() {
         }
     }
 
+    @Suppress("UNCHECKED_CAST")
     fun `test allocation block picks correct node`() {
         val logger = LogManager.getLogger(::ShrinkActionIT)
         val nodes = getNodes()
@@ -394,7 +395,9 @@ class ShrinkActionIT : IndexStateManagementRestTestCase() {
                     WaitForShrinkStep.SUCCESS_MESSAGE,
                     getExplainManagedIndexMetaData(indexName).info?.get("message")
                 )
-                assertEquals("Write block setting was not reset after successful shrink", "false", getIndexBlocksWriteSetting(indexName))
+                val indexSettings = getIndexSettings(indexName) as Map<String, Map<String, Map<String, Any?>>>
+                val writeBlock = indexSettings[indexName]!!["settings"]!![IndexMetadata.SETTING_BLOCKS_WRITE] as String?
+                assertNull("Write block setting was not reset after successful shrink", writeBlock)
             }
         }
     }

--- a/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/action/ShrinkActionIT.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/action/ShrinkActionIT.kt
@@ -18,11 +18,14 @@ import org.opensearch.indexmanagement.indexstatemanagement.step.shrink.WaitForMo
 import org.opensearch.indexmanagement.indexstatemanagement.step.shrink.WaitForShrinkStep
 import org.opensearch.indexmanagement.spi.indexstatemanagement.Step
 import org.opensearch.indexmanagement.waitFor
+import org.opensearch.script.Script
+import org.opensearch.script.ScriptType
 import java.time.Instant
 import java.time.temporal.ChronoUnit
 
 class ShrinkActionIT : IndexStateManagementRestTestCase() {
     private val testIndexName = javaClass.simpleName.lowercase()
+    private val testIndexSuffix = "_shrink_test"
     fun `test basic workflow number of shards`() {
         val logger = LogManager.getLogger(::ShrinkActionIT)
         val indexName = "${testIndexName}_index_1"
@@ -32,7 +35,7 @@ class ShrinkActionIT : IndexStateManagementRestTestCase() {
             numNewShards = 1,
             maxShardSize = null,
             percentageOfSourceShards = null,
-            targetIndexSuffix = "_shrink_test",
+            targetIndexTemplate = Script(ScriptType.INLINE, Script.DEFAULT_TEMPLATE_LANG, "{{ctx.index}}$testIndexSuffix", mapOf()),
             aliases = null,
             forceUnsafe = true,
             index = 0
@@ -64,7 +67,7 @@ class ShrinkActionIT : IndexStateManagementRestTestCase() {
         // Starts AttemptMoveShardsStep
         updateManagedIndexConfigStartTime(managedIndexConfig)
 
-        val targetIndexName = indexName + shrinkAction.targetIndexSuffix
+        val targetIndexName = indexName + testIndexSuffix
         waitFor(Instant.ofEpochSecond(60)) {
             assertEquals(targetIndexName, getExplainManagedIndexMetaData(indexName).actionMetaData!!.actionProperties!!.shrinkActionProperties!!.targetIndexName)
             assertEquals("true", getIndexBlocksWriteSetting(indexName))
@@ -120,7 +123,7 @@ class ShrinkActionIT : IndexStateManagementRestTestCase() {
             numNewShards = null,
             maxShardSize = testMaxShardSize,
             percentageOfSourceShards = null,
-            targetIndexSuffix = "_shrink_test",
+            targetIndexTemplate = Script(ScriptType.INLINE, Script.DEFAULT_TEMPLATE_LANG, "{{ctx.index}}$testIndexSuffix", mapOf()),
             aliases = null,
             forceUnsafe = true,
             index = 0
@@ -152,7 +155,7 @@ class ShrinkActionIT : IndexStateManagementRestTestCase() {
         // Starts AttemptMoveShardsStep
         updateManagedIndexConfigStartTime(managedIndexConfig)
 
-        val targetIndexName = indexName + shrinkAction.targetIndexSuffix
+        val targetIndexName = indexName + testIndexSuffix
         waitFor(Instant.ofEpochSecond(60)) {
             assertEquals(targetIndexName, getExplainManagedIndexMetaData(indexName).actionMetaData!!.actionProperties!!.shrinkActionProperties!!.targetIndexName)
             assertEquals("true", getIndexBlocksWriteSetting(indexName))
@@ -204,7 +207,7 @@ class ShrinkActionIT : IndexStateManagementRestTestCase() {
             numNewShards = null,
             maxShardSize = null,
             percentageOfSourceShards = 0.5,
-            targetIndexSuffix = "_shrink_test",
+            targetIndexTemplate = Script(ScriptType.INLINE, Script.DEFAULT_TEMPLATE_LANG, "{{ctx.index}}$testIndexSuffix", mapOf()),
             aliases = null,
             forceUnsafe = true,
             index = 0
@@ -235,7 +238,7 @@ class ShrinkActionIT : IndexStateManagementRestTestCase() {
         // Starts AttemptMoveShardsStep
         updateManagedIndexConfigStartTime(managedIndexConfig)
 
-        val targetIndexName = indexName + shrinkAction.targetIndexSuffix
+        val targetIndexName = indexName + testIndexSuffix
         waitFor(Instant.ofEpochSecond(60)) {
             assertEquals(targetIndexName, getExplainManagedIndexMetaData(indexName).actionMetaData!!.actionProperties!!.shrinkActionProperties!!.targetIndexName)
             assertEquals("true", getIndexBlocksWriteSetting(indexName))
@@ -292,7 +295,7 @@ class ShrinkActionIT : IndexStateManagementRestTestCase() {
                 numNewShards = null,
                 maxShardSize = null,
                 percentageOfSourceShards = 0.5,
-                targetIndexSuffix = "_shrink_test",
+                targetIndexTemplate = Script(ScriptType.INLINE, Script.DEFAULT_TEMPLATE_LANG, "{{ctx.index}}$testIndexSuffix", mapOf()),
                 aliases = null,
                 forceUnsafe = true,
                 index = 0
@@ -326,7 +329,7 @@ class ShrinkActionIT : IndexStateManagementRestTestCase() {
             waitFor(Instant.ofEpochSecond(60)) { assertEquals(policyID, getExplainManagedIndexMetaData(indexName).policyID) }
             // Starts AttemptMoveShardsStep
             updateManagedIndexConfigStartTime(managedIndexConfig)
-            val targetIndexName = indexName + shrinkAction.targetIndexSuffix
+            val targetIndexName = indexName + testIndexSuffix
             waitFor(Instant.ofEpochSecond(60)) {
                 assertEquals(
                     targetIndexName,
@@ -392,7 +395,7 @@ class ShrinkActionIT : IndexStateManagementRestTestCase() {
             numNewShards = null,
             maxShardSize = null,
             percentageOfSourceShards = 0.5,
-            targetIndexSuffix = "_shrink_test",
+            targetIndexTemplate = Script(ScriptType.INLINE, Script.DEFAULT_TEMPLATE_LANG, "{{ctx.index}}$testIndexSuffix", mapOf()),
             aliases = null,
             forceUnsafe = true,
             index = 0
@@ -444,7 +447,7 @@ class ShrinkActionIT : IndexStateManagementRestTestCase() {
         val testPolicy = """
         {"policy":{"description":"Default policy","default_state":"Shrink","states":[
         {"name":"Shrink","actions":[{"retry":{"count":2,"backoff":"constant","delay":"1s"},"shrink":
-        {"num_new_shards":1, "target_index_suffix":"_shrink_test", "force_unsafe": "true"}}],"transitions":[]}]}}
+        {"num_new_shards":1, "target_index_name_template":{"source": "{{ctx.index}}_shrink_test"}, "force_unsafe": "true"}}],"transitions":[]}]}}
         """.trimIndent()
         val logger = LogManager.getLogger(::ShrinkActionIT)
         val indexName = "${testIndexName}_retry"

--- a/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/action/ShrinkActionIT.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/action/ShrinkActionIT.kt
@@ -59,13 +59,13 @@ class ShrinkActionIT : IndexStateManagementRestTestCase() {
         val managedIndexConfig = getExistingManagedIndexConfig(indexName)
 
         updateManagedIndexConfigStartTime(managedIndexConfig)
-        waitFor { assertEquals(policyID, getExplainManagedIndexMetaData(indexName).policyID) }
+        waitFor(Instant.ofEpochSecond(60)) { assertEquals(policyID, getExplainManagedIndexMetaData(indexName).policyID) }
         logger.info("before attempt move shards")
         // Starts AttemptMoveShardsStep
         updateManagedIndexConfigStartTime(managedIndexConfig)
 
         val targetIndexName = indexName + shrinkAction.targetIndexSuffix
-        waitFor {
+        waitFor(Instant.ofEpochSecond(60)) {
             assertEquals(targetIndexName, getExplainManagedIndexMetaData(indexName).actionMetaData!!.actionProperties!!.shrinkActionProperties!!.targetIndexName)
             assertEquals("true", getIndexBlocksWriteSetting(indexName))
             assertNotNull("Couldn't find node to shrink onto.", getExplainManagedIndexMetaData(indexName).actionMetaData!!.actionProperties!!.shrinkActionProperties!!.nodeName)
@@ -81,7 +81,7 @@ class ShrinkActionIT : IndexStateManagementRestTestCase() {
         val nodeToShrink = getExplainManagedIndexMetaData(indexName).actionMetaData!!.actionProperties!!.shrinkActionProperties!!.nodeName
         // starts WaitForMoveShardsStep
         updateManagedIndexConfigStartTime(managedIndexConfig)
-        waitFor {
+        waitFor(Instant.ofEpochSecond(60)) {
             assertEquals(
                 WaitForMoveShardsStep.getSuccessMessage(nodeToShrink),
                 getExplainManagedIndexMetaData(indexName).info?.get("message")
@@ -101,7 +101,7 @@ class ShrinkActionIT : IndexStateManagementRestTestCase() {
 
         // starts WaitForShrinkStep
         updateManagedIndexConfigStartTime(managedIndexConfig)
-        waitFor {
+        waitFor(Instant.ofEpochSecond(60)) {
             // one primary and one replica
             assertTrue(getIndexShards(targetIndexName).size == 2)
             assertEquals(
@@ -147,13 +147,13 @@ class ShrinkActionIT : IndexStateManagementRestTestCase() {
         val managedIndexConfig = getExistingManagedIndexConfig(indexName)
 
         updateManagedIndexConfigStartTime(managedIndexConfig)
-        waitFor { assertEquals(policyID, getExplainManagedIndexMetaData(indexName).policyID) }
+        waitFor(Instant.ofEpochSecond(60)) { assertEquals(policyID, getExplainManagedIndexMetaData(indexName).policyID) }
         logger.info("before attempt move shards")
         // Starts AttemptMoveShardsStep
         updateManagedIndexConfigStartTime(managedIndexConfig)
 
         val targetIndexName = indexName + shrinkAction.targetIndexSuffix
-        waitFor {
+        waitFor(Instant.ofEpochSecond(60)) {
             assertEquals(targetIndexName, getExplainManagedIndexMetaData(indexName).actionMetaData!!.actionProperties!!.shrinkActionProperties!!.targetIndexName)
             assertEquals("true", getIndexBlocksWriteSetting(indexName))
             assertNotNull("Couldn't find node to shrink onto.", getExplainManagedIndexMetaData(indexName).actionMetaData!!.actionProperties!!.shrinkActionProperties!!.nodeName)
@@ -169,7 +169,7 @@ class ShrinkActionIT : IndexStateManagementRestTestCase() {
         val nodeToShrink = getExplainManagedIndexMetaData(indexName).actionMetaData!!.actionProperties!!.shrinkActionProperties!!.nodeName
         // starts WaitForMoveShardsStep
         updateManagedIndexConfigStartTime(managedIndexConfig)
-        waitFor {
+        waitFor(Instant.ofEpochSecond(60)) {
             assertEquals(
                 WaitForMoveShardsStep.getSuccessMessage(nodeToShrink),
                 getExplainManagedIndexMetaData(indexName).info?.get("message")
@@ -187,7 +187,7 @@ class ShrinkActionIT : IndexStateManagementRestTestCase() {
 
         // starts WaitForShrinkStep
         updateManagedIndexConfigStartTime(managedIndexConfig)
-        waitFor {
+        waitFor(Instant.ofEpochSecond(60)) {
             // one primary and one replica
             assertTrue(getIndexShards(targetIndexName).size == 2)
             assertEquals(
@@ -231,12 +231,12 @@ class ShrinkActionIT : IndexStateManagementRestTestCase() {
         val managedIndexConfig = getExistingManagedIndexConfig(indexName)
 
         updateManagedIndexConfigStartTime(managedIndexConfig)
-        waitFor { assertEquals(policyID, getExplainManagedIndexMetaData(indexName).policyID) }
+        waitFor(Instant.ofEpochSecond(60)) { assertEquals(policyID, getExplainManagedIndexMetaData(indexName).policyID) }
         // Starts AttemptMoveShardsStep
         updateManagedIndexConfigStartTime(managedIndexConfig)
 
         val targetIndexName = indexName + shrinkAction.targetIndexSuffix
-        waitFor {
+        waitFor(Instant.ofEpochSecond(60)) {
             assertEquals(targetIndexName, getExplainManagedIndexMetaData(indexName).actionMetaData!!.actionProperties!!.shrinkActionProperties!!.targetIndexName)
             assertEquals("true", getIndexBlocksWriteSetting(indexName))
             assertNotNull("Couldn't find node to shrink onto.", getExplainManagedIndexMetaData(indexName).actionMetaData!!.actionProperties!!.shrinkActionProperties!!.nodeName)
@@ -254,7 +254,7 @@ class ShrinkActionIT : IndexStateManagementRestTestCase() {
 
         // starts WaitForMoveShardsStep
         updateManagedIndexConfigStartTime(managedIndexConfig)
-        waitFor {
+        waitFor(Instant.ofEpochSecond(60)) {
             assertEquals(
                 WaitForMoveShardsStep.getSuccessMessage(nodeToShrink),
                 getExplainManagedIndexMetaData(indexName).info?.get("message")
@@ -272,7 +272,7 @@ class ShrinkActionIT : IndexStateManagementRestTestCase() {
 
         // starts WaitForShrinkStep
         updateManagedIndexConfigStartTime(managedIndexConfig)
-        waitFor {
+        waitFor(Instant.ofEpochSecond(60)) {
             // one primary and one replica
             assertTrue(getIndexShards(targetIndexName).size == 2)
             assertEquals(
@@ -323,11 +323,11 @@ class ShrinkActionIT : IndexStateManagementRestTestCase() {
             logger.info("index settings: \n ${getFlatSettings(indexName)}")
 
             updateManagedIndexConfigStartTime(managedIndexConfig)
-            waitFor { assertEquals(policyID, getExplainManagedIndexMetaData(indexName).policyID) }
+            waitFor(Instant.ofEpochSecond(60)) { assertEquals(policyID, getExplainManagedIndexMetaData(indexName).policyID) }
             // Starts AttemptMoveShardsStep
             updateManagedIndexConfigStartTime(managedIndexConfig)
             val targetIndexName = indexName + shrinkAction.targetIndexSuffix
-            waitFor {
+            waitFor(Instant.ofEpochSecond(60)) {
                 assertEquals(
                     targetIndexName,
                     getExplainManagedIndexMetaData(indexName).actionMetaData!!.actionProperties!!.shrinkActionProperties!!.targetIndexName
@@ -353,7 +353,7 @@ class ShrinkActionIT : IndexStateManagementRestTestCase() {
 
             // starts WaitForMoveShardsStep
             updateManagedIndexConfigStartTime(managedIndexConfig)
-            waitFor {
+            waitFor(Instant.ofEpochSecond(60)) {
                 assertEquals(
                     WaitForMoveShardsStep.getSuccessMessage(nodeToShrink),
                     getExplainManagedIndexMetaData(indexName).info?.get("message")
@@ -371,7 +371,7 @@ class ShrinkActionIT : IndexStateManagementRestTestCase() {
 
             // starts WaitForShrinkStep
             updateManagedIndexConfigStartTime(managedIndexConfig)
-            waitFor {
+            waitFor(Instant.ofEpochSecond(60)) {
                 // one primary and one replica
                 assertTrue(getIndexShards(targetIndexName).size == 2)
                 assertEquals(
@@ -419,13 +419,13 @@ class ShrinkActionIT : IndexStateManagementRestTestCase() {
         val managedIndexConfig = getExistingManagedIndexConfig(indexName)
 
         updateManagedIndexConfigStartTime(managedIndexConfig)
-        waitFor { assertEquals(policyID, getExplainManagedIndexMetaData(indexName).policyID) }
+        waitFor(Instant.ofEpochSecond(60)) { assertEquals(policyID, getExplainManagedIndexMetaData(indexName).policyID) }
         logger.info("before attempt move shards")
         // Starts AttemptMoveShardsStep
         updateManagedIndexConfigStartTime(managedIndexConfig)
 
         // The action should be done after the no-op
-        waitFor {
+        waitFor(Instant.ofEpochSecond(60)) {
             val metadata = getExplainManagedIndexMetaData(indexName)
             assertEquals(
                 "Did not get the no-op due to single primary shard message",
@@ -458,13 +458,13 @@ class ShrinkActionIT : IndexStateManagementRestTestCase() {
         // First execution: Policy is initialized
         val managedIndexConfig = getExistingManagedIndexConfig(indexName)
         updateManagedIndexConfigStartTime(managedIndexConfig)
-        waitFor { assertEquals(policyID, getExplainManagedIndexMetaData(indexName).policyID) }
+        waitFor(Instant.ofEpochSecond(60)) { assertEquals(policyID, getExplainManagedIndexMetaData(indexName).policyID) }
         logger.info("before attempt move shards")
         // Starts AttemptMoveShardsStep
         updateManagedIndexConfigStartTime(managedIndexConfig)
 
         val targetIndexName = indexName + "_shrink_test"
-        waitFor {
+        waitFor(Instant.ofEpochSecond(60)) {
             assertEquals(targetIndexName, getExplainManagedIndexMetaData(indexName).actionMetaData!!.actionProperties!!.shrinkActionProperties!!.targetIndexName)
             assertNotNull("Couldn't find node to shrink onto.", getExplainManagedIndexMetaData(indexName).actionMetaData!!.actionProperties!!.shrinkActionProperties!!.nodeName)
             val settings = getFlatSettings(indexName)
@@ -480,7 +480,7 @@ class ShrinkActionIT : IndexStateManagementRestTestCase() {
         val nodeToShrink = getExplainManagedIndexMetaData(indexName).actionMetaData!!.actionProperties!!.shrinkActionProperties!!.nodeName
         // starts WaitForMoveShardsStep
         updateManagedIndexConfigStartTime(managedIndexConfig)
-        waitFor {
+        waitFor(Instant.ofEpochSecond(60)) {
             assertEquals(
                 WaitForMoveShardsStep.getSuccessMessage(nodeToShrink),
                 getExplainManagedIndexMetaData(indexName).info?.get("message")
@@ -491,7 +491,7 @@ class ShrinkActionIT : IndexStateManagementRestTestCase() {
 
         // Wait for move should finish before this. Starts AttemptShrinkStep
         updateManagedIndexConfigStartTime(managedIndexConfig)
-        waitFor(Instant.ofEpochSecond(50)) {
+        waitFor(Instant.ofEpochSecond(60)) {
             val stepMetadata = getExplainManagedIndexMetaData(indexName).stepMetaData
             assertEquals("Did not fail due to target index existing step as expected", Step.StepStatus.FAILED, stepMetadata?.stepStatus)
             assertEquals(AttemptShrinkStep.name, stepMetadata?.name)
@@ -504,11 +504,14 @@ class ShrinkActionIT : IndexStateManagementRestTestCase() {
             )
         }
 
+        // wait 5 seconds for the timeout from the retry to pass
+        Thread.sleep(5000L)
+
         // Delete that index so it can pass
         deleteIndex(targetIndexName)
 
         updateManagedIndexConfigStartTime(managedIndexConfig)
-        waitFor {
+        waitFor(Instant.ofEpochSecond(60)) {
             val stepMetadata = getExplainManagedIndexMetaData(indexName).stepMetaData
             assertEquals("Shrink action should have started over after failing", stepMetadata?.name, AttemptMoveShardsStep.name)
             // The step status should be starting, but in the same execution will be completed. Allowing either to avoid flaky failures

--- a/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/model/ActionTests.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/model/ActionTests.kt
@@ -183,10 +183,6 @@ class ActionTests : OpenSearchTestCase() {
         assertEquals("Free bytes threshold not being calculated correctly for byte setting.", thresholdBytes, byteValue.bytes)
     }
 
-    fun `test for fun`() {
-        println(0x80000000)
-    }
-
     private fun roundTripAction(expectedAction: Action) {
         val baos = ByteArrayOutputStream()
         val osso = OutputStreamStreamOutput(baos)

--- a/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/model/ActionTests.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/model/ActionTests.kt
@@ -30,6 +30,7 @@ import org.opensearch.indexmanagement.indexstatemanagement.randomReadWriteAction
 import org.opensearch.indexmanagement.indexstatemanagement.randomReplicaCountActionConfig
 import org.opensearch.indexmanagement.indexstatemanagement.randomRolloverActionConfig
 import org.opensearch.indexmanagement.indexstatemanagement.randomRollupActionConfig
+import org.opensearch.indexmanagement.indexstatemanagement.randomShrinkAction
 import org.opensearch.indexmanagement.indexstatemanagement.randomSnapshotActionConfig
 import org.opensearch.indexmanagement.indexstatemanagement.randomTimeValueObject
 import org.opensearch.indexmanagement.indexstatemanagement.util.getFreeBytesThresholdHigh
@@ -72,6 +73,12 @@ class ActionTests : OpenSearchTestCase() {
     fun `test force merge action max num segments of zero fails`() {
         assertFailsWith(IllegalArgumentException::class, "Expected IllegalArgumentException for maxNumSegments less than 1") {
             randomForceMergeActionConfig(maxNumSegments = 0)
+        }
+    }
+
+    fun `test shrink action multiple shard options fails`() {
+        assertFailsWith(IllegalArgumentException::class, "Expected IllegalArgumentException for multiple shard options used") {
+            randomShrinkAction(3, randomByteSizeValue(), .30)
         }
     }
 
@@ -138,6 +145,10 @@ class ActionTests : OpenSearchTestCase() {
 
     fun `test delete action round trip`() {
         roundTripAction(randomDeleteActionConfig())
+    }
+
+    fun `test shrink action round trip`() {
+        roundTripAction(randomShrinkAction())
     }
 
     fun `test action timeout and retry round trip`() {

--- a/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/model/XContentTests.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/model/XContentTests.kt
@@ -28,6 +28,7 @@ import org.opensearch.indexmanagement.indexstatemanagement.randomReadWriteAction
 import org.opensearch.indexmanagement.indexstatemanagement.randomReplicaCountActionConfig
 import org.opensearch.indexmanagement.indexstatemanagement.randomRolloverActionConfig
 import org.opensearch.indexmanagement.indexstatemanagement.randomRollupActionConfig
+import org.opensearch.indexmanagement.indexstatemanagement.randomShrinkAction
 import org.opensearch.indexmanagement.indexstatemanagement.randomSnapshotActionConfig
 import org.opensearch.indexmanagement.indexstatemanagement.randomState
 import org.opensearch.indexmanagement.indexstatemanagement.randomTransition
@@ -221,6 +222,14 @@ class XContentTests : OpenSearchTestCase() {
         val parsedOpenAction = ISMActionsParser.instance.parse(parser(openActionString), 0)
 
         assertEquals("Round tripping OpenAction doesn't work", openAction.convertToMap(), parsedOpenAction.convertToMap())
+    }
+
+    fun `test shrink action parsing`() {
+        val shrinkAction = randomShrinkAction()
+        val shrinkActionString = shrinkAction.toJsonString()
+        val parsedShrinkAction = ISMActionsParser.instance.parse(parser(shrinkActionString), 0)
+
+        assertEquals("Round tripping ShrinkAction doesn't work", shrinkAction.convertToMap(), parsedShrinkAction.convertToMap())
     }
 
     fun `test managed index metadata parsing`() {

--- a/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/AttemptCloseStepTests.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/AttemptCloseStepTests.kt
@@ -22,7 +22,7 @@ import org.opensearch.indexmanagement.indexstatemanagement.step.close.AttemptClo
 import org.opensearch.indexmanagement.spi.indexstatemanagement.Step
 import org.opensearch.indexmanagement.spi.indexstatemanagement.model.ManagedIndexMetaData
 import org.opensearch.indexmanagement.spi.indexstatemanagement.model.StepContext
-import org.opensearch.jobscheduler.spi.JobExecutionContext
+import org.opensearch.jobscheduler.spi.utils.LockService
 import org.opensearch.script.ScriptService
 import org.opensearch.snapshots.SnapshotInProgressException
 import org.opensearch.test.OpenSearchTestCase
@@ -34,7 +34,7 @@ class AttemptCloseStepTests : OpenSearchTestCase() {
     private val clusterService: ClusterService = mock()
     private val scriptService: ScriptService = mock()
     private val settings: Settings = Settings.EMPTY
-    private val jobContext: JobExecutionContext = mock()
+    private val lockService: LockService = mock()
 
     fun `test close step sets step status to completed when successful`() {
         val closeIndexResponse = CloseIndexResponse(true, true, listOf())
@@ -43,7 +43,7 @@ class AttemptCloseStepTests : OpenSearchTestCase() {
         runBlocking {
             val managedIndexMetaData = ManagedIndexMetaData("test", "indexUuid", "policy_id", null, null, null, null, null, null, null, null, null, null, null)
             val attemptCloseStep = AttemptCloseStep()
-            val context = StepContext(managedIndexMetaData, clusterService, client, null, null, scriptService, settings, jobContext)
+            val context = StepContext(managedIndexMetaData, clusterService, client, null, null, scriptService, settings, lockService)
             attemptCloseStep.preExecute(logger, context).execute()
             val updatedManagedIndexMetaData = attemptCloseStep.getUpdatedManagedIndexMetadata(managedIndexMetaData)
             assertEquals("Step status is not COMPLETED", Step.StepStatus.COMPLETED, updatedManagedIndexMetaData.stepMetaData?.stepStatus)
@@ -57,7 +57,7 @@ class AttemptCloseStepTests : OpenSearchTestCase() {
         runBlocking {
             val managedIndexMetaData = ManagedIndexMetaData("test", "indexUuid", "policy_id", null, null, null, null, null, null, null, null, null, null, null)
             val attemptCloseStep = AttemptCloseStep()
-            val context = StepContext(managedIndexMetaData, clusterService, client, null, null, scriptService, settings, jobContext)
+            val context = StepContext(managedIndexMetaData, clusterService, client, null, null, scriptService, settings, lockService)
             attemptCloseStep.preExecute(logger, context).execute()
             val updatedManagedIndexMetaData = attemptCloseStep.getUpdatedManagedIndexMetadata(managedIndexMetaData)
             assertEquals("Step status is not FAILED", Step.StepStatus.FAILED, updatedManagedIndexMetaData.stepMetaData?.stepStatus)
@@ -71,7 +71,7 @@ class AttemptCloseStepTests : OpenSearchTestCase() {
         runBlocking {
             val managedIndexMetaData = ManagedIndexMetaData("test", "indexUuid", "policy_id", null, null, null, null, null, null, null, null, null, null, null)
             val attemptCloseStep = AttemptCloseStep()
-            val context = StepContext(managedIndexMetaData, clusterService, client, null, null, scriptService, settings, jobContext)
+            val context = StepContext(managedIndexMetaData, clusterService, client, null, null, scriptService, settings, lockService)
             attemptCloseStep.preExecute(logger, context).execute()
             val updatedManagedIndexMetaData = attemptCloseStep.getUpdatedManagedIndexMetadata(managedIndexMetaData)
             assertEquals("Step status is not FAILED", Step.StepStatus.FAILED, updatedManagedIndexMetaData.stepMetaData?.stepStatus)
@@ -85,7 +85,7 @@ class AttemptCloseStepTests : OpenSearchTestCase() {
         runBlocking {
             val managedIndexMetaData = ManagedIndexMetaData("test", "indexUuid", "policy_id", null, null, null, null, null, null, null, null, null, null, null)
             val attemptCloseStep = AttemptCloseStep()
-            val context = StepContext(managedIndexMetaData, clusterService, client, null, null, scriptService, settings, jobContext)
+            val context = StepContext(managedIndexMetaData, clusterService, client, null, null, scriptService, settings, lockService)
             attemptCloseStep.preExecute(logger, context).execute()
             val updatedManagedIndexMetaData = attemptCloseStep.getUpdatedManagedIndexMetadata(managedIndexMetaData)
             assertEquals("Step status is not CONDITION_NOT_MET", Step.StepStatus.CONDITION_NOT_MET, updatedManagedIndexMetaData.stepMetaData?.stepStatus)
@@ -99,7 +99,7 @@ class AttemptCloseStepTests : OpenSearchTestCase() {
         runBlocking {
             val managedIndexMetaData = ManagedIndexMetaData("test", "indexUuid", "policy_id", null, null, null, null, null, null, null, null, null, null, null)
             val attemptCloseStep = AttemptCloseStep()
-            val context = StepContext(managedIndexMetaData, clusterService, client, null, null, scriptService, settings, jobContext)
+            val context = StepContext(managedIndexMetaData, clusterService, client, null, null, scriptService, settings, lockService)
             attemptCloseStep.preExecute(logger, context).execute()
             val updatedManagedIndexMetaData = attemptCloseStep.getUpdatedManagedIndexMetadata(managedIndexMetaData)
             assertEquals("Step status is not CONDITION_NOT_MET", Step.StepStatus.CONDITION_NOT_MET, updatedManagedIndexMetaData.stepMetaData?.stepStatus)
@@ -113,7 +113,7 @@ class AttemptCloseStepTests : OpenSearchTestCase() {
         runBlocking {
             val managedIndexMetaData = ManagedIndexMetaData("test", "indexUuid", "policy_id", null, null, null, null, null, null, null, null, null, null, null)
             val attemptCloseStep = AttemptCloseStep()
-            val context = StepContext(managedIndexMetaData, clusterService, client, null, null, scriptService, settings, jobContext)
+            val context = StepContext(managedIndexMetaData, clusterService, client, null, null, scriptService, settings, lockService)
             attemptCloseStep.preExecute(logger, context).execute()
             val updatedManagedIndexMetaData = attemptCloseStep.getUpdatedManagedIndexMetadata(managedIndexMetaData)
             assertEquals("Step status is not FAILED", Step.StepStatus.FAILED, updatedManagedIndexMetaData.stepMetaData?.stepStatus)

--- a/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/AttemptCloseStepTests.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/AttemptCloseStepTests.kt
@@ -22,6 +22,7 @@ import org.opensearch.indexmanagement.indexstatemanagement.step.close.AttemptClo
 import org.opensearch.indexmanagement.spi.indexstatemanagement.Step
 import org.opensearch.indexmanagement.spi.indexstatemanagement.model.ManagedIndexMetaData
 import org.opensearch.indexmanagement.spi.indexstatemanagement.model.StepContext
+import org.opensearch.jobscheduler.spi.JobExecutionContext
 import org.opensearch.script.ScriptService
 import org.opensearch.snapshots.SnapshotInProgressException
 import org.opensearch.test.OpenSearchTestCase
@@ -33,6 +34,7 @@ class AttemptCloseStepTests : OpenSearchTestCase() {
     private val clusterService: ClusterService = mock()
     private val scriptService: ScriptService = mock()
     private val settings: Settings = Settings.EMPTY
+    private val jobContext: JobExecutionContext = mock()
 
     fun `test close step sets step status to completed when successful`() {
         val closeIndexResponse = CloseIndexResponse(true, true, listOf())
@@ -41,7 +43,7 @@ class AttemptCloseStepTests : OpenSearchTestCase() {
         runBlocking {
             val managedIndexMetaData = ManagedIndexMetaData("test", "indexUuid", "policy_id", null, null, null, null, null, null, null, null, null, null, null)
             val attemptCloseStep = AttemptCloseStep()
-            val context = StepContext(managedIndexMetaData, clusterService, client, null, null, scriptService, settings)
+            val context = StepContext(managedIndexMetaData, clusterService, client, null, null, scriptService, settings, jobContext)
             attemptCloseStep.preExecute(logger, context).execute()
             val updatedManagedIndexMetaData = attemptCloseStep.getUpdatedManagedIndexMetadata(managedIndexMetaData)
             assertEquals("Step status is not COMPLETED", Step.StepStatus.COMPLETED, updatedManagedIndexMetaData.stepMetaData?.stepStatus)
@@ -55,7 +57,7 @@ class AttemptCloseStepTests : OpenSearchTestCase() {
         runBlocking {
             val managedIndexMetaData = ManagedIndexMetaData("test", "indexUuid", "policy_id", null, null, null, null, null, null, null, null, null, null, null)
             val attemptCloseStep = AttemptCloseStep()
-            val context = StepContext(managedIndexMetaData, clusterService, client, null, null, scriptService, settings)
+            val context = StepContext(managedIndexMetaData, clusterService, client, null, null, scriptService, settings, jobContext)
             attemptCloseStep.preExecute(logger, context).execute()
             val updatedManagedIndexMetaData = attemptCloseStep.getUpdatedManagedIndexMetadata(managedIndexMetaData)
             assertEquals("Step status is not FAILED", Step.StepStatus.FAILED, updatedManagedIndexMetaData.stepMetaData?.stepStatus)
@@ -69,7 +71,7 @@ class AttemptCloseStepTests : OpenSearchTestCase() {
         runBlocking {
             val managedIndexMetaData = ManagedIndexMetaData("test", "indexUuid", "policy_id", null, null, null, null, null, null, null, null, null, null, null)
             val attemptCloseStep = AttemptCloseStep()
-            val context = StepContext(managedIndexMetaData, clusterService, client, null, null, scriptService, settings)
+            val context = StepContext(managedIndexMetaData, clusterService, client, null, null, scriptService, settings, jobContext)
             attemptCloseStep.preExecute(logger, context).execute()
             val updatedManagedIndexMetaData = attemptCloseStep.getUpdatedManagedIndexMetadata(managedIndexMetaData)
             assertEquals("Step status is not FAILED", Step.StepStatus.FAILED, updatedManagedIndexMetaData.stepMetaData?.stepStatus)
@@ -83,7 +85,7 @@ class AttemptCloseStepTests : OpenSearchTestCase() {
         runBlocking {
             val managedIndexMetaData = ManagedIndexMetaData("test", "indexUuid", "policy_id", null, null, null, null, null, null, null, null, null, null, null)
             val attemptCloseStep = AttemptCloseStep()
-            val context = StepContext(managedIndexMetaData, clusterService, client, null, null, scriptService, settings)
+            val context = StepContext(managedIndexMetaData, clusterService, client, null, null, scriptService, settings, jobContext)
             attemptCloseStep.preExecute(logger, context).execute()
             val updatedManagedIndexMetaData = attemptCloseStep.getUpdatedManagedIndexMetadata(managedIndexMetaData)
             assertEquals("Step status is not CONDITION_NOT_MET", Step.StepStatus.CONDITION_NOT_MET, updatedManagedIndexMetaData.stepMetaData?.stepStatus)
@@ -97,7 +99,7 @@ class AttemptCloseStepTests : OpenSearchTestCase() {
         runBlocking {
             val managedIndexMetaData = ManagedIndexMetaData("test", "indexUuid", "policy_id", null, null, null, null, null, null, null, null, null, null, null)
             val attemptCloseStep = AttemptCloseStep()
-            val context = StepContext(managedIndexMetaData, clusterService, client, null, null, scriptService, settings)
+            val context = StepContext(managedIndexMetaData, clusterService, client, null, null, scriptService, settings, jobContext)
             attemptCloseStep.preExecute(logger, context).execute()
             val updatedManagedIndexMetaData = attemptCloseStep.getUpdatedManagedIndexMetadata(managedIndexMetaData)
             assertEquals("Step status is not CONDITION_NOT_MET", Step.StepStatus.CONDITION_NOT_MET, updatedManagedIndexMetaData.stepMetaData?.stepStatus)
@@ -111,7 +113,7 @@ class AttemptCloseStepTests : OpenSearchTestCase() {
         runBlocking {
             val managedIndexMetaData = ManagedIndexMetaData("test", "indexUuid", "policy_id", null, null, null, null, null, null, null, null, null, null, null)
             val attemptCloseStep = AttemptCloseStep()
-            val context = StepContext(managedIndexMetaData, clusterService, client, null, null, scriptService, settings)
+            val context = StepContext(managedIndexMetaData, clusterService, client, null, null, scriptService, settings, jobContext)
             attemptCloseStep.preExecute(logger, context).execute()
             val updatedManagedIndexMetaData = attemptCloseStep.getUpdatedManagedIndexMetadata(managedIndexMetaData)
             assertEquals("Step status is not FAILED", Step.StepStatus.FAILED, updatedManagedIndexMetaData.stepMetaData?.stepStatus)

--- a/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/AttemptCloseStepTests.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/AttemptCloseStepTests.kt
@@ -34,7 +34,7 @@ class AttemptCloseStepTests : OpenSearchTestCase() {
     private val clusterService: ClusterService = mock()
     private val scriptService: ScriptService = mock()
     private val settings: Settings = Settings.EMPTY
-    private val lockService: LockService = mock()
+    private val lockService: LockService = LockService(mock(), clusterService)
 
     fun `test close step sets step status to completed when successful`() {
         val closeIndexResponse = CloseIndexResponse(true, true, listOf())

--- a/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/AttemptDeleteStepTests.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/AttemptDeleteStepTests.kt
@@ -22,7 +22,7 @@ import org.opensearch.indexmanagement.indexstatemanagement.step.delete.AttemptDe
 import org.opensearch.indexmanagement.spi.indexstatemanagement.Step
 import org.opensearch.indexmanagement.spi.indexstatemanagement.model.ManagedIndexMetaData
 import org.opensearch.indexmanagement.spi.indexstatemanagement.model.StepContext
-import org.opensearch.jobscheduler.spi.JobExecutionContext
+import org.opensearch.jobscheduler.spi.utils.LockService
 import org.opensearch.script.ScriptService
 import org.opensearch.snapshots.SnapshotInProgressException
 import org.opensearch.test.OpenSearchTestCase
@@ -32,7 +32,7 @@ class AttemptDeleteStepTests : OpenSearchTestCase() {
     private val clusterService: ClusterService = mock()
     private val scriptService: ScriptService = mock()
     private val settings: Settings = Settings.EMPTY
-    private val jobContext: JobExecutionContext = mock()
+    private val lockService: LockService = mock()
 
     fun `test delete step sets step status to completed when successful`() {
         val acknowledgedResponse = AcknowledgedResponse(true)
@@ -41,7 +41,7 @@ class AttemptDeleteStepTests : OpenSearchTestCase() {
         runBlocking {
             val managedIndexMetaData = ManagedIndexMetaData("test", "indexUuid", "policy_id", null, null, null, null, null, null, null, null, null, null, null)
             val attemptDeleteStep = AttemptDeleteStep()
-            val context = StepContext(managedIndexMetaData, clusterService, client, null, null, scriptService, settings, jobContext)
+            val context = StepContext(managedIndexMetaData, clusterService, client, null, null, scriptService, settings, lockService)
             attemptDeleteStep.preExecute(logger, context).execute()
             val updatedManagedIndexMetaData = attemptDeleteStep.getUpdatedManagedIndexMetadata(managedIndexMetaData)
             assertEquals("Step status is not COMPLETED", Step.StepStatus.COMPLETED, updatedManagedIndexMetaData.stepMetaData?.stepStatus)
@@ -55,7 +55,7 @@ class AttemptDeleteStepTests : OpenSearchTestCase() {
         runBlocking {
             val managedIndexMetaData = ManagedIndexMetaData("test", "indexUuid", "policy_id", null, null, null, null, null, null, null, null, null, null, null)
             val attemptDeleteStep = AttemptDeleteStep()
-            val context = StepContext(managedIndexMetaData, clusterService, client, null, null, scriptService, settings, jobContext)
+            val context = StepContext(managedIndexMetaData, clusterService, client, null, null, scriptService, settings, lockService)
             attemptDeleteStep.preExecute(logger, context).execute()
             val updatedManagedIndexMetaData = attemptDeleteStep.getUpdatedManagedIndexMetadata(managedIndexMetaData)
             assertEquals("Step status is not FAILED", Step.StepStatus.FAILED, updatedManagedIndexMetaData.stepMetaData?.stepStatus)
@@ -69,7 +69,7 @@ class AttemptDeleteStepTests : OpenSearchTestCase() {
         runBlocking {
             val managedIndexMetaData = ManagedIndexMetaData("test", "indexUuid", "policy_id", null, null, null, null, null, null, null, null, null, null, null)
             val attemptDeleteStep = AttemptDeleteStep()
-            val context = StepContext(managedIndexMetaData, clusterService, client, null, null, scriptService, settings, jobContext)
+            val context = StepContext(managedIndexMetaData, clusterService, client, null, null, scriptService, settings, lockService)
             attemptDeleteStep.preExecute(logger, context).execute()
             val updatedManagedIndexMetaData = attemptDeleteStep.getUpdatedManagedIndexMetadata(managedIndexMetaData)
             logger.info(updatedManagedIndexMetaData)
@@ -84,7 +84,7 @@ class AttemptDeleteStepTests : OpenSearchTestCase() {
         runBlocking {
             val managedIndexMetaData = ManagedIndexMetaData("test", "indexUuid", "policy_id", null, null, null, null, null, null, null, null, null, null, null)
             val attemptDeleteStep = AttemptDeleteStep()
-            val context = StepContext(managedIndexMetaData, clusterService, client, null, null, scriptService, settings, jobContext)
+            val context = StepContext(managedIndexMetaData, clusterService, client, null, null, scriptService, settings, lockService)
             attemptDeleteStep.preExecute(logger, context).execute()
             val updatedManagedIndexMetaData = attemptDeleteStep.getUpdatedManagedIndexMetadata(managedIndexMetaData)
             assertEquals("Step status is not CONDITION_NOT_MET", Step.StepStatus.CONDITION_NOT_MET, updatedManagedIndexMetaData.stepMetaData?.stepStatus)

--- a/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/AttemptDeleteStepTests.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/AttemptDeleteStepTests.kt
@@ -32,7 +32,7 @@ class AttemptDeleteStepTests : OpenSearchTestCase() {
     private val clusterService: ClusterService = mock()
     private val scriptService: ScriptService = mock()
     private val settings: Settings = Settings.EMPTY
-    private val lockService: LockService = mock()
+    private val lockService: LockService = LockService(mock(), clusterService)
 
     fun `test delete step sets step status to completed when successful`() {
         val acknowledgedResponse = AcknowledgedResponse(true)

--- a/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/AttemptDeleteStepTests.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/AttemptDeleteStepTests.kt
@@ -22,6 +22,7 @@ import org.opensearch.indexmanagement.indexstatemanagement.step.delete.AttemptDe
 import org.opensearch.indexmanagement.spi.indexstatemanagement.Step
 import org.opensearch.indexmanagement.spi.indexstatemanagement.model.ManagedIndexMetaData
 import org.opensearch.indexmanagement.spi.indexstatemanagement.model.StepContext
+import org.opensearch.jobscheduler.spi.JobExecutionContext
 import org.opensearch.script.ScriptService
 import org.opensearch.snapshots.SnapshotInProgressException
 import org.opensearch.test.OpenSearchTestCase
@@ -31,6 +32,7 @@ class AttemptDeleteStepTests : OpenSearchTestCase() {
     private val clusterService: ClusterService = mock()
     private val scriptService: ScriptService = mock()
     private val settings: Settings = Settings.EMPTY
+    private val jobContext: JobExecutionContext = mock()
 
     fun `test delete step sets step status to completed when successful`() {
         val acknowledgedResponse = AcknowledgedResponse(true)
@@ -39,7 +41,7 @@ class AttemptDeleteStepTests : OpenSearchTestCase() {
         runBlocking {
             val managedIndexMetaData = ManagedIndexMetaData("test", "indexUuid", "policy_id", null, null, null, null, null, null, null, null, null, null, null)
             val attemptDeleteStep = AttemptDeleteStep()
-            val context = StepContext(managedIndexMetaData, clusterService, client, null, null, scriptService, settings)
+            val context = StepContext(managedIndexMetaData, clusterService, client, null, null, scriptService, settings, jobContext)
             attemptDeleteStep.preExecute(logger, context).execute()
             val updatedManagedIndexMetaData = attemptDeleteStep.getUpdatedManagedIndexMetadata(managedIndexMetaData)
             assertEquals("Step status is not COMPLETED", Step.StepStatus.COMPLETED, updatedManagedIndexMetaData.stepMetaData?.stepStatus)
@@ -53,7 +55,7 @@ class AttemptDeleteStepTests : OpenSearchTestCase() {
         runBlocking {
             val managedIndexMetaData = ManagedIndexMetaData("test", "indexUuid", "policy_id", null, null, null, null, null, null, null, null, null, null, null)
             val attemptDeleteStep = AttemptDeleteStep()
-            val context = StepContext(managedIndexMetaData, clusterService, client, null, null, scriptService, settings)
+            val context = StepContext(managedIndexMetaData, clusterService, client, null, null, scriptService, settings, jobContext)
             attemptDeleteStep.preExecute(logger, context).execute()
             val updatedManagedIndexMetaData = attemptDeleteStep.getUpdatedManagedIndexMetadata(managedIndexMetaData)
             assertEquals("Step status is not FAILED", Step.StepStatus.FAILED, updatedManagedIndexMetaData.stepMetaData?.stepStatus)
@@ -67,7 +69,7 @@ class AttemptDeleteStepTests : OpenSearchTestCase() {
         runBlocking {
             val managedIndexMetaData = ManagedIndexMetaData("test", "indexUuid", "policy_id", null, null, null, null, null, null, null, null, null, null, null)
             val attemptDeleteStep = AttemptDeleteStep()
-            val context = StepContext(managedIndexMetaData, clusterService, client, null, null, scriptService, settings)
+            val context = StepContext(managedIndexMetaData, clusterService, client, null, null, scriptService, settings, jobContext)
             attemptDeleteStep.preExecute(logger, context).execute()
             val updatedManagedIndexMetaData = attemptDeleteStep.getUpdatedManagedIndexMetadata(managedIndexMetaData)
             logger.info(updatedManagedIndexMetaData)
@@ -82,7 +84,7 @@ class AttemptDeleteStepTests : OpenSearchTestCase() {
         runBlocking {
             val managedIndexMetaData = ManagedIndexMetaData("test", "indexUuid", "policy_id", null, null, null, null, null, null, null, null, null, null, null)
             val attemptDeleteStep = AttemptDeleteStep()
-            val context = StepContext(managedIndexMetaData, clusterService, client, null, null, scriptService, settings)
+            val context = StepContext(managedIndexMetaData, clusterService, client, null, null, scriptService, settings, jobContext)
             attemptDeleteStep.preExecute(logger, context).execute()
             val updatedManagedIndexMetaData = attemptDeleteStep.getUpdatedManagedIndexMetadata(managedIndexMetaData)
             assertEquals("Step status is not CONDITION_NOT_MET", Step.StepStatus.CONDITION_NOT_MET, updatedManagedIndexMetaData.stepMetaData?.stepStatus)

--- a/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/AttemptOpenStepTests.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/AttemptOpenStepTests.kt
@@ -22,7 +22,7 @@ import org.opensearch.indexmanagement.indexstatemanagement.step.open.AttemptOpen
 import org.opensearch.indexmanagement.spi.indexstatemanagement.Step
 import org.opensearch.indexmanagement.spi.indexstatemanagement.model.ManagedIndexMetaData
 import org.opensearch.indexmanagement.spi.indexstatemanagement.model.StepContext
-import org.opensearch.jobscheduler.spi.JobExecutionContext
+import org.opensearch.jobscheduler.spi.utils.LockService
 import org.opensearch.script.ScriptService
 import org.opensearch.test.OpenSearchTestCase
 import org.opensearch.transport.RemoteTransportException
@@ -32,7 +32,7 @@ class AttemptOpenStepTests : OpenSearchTestCase() {
     private val clusterService: ClusterService = mock()
     private val scriptService: ScriptService = mock()
     private val settings: Settings = Settings.EMPTY
-    private val jobContext: JobExecutionContext = mock()
+    private val lockService: LockService = mock()
 
     fun `test open step sets step status to failed when not acknowledged`() {
         val openIndexResponse = OpenIndexResponse(false, false)
@@ -41,7 +41,7 @@ class AttemptOpenStepTests : OpenSearchTestCase() {
         runBlocking {
             val managedIndexMetaData = ManagedIndexMetaData("test", "indexUuid", "policy_id", null, null, null, null, null, null, null, null, null, null, null)
             val attemptOpenStep = AttemptOpenStep()
-            val context = StepContext(managedIndexMetaData, clusterService, client, null, null, scriptService, settings, jobContext)
+            val context = StepContext(managedIndexMetaData, clusterService, client, null, null, scriptService, settings, lockService)
             attemptOpenStep.preExecute(logger, context).execute()
             val updatedManagedIndexMetaData = attemptOpenStep.getUpdatedManagedIndexMetadata(managedIndexMetaData)
             assertEquals("Step status is not FAILED", Step.StepStatus.FAILED, updatedManagedIndexMetaData.stepMetaData?.stepStatus)
@@ -55,7 +55,7 @@ class AttemptOpenStepTests : OpenSearchTestCase() {
         runBlocking {
             val managedIndexMetaData = ManagedIndexMetaData("test", "indexUuid", "policy_id", null, null, null, null, null, null, null, null, null, null, null)
             val attemptOpenStep = AttemptOpenStep()
-            val context = StepContext(managedIndexMetaData, clusterService, client, null, null, scriptService, settings, jobContext)
+            val context = StepContext(managedIndexMetaData, clusterService, client, null, null, scriptService, settings, lockService)
             attemptOpenStep.preExecute(logger, context).execute()
             val updatedManagedIndexMetaData = attemptOpenStep.getUpdatedManagedIndexMetadata(managedIndexMetaData)
             assertEquals("Step status is not FAILED", Step.StepStatus.FAILED, updatedManagedIndexMetaData.stepMetaData?.stepStatus)
@@ -69,7 +69,7 @@ class AttemptOpenStepTests : OpenSearchTestCase() {
         runBlocking {
             val managedIndexMetaData = ManagedIndexMetaData("test", "indexUuid", "policy_id", null, null, null, null, null, null, null, null, null, null, null)
             val attemptOpenStep = AttemptOpenStep()
-            val context = StepContext(managedIndexMetaData, clusterService, client, null, null, scriptService, settings, jobContext)
+            val context = StepContext(managedIndexMetaData, clusterService, client, null, null, scriptService, settings, lockService)
             attemptOpenStep.preExecute(logger, context).execute()
             val updatedManagedIndexMetaData = attemptOpenStep.getUpdatedManagedIndexMetadata(managedIndexMetaData)
             assertEquals("Step status is not FAILED", Step.StepStatus.FAILED, updatedManagedIndexMetaData.stepMetaData?.stepStatus)

--- a/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/AttemptOpenStepTests.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/AttemptOpenStepTests.kt
@@ -22,6 +22,7 @@ import org.opensearch.indexmanagement.indexstatemanagement.step.open.AttemptOpen
 import org.opensearch.indexmanagement.spi.indexstatemanagement.Step
 import org.opensearch.indexmanagement.spi.indexstatemanagement.model.ManagedIndexMetaData
 import org.opensearch.indexmanagement.spi.indexstatemanagement.model.StepContext
+import org.opensearch.jobscheduler.spi.JobExecutionContext
 import org.opensearch.script.ScriptService
 import org.opensearch.test.OpenSearchTestCase
 import org.opensearch.transport.RemoteTransportException
@@ -31,6 +32,7 @@ class AttemptOpenStepTests : OpenSearchTestCase() {
     private val clusterService: ClusterService = mock()
     private val scriptService: ScriptService = mock()
     private val settings: Settings = Settings.EMPTY
+    private val jobContext: JobExecutionContext = mock()
 
     fun `test open step sets step status to failed when not acknowledged`() {
         val openIndexResponse = OpenIndexResponse(false, false)
@@ -39,7 +41,7 @@ class AttemptOpenStepTests : OpenSearchTestCase() {
         runBlocking {
             val managedIndexMetaData = ManagedIndexMetaData("test", "indexUuid", "policy_id", null, null, null, null, null, null, null, null, null, null, null)
             val attemptOpenStep = AttemptOpenStep()
-            val context = StepContext(managedIndexMetaData, clusterService, client, null, null, scriptService, settings)
+            val context = StepContext(managedIndexMetaData, clusterService, client, null, null, scriptService, settings, jobContext)
             attemptOpenStep.preExecute(logger, context).execute()
             val updatedManagedIndexMetaData = attemptOpenStep.getUpdatedManagedIndexMetadata(managedIndexMetaData)
             assertEquals("Step status is not FAILED", Step.StepStatus.FAILED, updatedManagedIndexMetaData.stepMetaData?.stepStatus)
@@ -53,7 +55,7 @@ class AttemptOpenStepTests : OpenSearchTestCase() {
         runBlocking {
             val managedIndexMetaData = ManagedIndexMetaData("test", "indexUuid", "policy_id", null, null, null, null, null, null, null, null, null, null, null)
             val attemptOpenStep = AttemptOpenStep()
-            val context = StepContext(managedIndexMetaData, clusterService, client, null, null, scriptService, settings)
+            val context = StepContext(managedIndexMetaData, clusterService, client, null, null, scriptService, settings, jobContext)
             attemptOpenStep.preExecute(logger, context).execute()
             val updatedManagedIndexMetaData = attemptOpenStep.getUpdatedManagedIndexMetadata(managedIndexMetaData)
             assertEquals("Step status is not FAILED", Step.StepStatus.FAILED, updatedManagedIndexMetaData.stepMetaData?.stepStatus)
@@ -67,7 +69,7 @@ class AttemptOpenStepTests : OpenSearchTestCase() {
         runBlocking {
             val managedIndexMetaData = ManagedIndexMetaData("test", "indexUuid", "policy_id", null, null, null, null, null, null, null, null, null, null, null)
             val attemptOpenStep = AttemptOpenStep()
-            val context = StepContext(managedIndexMetaData, clusterService, client, null, null, scriptService, settings)
+            val context = StepContext(managedIndexMetaData, clusterService, client, null, null, scriptService, settings, jobContext)
             attemptOpenStep.preExecute(logger, context).execute()
             val updatedManagedIndexMetaData = attemptOpenStep.getUpdatedManagedIndexMetadata(managedIndexMetaData)
             assertEquals("Step status is not FAILED", Step.StepStatus.FAILED, updatedManagedIndexMetaData.stepMetaData?.stepStatus)

--- a/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/AttemptOpenStepTests.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/AttemptOpenStepTests.kt
@@ -32,7 +32,7 @@ class AttemptOpenStepTests : OpenSearchTestCase() {
     private val clusterService: ClusterService = mock()
     private val scriptService: ScriptService = mock()
     private val settings: Settings = Settings.EMPTY
-    private val lockService: LockService = mock()
+    private val lockService: LockService = LockService(mock(), clusterService)
 
     fun `test open step sets step status to failed when not acknowledged`() {
         val openIndexResponse = OpenIndexResponse(false, false)

--- a/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/AttemptSetIndexPriorityStepTests.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/AttemptSetIndexPriorityStepTests.kt
@@ -33,7 +33,7 @@ class AttemptSetIndexPriorityStepTests : OpenSearchTestCase() {
     private val clusterService: ClusterService = mock()
     private val scriptService: ScriptService = mock()
     private val settings: Settings = Settings.EMPTY
-    private val lockService: LockService = mock()
+    private val lockService: LockService = LockService(mock(), clusterService)
 
     fun `test set priority step sets step status to completed when successful`() {
         val acknowledgedResponse = AcknowledgedResponse(true)

--- a/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/AttemptSetIndexPriorityStepTests.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/AttemptSetIndexPriorityStepTests.kt
@@ -23,6 +23,7 @@ import org.opensearch.indexmanagement.indexstatemanagement.step.indexpriority.At
 import org.opensearch.indexmanagement.spi.indexstatemanagement.Step
 import org.opensearch.indexmanagement.spi.indexstatemanagement.model.ManagedIndexMetaData
 import org.opensearch.indexmanagement.spi.indexstatemanagement.model.StepContext
+import org.opensearch.jobscheduler.spi.JobExecutionContext
 import org.opensearch.script.ScriptService
 import org.opensearch.test.OpenSearchTestCase
 import org.opensearch.transport.RemoteTransportException
@@ -32,6 +33,7 @@ class AttemptSetIndexPriorityStepTests : OpenSearchTestCase() {
     private val clusterService: ClusterService = mock()
     private val scriptService: ScriptService = mock()
     private val settings: Settings = Settings.EMPTY
+    private val jobContext: JobExecutionContext = mock()
 
     fun `test set priority step sets step status to completed when successful`() {
         val acknowledgedResponse = AcknowledgedResponse(true)
@@ -41,7 +43,7 @@ class AttemptSetIndexPriorityStepTests : OpenSearchTestCase() {
             val indexPriorityAction = IndexPriorityAction(50, 0)
             val managedIndexMetaData = ManagedIndexMetaData("test", "indexUuid", "policy_id", null, null, null, null, null, null, null, null, null, null, null)
             val attemptSetPriorityStep = AttemptSetIndexPriorityStep(indexPriorityAction)
-            val context = StepContext(managedIndexMetaData, clusterService, client, null, null, scriptService, settings)
+            val context = StepContext(managedIndexMetaData, clusterService, client, null, null, scriptService, settings, jobContext)
             attemptSetPriorityStep.preExecute(logger, context).execute()
             val updatedManagedIndexMetaData = attemptSetPriorityStep.getUpdatedManagedIndexMetadata(managedIndexMetaData)
             assertEquals("Step status is not COMPLETED", Step.StepStatus.COMPLETED, updatedManagedIndexMetaData.stepMetaData?.stepStatus)
@@ -56,7 +58,7 @@ class AttemptSetIndexPriorityStepTests : OpenSearchTestCase() {
             val indexPriorityAction = IndexPriorityAction(50, 0)
             val managedIndexMetaData = ManagedIndexMetaData("test", "indexUuid", "policy_id", null, null, null, null, null, null, null, null, null, null, null)
             val attemptSetPriorityStep = AttemptSetIndexPriorityStep(indexPriorityAction)
-            val context = StepContext(managedIndexMetaData, clusterService, client, null, null, scriptService, settings)
+            val context = StepContext(managedIndexMetaData, clusterService, client, null, null, scriptService, settings, jobContext)
             attemptSetPriorityStep.preExecute(logger, context).execute()
             val updatedManagedIndexMetaData = attemptSetPriorityStep.getUpdatedManagedIndexMetadata(managedIndexMetaData)
             assertEquals("Step status is not FAILED", Step.StepStatus.FAILED, updatedManagedIndexMetaData.stepMetaData?.stepStatus)
@@ -71,7 +73,7 @@ class AttemptSetIndexPriorityStepTests : OpenSearchTestCase() {
             val indexPriorityAction = IndexPriorityAction(50, 0)
             val managedIndexMetaData = ManagedIndexMetaData("test", "indexUuid", "policy_id", null, null, null, null, null, null, null, null, null, null, null)
             val attemptSetPriorityStep = AttemptSetIndexPriorityStep(indexPriorityAction)
-            val context = StepContext(managedIndexMetaData, clusterService, client, null, null, scriptService, settings)
+            val context = StepContext(managedIndexMetaData, clusterService, client, null, null, scriptService, settings, jobContext)
             attemptSetPriorityStep.preExecute(logger, context).execute()
             val updatedManagedIndexMetaData = attemptSetPriorityStep.getUpdatedManagedIndexMetadata(managedIndexMetaData)
             logger.info(updatedManagedIndexMetaData)
@@ -87,7 +89,7 @@ class AttemptSetIndexPriorityStepTests : OpenSearchTestCase() {
             val indexPriorityAction = IndexPriorityAction(50, 0)
             val managedIndexMetaData = ManagedIndexMetaData("test", "indexUuid", "policy_id", null, null, null, null, null, null, null, null, null, null, null)
             val attemptSetPriorityStep = AttemptSetIndexPriorityStep(indexPriorityAction)
-            val context = StepContext(managedIndexMetaData, clusterService, client, null, null, scriptService, settings)
+            val context = StepContext(managedIndexMetaData, clusterService, client, null, null, scriptService, settings, jobContext)
             attemptSetPriorityStep.preExecute(logger, context).execute()
             val updatedManagedIndexMetaData = attemptSetPriorityStep.getUpdatedManagedIndexMetadata(managedIndexMetaData)
             logger.info(updatedManagedIndexMetaData)

--- a/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/AttemptSetIndexPriorityStepTests.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/AttemptSetIndexPriorityStepTests.kt
@@ -23,7 +23,7 @@ import org.opensearch.indexmanagement.indexstatemanagement.step.indexpriority.At
 import org.opensearch.indexmanagement.spi.indexstatemanagement.Step
 import org.opensearch.indexmanagement.spi.indexstatemanagement.model.ManagedIndexMetaData
 import org.opensearch.indexmanagement.spi.indexstatemanagement.model.StepContext
-import org.opensearch.jobscheduler.spi.JobExecutionContext
+import org.opensearch.jobscheduler.spi.utils.LockService
 import org.opensearch.script.ScriptService
 import org.opensearch.test.OpenSearchTestCase
 import org.opensearch.transport.RemoteTransportException
@@ -33,7 +33,7 @@ class AttemptSetIndexPriorityStepTests : OpenSearchTestCase() {
     private val clusterService: ClusterService = mock()
     private val scriptService: ScriptService = mock()
     private val settings: Settings = Settings.EMPTY
-    private val jobContext: JobExecutionContext = mock()
+    private val lockService: LockService = mock()
 
     fun `test set priority step sets step status to completed when successful`() {
         val acknowledgedResponse = AcknowledgedResponse(true)
@@ -43,7 +43,7 @@ class AttemptSetIndexPriorityStepTests : OpenSearchTestCase() {
             val indexPriorityAction = IndexPriorityAction(50, 0)
             val managedIndexMetaData = ManagedIndexMetaData("test", "indexUuid", "policy_id", null, null, null, null, null, null, null, null, null, null, null)
             val attemptSetPriorityStep = AttemptSetIndexPriorityStep(indexPriorityAction)
-            val context = StepContext(managedIndexMetaData, clusterService, client, null, null, scriptService, settings, jobContext)
+            val context = StepContext(managedIndexMetaData, clusterService, client, null, null, scriptService, settings, lockService)
             attemptSetPriorityStep.preExecute(logger, context).execute()
             val updatedManagedIndexMetaData = attemptSetPriorityStep.getUpdatedManagedIndexMetadata(managedIndexMetaData)
             assertEquals("Step status is not COMPLETED", Step.StepStatus.COMPLETED, updatedManagedIndexMetaData.stepMetaData?.stepStatus)
@@ -58,7 +58,7 @@ class AttemptSetIndexPriorityStepTests : OpenSearchTestCase() {
             val indexPriorityAction = IndexPriorityAction(50, 0)
             val managedIndexMetaData = ManagedIndexMetaData("test", "indexUuid", "policy_id", null, null, null, null, null, null, null, null, null, null, null)
             val attemptSetPriorityStep = AttemptSetIndexPriorityStep(indexPriorityAction)
-            val context = StepContext(managedIndexMetaData, clusterService, client, null, null, scriptService, settings, jobContext)
+            val context = StepContext(managedIndexMetaData, clusterService, client, null, null, scriptService, settings, lockService)
             attemptSetPriorityStep.preExecute(logger, context).execute()
             val updatedManagedIndexMetaData = attemptSetPriorityStep.getUpdatedManagedIndexMetadata(managedIndexMetaData)
             assertEquals("Step status is not FAILED", Step.StepStatus.FAILED, updatedManagedIndexMetaData.stepMetaData?.stepStatus)
@@ -73,7 +73,7 @@ class AttemptSetIndexPriorityStepTests : OpenSearchTestCase() {
             val indexPriorityAction = IndexPriorityAction(50, 0)
             val managedIndexMetaData = ManagedIndexMetaData("test", "indexUuid", "policy_id", null, null, null, null, null, null, null, null, null, null, null)
             val attemptSetPriorityStep = AttemptSetIndexPriorityStep(indexPriorityAction)
-            val context = StepContext(managedIndexMetaData, clusterService, client, null, null, scriptService, settings, jobContext)
+            val context = StepContext(managedIndexMetaData, clusterService, client, null, null, scriptService, settings, lockService)
             attemptSetPriorityStep.preExecute(logger, context).execute()
             val updatedManagedIndexMetaData = attemptSetPriorityStep.getUpdatedManagedIndexMetadata(managedIndexMetaData)
             logger.info(updatedManagedIndexMetaData)
@@ -89,7 +89,7 @@ class AttemptSetIndexPriorityStepTests : OpenSearchTestCase() {
             val indexPriorityAction = IndexPriorityAction(50, 0)
             val managedIndexMetaData = ManagedIndexMetaData("test", "indexUuid", "policy_id", null, null, null, null, null, null, null, null, null, null, null)
             val attemptSetPriorityStep = AttemptSetIndexPriorityStep(indexPriorityAction)
-            val context = StepContext(managedIndexMetaData, clusterService, client, null, null, scriptService, settings, jobContext)
+            val context = StepContext(managedIndexMetaData, clusterService, client, null, null, scriptService, settings, lockService)
             attemptSetPriorityStep.preExecute(logger, context).execute()
             val updatedManagedIndexMetaData = attemptSetPriorityStep.getUpdatedManagedIndexMetadata(managedIndexMetaData)
             logger.info(updatedManagedIndexMetaData)

--- a/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/AttemptSetReplicaCountStepTests.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/AttemptSetReplicaCountStepTests.kt
@@ -23,7 +23,7 @@ import org.opensearch.indexmanagement.indexstatemanagement.step.replicacount.Att
 import org.opensearch.indexmanagement.spi.indexstatemanagement.Step
 import org.opensearch.indexmanagement.spi.indexstatemanagement.model.ManagedIndexMetaData
 import org.opensearch.indexmanagement.spi.indexstatemanagement.model.StepContext
-import org.opensearch.jobscheduler.spi.JobExecutionContext
+import org.opensearch.jobscheduler.spi.utils.LockService
 import org.opensearch.script.ScriptService
 import org.opensearch.test.OpenSearchTestCase
 import org.opensearch.transport.RemoteTransportException
@@ -33,7 +33,7 @@ class AttemptSetReplicaCountStepTests : OpenSearchTestCase() {
     private val clusterService: ClusterService = mock()
     private val scriptService: ScriptService = mock()
     private val settings: Settings = Settings.EMPTY
-    private val jobContext: JobExecutionContext = mock()
+    private val lockService: LockService = mock()
 
     fun `test replica step sets step status to failed when not acknowledged`() {
         val replicaCountResponse = AcknowledgedResponse(false)
@@ -43,7 +43,7 @@ class AttemptSetReplicaCountStepTests : OpenSearchTestCase() {
             val replicaCountAction = ReplicaCountAction(2, 0)
             val managedIndexMetaData = ManagedIndexMetaData("test", "indexUuid", "policy_id", null, null, null, null, null, null, null, null, null, null, null)
             val replicaCountStep = AttemptReplicaCountStep(replicaCountAction)
-            val context = StepContext(managedIndexMetaData, clusterService, client, null, null, scriptService, settings, jobContext)
+            val context = StepContext(managedIndexMetaData, clusterService, client, null, null, scriptService, settings, lockService)
             replicaCountStep.preExecute(logger, context).execute()
             val updatedManagedIndexMetaData = replicaCountStep.getUpdatedManagedIndexMetadata(managedIndexMetaData)
             assertEquals("Step status is not FAILED", Step.StepStatus.FAILED, updatedManagedIndexMetaData.stepMetaData?.stepStatus)
@@ -58,7 +58,7 @@ class AttemptSetReplicaCountStepTests : OpenSearchTestCase() {
             val replicaCountAction = ReplicaCountAction(2, 0)
             val managedIndexMetaData = ManagedIndexMetaData("test", "indexUuid", "policy_id", null, null, null, null, null, null, null, null, null, null, null)
             val replicaCountStep = AttemptReplicaCountStep(replicaCountAction)
-            val context = StepContext(managedIndexMetaData, clusterService, client, null, null, scriptService, settings, jobContext)
+            val context = StepContext(managedIndexMetaData, clusterService, client, null, null, scriptService, settings, lockService)
             replicaCountStep.preExecute(logger, context).execute()
             val updatedManagedIndexMetaData = replicaCountStep.getUpdatedManagedIndexMetadata(managedIndexMetaData)
             assertEquals("Step status is not FAILED", Step.StepStatus.FAILED, updatedManagedIndexMetaData.stepMetaData?.stepStatus)
@@ -73,7 +73,7 @@ class AttemptSetReplicaCountStepTests : OpenSearchTestCase() {
             val replicaCountAction = ReplicaCountAction(2, 0)
             val managedIndexMetaData = ManagedIndexMetaData("test", "indexUuid", "policy_id", null, null, null, null, null, null, null, null, null, null, null)
             val replicaCountStep = AttemptReplicaCountStep(replicaCountAction)
-            val context = StepContext(managedIndexMetaData, clusterService, client, null, null, scriptService, settings, jobContext)
+            val context = StepContext(managedIndexMetaData, clusterService, client, null, null, scriptService, settings, lockService)
             replicaCountStep.preExecute(logger, context).execute()
             val updatedManagedIndexMetaData = replicaCountStep.getUpdatedManagedIndexMetadata(managedIndexMetaData)
             assertEquals("Step status is not FAILED", Step.StepStatus.FAILED, updatedManagedIndexMetaData.stepMetaData?.stepStatus)

--- a/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/AttemptSetReplicaCountStepTests.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/AttemptSetReplicaCountStepTests.kt
@@ -33,7 +33,7 @@ class AttemptSetReplicaCountStepTests : OpenSearchTestCase() {
     private val clusterService: ClusterService = mock()
     private val scriptService: ScriptService = mock()
     private val settings: Settings = Settings.EMPTY
-    private val lockService: LockService = mock()
+    private val lockService: LockService = LockService(mock(), clusterService)
 
     fun `test replica step sets step status to failed when not acknowledged`() {
         val replicaCountResponse = AcknowledgedResponse(false)

--- a/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/AttemptSetReplicaCountStepTests.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/AttemptSetReplicaCountStepTests.kt
@@ -23,6 +23,7 @@ import org.opensearch.indexmanagement.indexstatemanagement.step.replicacount.Att
 import org.opensearch.indexmanagement.spi.indexstatemanagement.Step
 import org.opensearch.indexmanagement.spi.indexstatemanagement.model.ManagedIndexMetaData
 import org.opensearch.indexmanagement.spi.indexstatemanagement.model.StepContext
+import org.opensearch.jobscheduler.spi.JobExecutionContext
 import org.opensearch.script.ScriptService
 import org.opensearch.test.OpenSearchTestCase
 import org.opensearch.transport.RemoteTransportException
@@ -32,6 +33,7 @@ class AttemptSetReplicaCountStepTests : OpenSearchTestCase() {
     private val clusterService: ClusterService = mock()
     private val scriptService: ScriptService = mock()
     private val settings: Settings = Settings.EMPTY
+    private val jobContext: JobExecutionContext = mock()
 
     fun `test replica step sets step status to failed when not acknowledged`() {
         val replicaCountResponse = AcknowledgedResponse(false)
@@ -41,7 +43,7 @@ class AttemptSetReplicaCountStepTests : OpenSearchTestCase() {
             val replicaCountAction = ReplicaCountAction(2, 0)
             val managedIndexMetaData = ManagedIndexMetaData("test", "indexUuid", "policy_id", null, null, null, null, null, null, null, null, null, null, null)
             val replicaCountStep = AttemptReplicaCountStep(replicaCountAction)
-            val context = StepContext(managedIndexMetaData, clusterService, client, null, null, scriptService, settings)
+            val context = StepContext(managedIndexMetaData, clusterService, client, null, null, scriptService, settings, jobContext)
             replicaCountStep.preExecute(logger, context).execute()
             val updatedManagedIndexMetaData = replicaCountStep.getUpdatedManagedIndexMetadata(managedIndexMetaData)
             assertEquals("Step status is not FAILED", Step.StepStatus.FAILED, updatedManagedIndexMetaData.stepMetaData?.stepStatus)
@@ -56,7 +58,7 @@ class AttemptSetReplicaCountStepTests : OpenSearchTestCase() {
             val replicaCountAction = ReplicaCountAction(2, 0)
             val managedIndexMetaData = ManagedIndexMetaData("test", "indexUuid", "policy_id", null, null, null, null, null, null, null, null, null, null, null)
             val replicaCountStep = AttemptReplicaCountStep(replicaCountAction)
-            val context = StepContext(managedIndexMetaData, clusterService, client, null, null, scriptService, settings)
+            val context = StepContext(managedIndexMetaData, clusterService, client, null, null, scriptService, settings, jobContext)
             replicaCountStep.preExecute(logger, context).execute()
             val updatedManagedIndexMetaData = replicaCountStep.getUpdatedManagedIndexMetadata(managedIndexMetaData)
             assertEquals("Step status is not FAILED", Step.StepStatus.FAILED, updatedManagedIndexMetaData.stepMetaData?.stepStatus)
@@ -71,7 +73,7 @@ class AttemptSetReplicaCountStepTests : OpenSearchTestCase() {
             val replicaCountAction = ReplicaCountAction(2, 0)
             val managedIndexMetaData = ManagedIndexMetaData("test", "indexUuid", "policy_id", null, null, null, null, null, null, null, null, null, null, null)
             val replicaCountStep = AttemptReplicaCountStep(replicaCountAction)
-            val context = StepContext(managedIndexMetaData, clusterService, client, null, null, scriptService, settings)
+            val context = StepContext(managedIndexMetaData, clusterService, client, null, null, scriptService, settings, jobContext)
             replicaCountStep.preExecute(logger, context).execute()
             val updatedManagedIndexMetaData = replicaCountStep.getUpdatedManagedIndexMetadata(managedIndexMetaData)
             assertEquals("Step status is not FAILED", Step.StepStatus.FAILED, updatedManagedIndexMetaData.stepMetaData?.stepStatus)

--- a/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/AttemptSnapshotStepTests.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/AttemptSnapshotStepTests.kt
@@ -45,7 +45,7 @@ class AttemptSnapshotStepTests : OpenSearchTestCase() {
     private val settings: Settings = Settings.EMPTY
     private val snapshotAction = randomSnapshotActionConfig("repo", "snapshot-name")
     private val metadata = ManagedIndexMetaData("test", "indexUuid", "policy_id", null, null, null, null, null, null, null, ActionMetaData(AttemptSnapshotStep.name, 1, 0, false, 0, null, ActionProperties(snapshotName = "snapshot-name")), null, null, null)
-    private val lockService: LockService = mock()
+    private val lockService: LockService = LockService(mock(), clusterService)
 
     @Before
     fun settings() {

--- a/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/AttemptSnapshotStepTests.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/AttemptSnapshotStepTests.kt
@@ -30,7 +30,7 @@ import org.opensearch.indexmanagement.spi.indexstatemanagement.model.ActionPrope
 import org.opensearch.indexmanagement.spi.indexstatemanagement.model.ManagedIndexMetaData
 import org.opensearch.indexmanagement.spi.indexstatemanagement.model.StepContext
 import org.opensearch.ingest.TestTemplateService.MockTemplateScript
-import org.opensearch.jobscheduler.spi.JobExecutionContext
+import org.opensearch.jobscheduler.spi.utils.LockService
 import org.opensearch.rest.RestStatus
 import org.opensearch.script.ScriptService
 import org.opensearch.script.TemplateScript
@@ -45,7 +45,7 @@ class AttemptSnapshotStepTests : OpenSearchTestCase() {
     private val settings: Settings = Settings.EMPTY
     private val snapshotAction = randomSnapshotActionConfig("repo", "snapshot-name")
     private val metadata = ManagedIndexMetaData("test", "indexUuid", "policy_id", null, null, null, null, null, null, null, ActionMetaData(AttemptSnapshotStep.name, 1, 0, false, 0, null, ActionProperties(snapshotName = "snapshot-name")), null, null, null)
-    private val jobContext: JobExecutionContext = mock()
+    private val lockService: LockService = mock()
 
     @Before
     fun settings() {
@@ -60,7 +60,7 @@ class AttemptSnapshotStepTests : OpenSearchTestCase() {
         whenever(response.status()).doReturn(RestStatus.ACCEPTED)
         runBlocking {
             val step = AttemptSnapshotStep(snapshotAction)
-            val context = StepContext(metadata, clusterService, client, null, null, scriptService, settings, jobContext)
+            val context = StepContext(metadata, clusterService, client, null, null, scriptService, settings, lockService)
             step.preExecute(logger, context).execute()
             val updatedManagedIndexMetaData = step.getUpdatedManagedIndexMetadata(metadata)
             assertEquals("Step status is not COMPLETED", Step.StepStatus.COMPLETED, updatedManagedIndexMetaData.stepMetaData?.stepStatus)
@@ -69,7 +69,7 @@ class AttemptSnapshotStepTests : OpenSearchTestCase() {
         whenever(response.status()).doReturn(RestStatus.OK)
         runBlocking {
             val step = AttemptSnapshotStep(snapshotAction)
-            val context = StepContext(metadata, clusterService, client, null, null, scriptService, settings, jobContext)
+            val context = StepContext(metadata, clusterService, client, null, null, scriptService, settings, lockService)
             step.preExecute(logger, context).execute()
             val updatedManagedIndexMetaData = step.getUpdatedManagedIndexMetadata(metadata)
             assertEquals("Step status is not COMPLETED", Step.StepStatus.COMPLETED, updatedManagedIndexMetaData.stepMetaData?.stepStatus)
@@ -78,7 +78,7 @@ class AttemptSnapshotStepTests : OpenSearchTestCase() {
         whenever(response.status()).doReturn(RestStatus.INTERNAL_SERVER_ERROR)
         runBlocking {
             val step = AttemptSnapshotStep(snapshotAction)
-            val context = StepContext(metadata, clusterService, client, null, null, scriptService, settings, jobContext)
+            val context = StepContext(metadata, clusterService, client, null, null, scriptService, settings, lockService)
             step.preExecute(logger, context).execute()
             val updatedManagedIndexMetaData = step.getUpdatedManagedIndexMetadata(metadata)
             assertEquals("Step status is not FAILED", Step.StepStatus.FAILED, updatedManagedIndexMetaData.stepMetaData?.stepStatus)
@@ -90,7 +90,7 @@ class AttemptSnapshotStepTests : OpenSearchTestCase() {
         val client = getClient(getAdminClient(getClusterAdminClient(null, exception)))
         runBlocking {
             val step = AttemptSnapshotStep(snapshotAction)
-            val context = StepContext(metadata, clusterService, client, null, null, scriptService, settings, jobContext)
+            val context = StepContext(metadata, clusterService, client, null, null, scriptService, settings, lockService)
             step.preExecute(logger, context).execute()
             val updatedManagedIndexMetaData = step.getUpdatedManagedIndexMetadata(metadata)
             assertEquals("Step status is not FAILED", Step.StepStatus.FAILED, updatedManagedIndexMetaData.stepMetaData?.stepStatus)
@@ -103,7 +103,7 @@ class AttemptSnapshotStepTests : OpenSearchTestCase() {
         val client = getClient(getAdminClient(getClusterAdminClient(null, exception)))
         runBlocking {
             val step = AttemptSnapshotStep(snapshotAction)
-            val context = StepContext(metadata, clusterService, client, null, null, scriptService, settings, jobContext)
+            val context = StepContext(metadata, clusterService, client, null, null, scriptService, settings, lockService)
             step.preExecute(logger, context).execute()
             val updatedManagedIndexMetaData = step.getUpdatedManagedIndexMetadata(metadata)
             assertEquals("Step status is not CONDITION_NOT_MET", Step.StepStatus.CONDITION_NOT_MET, updatedManagedIndexMetaData.stepMetaData?.stepStatus)
@@ -116,7 +116,7 @@ class AttemptSnapshotStepTests : OpenSearchTestCase() {
         val client = getClient(getAdminClient(getClusterAdminClient(null, exception)))
         runBlocking {
             val step = AttemptSnapshotStep(snapshotAction)
-            val context = StepContext(metadata, clusterService, client, null, null, scriptService, settings, jobContext)
+            val context = StepContext(metadata, clusterService, client, null, null, scriptService, settings, lockService)
             step.preExecute(logger, context).execute()
             val updatedManagedIndexMetaData = step.getUpdatedManagedIndexMetadata(metadata)
             assertEquals("Step status is not CONDITION_NOT_MET", Step.StepStatus.CONDITION_NOT_MET, updatedManagedIndexMetaData.stepMetaData?.stepStatus)
@@ -129,7 +129,7 @@ class AttemptSnapshotStepTests : OpenSearchTestCase() {
         val client = getClient(getAdminClient(getClusterAdminClient(null, exception)))
         runBlocking {
             val step = AttemptSnapshotStep(snapshotAction)
-            val context = StepContext(metadata, clusterService, client, null, null, scriptService, settings, jobContext)
+            val context = StepContext(metadata, clusterService, client, null, null, scriptService, settings, lockService)
             step.preExecute(logger, context).execute()
             val updatedManagedIndexMetaData = step.getUpdatedManagedIndexMetadata(metadata)
             assertEquals("Step status is not FAILED", Step.StepStatus.FAILED, updatedManagedIndexMetaData.stepMetaData?.stepStatus)

--- a/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/AttemptSnapshotStepTests.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/AttemptSnapshotStepTests.kt
@@ -30,6 +30,7 @@ import org.opensearch.indexmanagement.spi.indexstatemanagement.model.ActionPrope
 import org.opensearch.indexmanagement.spi.indexstatemanagement.model.ManagedIndexMetaData
 import org.opensearch.indexmanagement.spi.indexstatemanagement.model.StepContext
 import org.opensearch.ingest.TestTemplateService.MockTemplateScript
+import org.opensearch.jobscheduler.spi.JobExecutionContext
 import org.opensearch.rest.RestStatus
 import org.opensearch.script.ScriptService
 import org.opensearch.script.TemplateScript
@@ -44,6 +45,7 @@ class AttemptSnapshotStepTests : OpenSearchTestCase() {
     private val settings: Settings = Settings.EMPTY
     private val snapshotAction = randomSnapshotActionConfig("repo", "snapshot-name")
     private val metadata = ManagedIndexMetaData("test", "indexUuid", "policy_id", null, null, null, null, null, null, null, ActionMetaData(AttemptSnapshotStep.name, 1, 0, false, 0, null, ActionProperties(snapshotName = "snapshot-name")), null, null, null)
+    private val jobContext: JobExecutionContext = mock()
 
     @Before
     fun settings() {
@@ -58,7 +60,7 @@ class AttemptSnapshotStepTests : OpenSearchTestCase() {
         whenever(response.status()).doReturn(RestStatus.ACCEPTED)
         runBlocking {
             val step = AttemptSnapshotStep(snapshotAction)
-            val context = StepContext(metadata, clusterService, client, null, null, scriptService, settings)
+            val context = StepContext(metadata, clusterService, client, null, null, scriptService, settings, jobContext)
             step.preExecute(logger, context).execute()
             val updatedManagedIndexMetaData = step.getUpdatedManagedIndexMetadata(metadata)
             assertEquals("Step status is not COMPLETED", Step.StepStatus.COMPLETED, updatedManagedIndexMetaData.stepMetaData?.stepStatus)
@@ -67,7 +69,7 @@ class AttemptSnapshotStepTests : OpenSearchTestCase() {
         whenever(response.status()).doReturn(RestStatus.OK)
         runBlocking {
             val step = AttemptSnapshotStep(snapshotAction)
-            val context = StepContext(metadata, clusterService, client, null, null, scriptService, settings)
+            val context = StepContext(metadata, clusterService, client, null, null, scriptService, settings, jobContext)
             step.preExecute(logger, context).execute()
             val updatedManagedIndexMetaData = step.getUpdatedManagedIndexMetadata(metadata)
             assertEquals("Step status is not COMPLETED", Step.StepStatus.COMPLETED, updatedManagedIndexMetaData.stepMetaData?.stepStatus)
@@ -76,7 +78,7 @@ class AttemptSnapshotStepTests : OpenSearchTestCase() {
         whenever(response.status()).doReturn(RestStatus.INTERNAL_SERVER_ERROR)
         runBlocking {
             val step = AttemptSnapshotStep(snapshotAction)
-            val context = StepContext(metadata, clusterService, client, null, null, scriptService, settings)
+            val context = StepContext(metadata, clusterService, client, null, null, scriptService, settings, jobContext)
             step.preExecute(logger, context).execute()
             val updatedManagedIndexMetaData = step.getUpdatedManagedIndexMetadata(metadata)
             assertEquals("Step status is not FAILED", Step.StepStatus.FAILED, updatedManagedIndexMetaData.stepMetaData?.stepStatus)
@@ -88,7 +90,7 @@ class AttemptSnapshotStepTests : OpenSearchTestCase() {
         val client = getClient(getAdminClient(getClusterAdminClient(null, exception)))
         runBlocking {
             val step = AttemptSnapshotStep(snapshotAction)
-            val context = StepContext(metadata, clusterService, client, null, null, scriptService, settings)
+            val context = StepContext(metadata, clusterService, client, null, null, scriptService, settings, jobContext)
             step.preExecute(logger, context).execute()
             val updatedManagedIndexMetaData = step.getUpdatedManagedIndexMetadata(metadata)
             assertEquals("Step status is not FAILED", Step.StepStatus.FAILED, updatedManagedIndexMetaData.stepMetaData?.stepStatus)
@@ -101,7 +103,7 @@ class AttemptSnapshotStepTests : OpenSearchTestCase() {
         val client = getClient(getAdminClient(getClusterAdminClient(null, exception)))
         runBlocking {
             val step = AttemptSnapshotStep(snapshotAction)
-            val context = StepContext(metadata, clusterService, client, null, null, scriptService, settings)
+            val context = StepContext(metadata, clusterService, client, null, null, scriptService, settings, jobContext)
             step.preExecute(logger, context).execute()
             val updatedManagedIndexMetaData = step.getUpdatedManagedIndexMetadata(metadata)
             assertEquals("Step status is not CONDITION_NOT_MET", Step.StepStatus.CONDITION_NOT_MET, updatedManagedIndexMetaData.stepMetaData?.stepStatus)
@@ -114,7 +116,7 @@ class AttemptSnapshotStepTests : OpenSearchTestCase() {
         val client = getClient(getAdminClient(getClusterAdminClient(null, exception)))
         runBlocking {
             val step = AttemptSnapshotStep(snapshotAction)
-            val context = StepContext(metadata, clusterService, client, null, null, scriptService, settings)
+            val context = StepContext(metadata, clusterService, client, null, null, scriptService, settings, jobContext)
             step.preExecute(logger, context).execute()
             val updatedManagedIndexMetaData = step.getUpdatedManagedIndexMetadata(metadata)
             assertEquals("Step status is not CONDITION_NOT_MET", Step.StepStatus.CONDITION_NOT_MET, updatedManagedIndexMetaData.stepMetaData?.stepStatus)
@@ -127,7 +129,7 @@ class AttemptSnapshotStepTests : OpenSearchTestCase() {
         val client = getClient(getAdminClient(getClusterAdminClient(null, exception)))
         runBlocking {
             val step = AttemptSnapshotStep(snapshotAction)
-            val context = StepContext(metadata, clusterService, client, null, null, scriptService, settings)
+            val context = StepContext(metadata, clusterService, client, null, null, scriptService, settings, jobContext)
             step.preExecute(logger, context).execute()
             val updatedManagedIndexMetaData = step.getUpdatedManagedIndexMetadata(metadata)
             assertEquals("Step status is not FAILED", Step.StepStatus.FAILED, updatedManagedIndexMetaData.stepMetaData?.stepStatus)

--- a/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/AttemptTransitionStepTests.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/AttemptTransitionStepTests.kt
@@ -37,7 +37,7 @@ import org.opensearch.indexmanagement.spi.indexstatemanagement.Step
 import org.opensearch.indexmanagement.spi.indexstatemanagement.model.ManagedIndexMetaData
 import org.opensearch.indexmanagement.spi.indexstatemanagement.model.StepContext
 import org.opensearch.indexmanagement.spi.indexstatemanagement.model.StepMetaData
-import org.opensearch.jobscheduler.spi.JobExecutionContext
+import org.opensearch.jobscheduler.spi.utils.LockService
 import org.opensearch.rest.RestStatus
 import org.opensearch.script.ScriptService
 import org.opensearch.test.OpenSearchTestCase
@@ -61,7 +61,7 @@ class AttemptTransitionStepTests : OpenSearchTestCase() {
     private val clusterService: ClusterService = mock { on { state() } doReturn clusterState }
     private val scriptService: ScriptService = mock()
     private val settings: Settings = Settings.EMPTY
-    private val jobContext: JobExecutionContext = mock()
+    private val lockService: LockService = mock()
 
     private val docsStats: DocsStats = mock()
     private val primaries: CommonStats = mock { on { getDocs() } doReturn docsStats }
@@ -85,7 +85,7 @@ class AttemptTransitionStepTests : OpenSearchTestCase() {
             val managedIndexMetadata = ManagedIndexMetaData(indexName, indexUUID, "policy_id", null, null, null, null, null, null, null, null, null, null, null)
             val transitionsAction = TransitionsAction(listOf(Transition("some_state", Conditions(docCount = 5L))), indexMetadataProvider)
             val attemptTransitionStep = AttemptTransitionStep(transitionsAction)
-            val context = StepContext(managedIndexMetadata, clusterService, client, null, null, scriptService, settings, jobContext)
+            val context = StepContext(managedIndexMetadata, clusterService, client, null, null, scriptService, settings, lockService)
             attemptTransitionStep.preExecute(logger, context).execute()
             val updatedManagedIndexMetaData = attemptTransitionStep.getUpdatedManagedIndexMetadata(managedIndexMetadata)
             assertEquals("Step status is not FAILED", Step.StepStatus.FAILED, updatedManagedIndexMetaData.stepMetaData?.stepStatus)
@@ -103,7 +103,7 @@ class AttemptTransitionStepTests : OpenSearchTestCase() {
             val managedIndexMetadata = ManagedIndexMetaData(indexName, indexUUID, "policy_id", null, null, null, null, null, null, null, null, null, null, null)
             val transitionsAction = TransitionsAction(listOf(Transition("some_state", Conditions(docCount = 5L))), indexMetadataProvider)
             val attemptTransitionStep = AttemptTransitionStep(transitionsAction)
-            val context = StepContext(managedIndexMetadata, clusterService, client, null, null, scriptService, settings, jobContext)
+            val context = StepContext(managedIndexMetadata, clusterService, client, null, null, scriptService, settings, lockService)
             attemptTransitionStep.preExecute(logger, context).execute()
             val updatedManagedIndexMetaData = attemptTransitionStep.getUpdatedManagedIndexMetadata(managedIndexMetadata)
             assertEquals("Step status is not FAILED", Step.StepStatus.FAILED, updatedManagedIndexMetaData.stepMetaData?.stepStatus)
@@ -121,7 +121,7 @@ class AttemptTransitionStepTests : OpenSearchTestCase() {
             val managedIndexMetadata = ManagedIndexMetaData(indexName, indexUUID, "policy_id", null, null, null, null, null, null, null, null, null, null, null)
             val transitionsAction = TransitionsAction(listOf(Transition("some_state", Conditions(docCount = 5L))), indexMetadataProvider)
             val attemptTransitionStep = AttemptTransitionStep(transitionsAction)
-            val context = StepContext(managedIndexMetadata, clusterService, client, null, null, scriptService, settings, jobContext)
+            val context = StepContext(managedIndexMetadata, clusterService, client, null, null, scriptService, settings, lockService)
             attemptTransitionStep.preExecute(logger, context).execute()
             val updatedManagedIndexMetaData = attemptTransitionStep.getUpdatedManagedIndexMetadata(managedIndexMetadata)
             assertEquals("Step status is not FAILED", Step.StepStatus.FAILED, updatedManagedIndexMetaData.stepMetaData?.stepStatus)

--- a/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/AttemptTransitionStepTests.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/AttemptTransitionStepTests.kt
@@ -37,6 +37,7 @@ import org.opensearch.indexmanagement.spi.indexstatemanagement.Step
 import org.opensearch.indexmanagement.spi.indexstatemanagement.model.ManagedIndexMetaData
 import org.opensearch.indexmanagement.spi.indexstatemanagement.model.StepContext
 import org.opensearch.indexmanagement.spi.indexstatemanagement.model.StepMetaData
+import org.opensearch.jobscheduler.spi.JobExecutionContext
 import org.opensearch.rest.RestStatus
 import org.opensearch.script.ScriptService
 import org.opensearch.test.OpenSearchTestCase
@@ -60,6 +61,7 @@ class AttemptTransitionStepTests : OpenSearchTestCase() {
     private val clusterService: ClusterService = mock { on { state() } doReturn clusterState }
     private val scriptService: ScriptService = mock()
     private val settings: Settings = Settings.EMPTY
+    private val jobContext: JobExecutionContext = mock()
 
     private val docsStats: DocsStats = mock()
     private val primaries: CommonStats = mock { on { getDocs() } doReturn docsStats }
@@ -83,7 +85,7 @@ class AttemptTransitionStepTests : OpenSearchTestCase() {
             val managedIndexMetadata = ManagedIndexMetaData(indexName, indexUUID, "policy_id", null, null, null, null, null, null, null, null, null, null, null)
             val transitionsAction = TransitionsAction(listOf(Transition("some_state", Conditions(docCount = 5L))), indexMetadataProvider)
             val attemptTransitionStep = AttemptTransitionStep(transitionsAction)
-            val context = StepContext(managedIndexMetadata, clusterService, client, null, null, scriptService, settings)
+            val context = StepContext(managedIndexMetadata, clusterService, client, null, null, scriptService, settings, jobContext)
             attemptTransitionStep.preExecute(logger, context).execute()
             val updatedManagedIndexMetaData = attemptTransitionStep.getUpdatedManagedIndexMetadata(managedIndexMetadata)
             assertEquals("Step status is not FAILED", Step.StepStatus.FAILED, updatedManagedIndexMetaData.stepMetaData?.stepStatus)
@@ -101,7 +103,7 @@ class AttemptTransitionStepTests : OpenSearchTestCase() {
             val managedIndexMetadata = ManagedIndexMetaData(indexName, indexUUID, "policy_id", null, null, null, null, null, null, null, null, null, null, null)
             val transitionsAction = TransitionsAction(listOf(Transition("some_state", Conditions(docCount = 5L))), indexMetadataProvider)
             val attemptTransitionStep = AttemptTransitionStep(transitionsAction)
-            val context = StepContext(managedIndexMetadata, clusterService, client, null, null, scriptService, settings)
+            val context = StepContext(managedIndexMetadata, clusterService, client, null, null, scriptService, settings, jobContext)
             attemptTransitionStep.preExecute(logger, context).execute()
             val updatedManagedIndexMetaData = attemptTransitionStep.getUpdatedManagedIndexMetadata(managedIndexMetadata)
             assertEquals("Step status is not FAILED", Step.StepStatus.FAILED, updatedManagedIndexMetaData.stepMetaData?.stepStatus)
@@ -119,7 +121,7 @@ class AttemptTransitionStepTests : OpenSearchTestCase() {
             val managedIndexMetadata = ManagedIndexMetaData(indexName, indexUUID, "policy_id", null, null, null, null, null, null, null, null, null, null, null)
             val transitionsAction = TransitionsAction(listOf(Transition("some_state", Conditions(docCount = 5L))), indexMetadataProvider)
             val attemptTransitionStep = AttemptTransitionStep(transitionsAction)
-            val context = StepContext(managedIndexMetadata, clusterService, client, null, null, scriptService, settings)
+            val context = StepContext(managedIndexMetadata, clusterService, client, null, null, scriptService, settings, jobContext)
             attemptTransitionStep.preExecute(logger, context).execute()
             val updatedManagedIndexMetaData = attemptTransitionStep.getUpdatedManagedIndexMetadata(managedIndexMetadata)
             assertEquals("Step status is not FAILED", Step.StepStatus.FAILED, updatedManagedIndexMetaData.stepMetaData?.stepStatus)

--- a/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/AttemptTransitionStepTests.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/AttemptTransitionStepTests.kt
@@ -61,7 +61,7 @@ class AttemptTransitionStepTests : OpenSearchTestCase() {
     private val clusterService: ClusterService = mock { on { state() } doReturn clusterState }
     private val scriptService: ScriptService = mock()
     private val settings: Settings = Settings.EMPTY
-    private val lockService: LockService = mock()
+    private val lockService: LockService = LockService(mock(), clusterService)
 
     private val docsStats: DocsStats = mock()
     private val primaries: CommonStats = mock { on { getDocs() } doReturn docsStats }

--- a/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/SetReadOnlyStepTests.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/SetReadOnlyStepTests.kt
@@ -22,7 +22,7 @@ import org.opensearch.indexmanagement.indexstatemanagement.step.readonly.SetRead
 import org.opensearch.indexmanagement.spi.indexstatemanagement.Step
 import org.opensearch.indexmanagement.spi.indexstatemanagement.model.ManagedIndexMetaData
 import org.opensearch.indexmanagement.spi.indexstatemanagement.model.StepContext
-import org.opensearch.jobscheduler.spi.JobExecutionContext
+import org.opensearch.jobscheduler.spi.utils.LockService
 import org.opensearch.script.ScriptService
 import org.opensearch.test.OpenSearchTestCase
 import org.opensearch.transport.RemoteTransportException
@@ -32,7 +32,7 @@ class SetReadOnlyStepTests : OpenSearchTestCase() {
     private val clusterService: ClusterService = mock()
     private val scriptService: ScriptService = mock()
     private val settings: Settings = Settings.EMPTY
-    private val jobContext: JobExecutionContext = mock()
+    private val lockService: LockService = mock()
 
     fun `test read only step sets step status to failed when not acknowledged`() {
         val setReadOnlyResponse = AcknowledgedResponse(false)
@@ -41,7 +41,7 @@ class SetReadOnlyStepTests : OpenSearchTestCase() {
         runBlocking {
             val managedIndexMetaData = ManagedIndexMetaData("test", "indexUuid", "policy_id", null, null, null, null, null, null, null, null, null, null, null)
             val setReadOnlyStep = SetReadOnlyStep()
-            val context = StepContext(managedIndexMetaData, clusterService, client, null, null, scriptService, settings, jobContext)
+            val context = StepContext(managedIndexMetaData, clusterService, client, null, null, scriptService, settings, lockService)
             setReadOnlyStep.preExecute(logger, context).execute()
             val updatedManagedIndexMetaData = setReadOnlyStep.getUpdatedManagedIndexMetadata(managedIndexMetaData)
             assertEquals("Step status is not FAILED", Step.StepStatus.FAILED, updatedManagedIndexMetaData.stepMetaData?.stepStatus)
@@ -55,7 +55,7 @@ class SetReadOnlyStepTests : OpenSearchTestCase() {
         runBlocking {
             val managedIndexMetaData = ManagedIndexMetaData("test", "indexUuid", "policy_id", null, null, null, null, null, null, null, null, null, null, null)
             val setReadOnlyStep = SetReadOnlyStep()
-            val context = StepContext(managedIndexMetaData, clusterService, client, null, null, scriptService, settings, jobContext)
+            val context = StepContext(managedIndexMetaData, clusterService, client, null, null, scriptService, settings, lockService)
             setReadOnlyStep.preExecute(logger, context).execute()
             val updatedManagedIndexMetaData = setReadOnlyStep.getUpdatedManagedIndexMetadata(managedIndexMetaData)
             assertEquals("Step status is not FAILED", Step.StepStatus.FAILED, updatedManagedIndexMetaData.stepMetaData?.stepStatus)
@@ -69,7 +69,7 @@ class SetReadOnlyStepTests : OpenSearchTestCase() {
         runBlocking {
             val managedIndexMetaData = ManagedIndexMetaData("test", "indexUuid", "policy_id", null, null, null, null, null, null, null, null, null, null, null)
             val setReadOnlyStep = SetReadOnlyStep()
-            val context = StepContext(managedIndexMetaData, clusterService, client, null, null, scriptService, settings, jobContext)
+            val context = StepContext(managedIndexMetaData, clusterService, client, null, null, scriptService, settings, lockService)
             setReadOnlyStep.preExecute(logger, context).execute()
             val updatedManagedIndexMetaData = setReadOnlyStep.getUpdatedManagedIndexMetadata(managedIndexMetaData)
             assertEquals("Step status is not FAILED", Step.StepStatus.FAILED, updatedManagedIndexMetaData.stepMetaData?.stepStatus)

--- a/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/SetReadOnlyStepTests.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/SetReadOnlyStepTests.kt
@@ -32,7 +32,7 @@ class SetReadOnlyStepTests : OpenSearchTestCase() {
     private val clusterService: ClusterService = mock()
     private val scriptService: ScriptService = mock()
     private val settings: Settings = Settings.EMPTY
-    private val lockService: LockService = mock()
+    private val lockService: LockService = LockService(mock(), clusterService)
 
     fun `test read only step sets step status to failed when not acknowledged`() {
         val setReadOnlyResponse = AcknowledgedResponse(false)

--- a/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/SetReadOnlyStepTests.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/SetReadOnlyStepTests.kt
@@ -22,6 +22,7 @@ import org.opensearch.indexmanagement.indexstatemanagement.step.readonly.SetRead
 import org.opensearch.indexmanagement.spi.indexstatemanagement.Step
 import org.opensearch.indexmanagement.spi.indexstatemanagement.model.ManagedIndexMetaData
 import org.opensearch.indexmanagement.spi.indexstatemanagement.model.StepContext
+import org.opensearch.jobscheduler.spi.JobExecutionContext
 import org.opensearch.script.ScriptService
 import org.opensearch.test.OpenSearchTestCase
 import org.opensearch.transport.RemoteTransportException
@@ -31,6 +32,7 @@ class SetReadOnlyStepTests : OpenSearchTestCase() {
     private val clusterService: ClusterService = mock()
     private val scriptService: ScriptService = mock()
     private val settings: Settings = Settings.EMPTY
+    private val jobContext: JobExecutionContext = mock()
 
     fun `test read only step sets step status to failed when not acknowledged`() {
         val setReadOnlyResponse = AcknowledgedResponse(false)
@@ -39,7 +41,7 @@ class SetReadOnlyStepTests : OpenSearchTestCase() {
         runBlocking {
             val managedIndexMetaData = ManagedIndexMetaData("test", "indexUuid", "policy_id", null, null, null, null, null, null, null, null, null, null, null)
             val setReadOnlyStep = SetReadOnlyStep()
-            val context = StepContext(managedIndexMetaData, clusterService, client, null, null, scriptService, settings)
+            val context = StepContext(managedIndexMetaData, clusterService, client, null, null, scriptService, settings, jobContext)
             setReadOnlyStep.preExecute(logger, context).execute()
             val updatedManagedIndexMetaData = setReadOnlyStep.getUpdatedManagedIndexMetadata(managedIndexMetaData)
             assertEquals("Step status is not FAILED", Step.StepStatus.FAILED, updatedManagedIndexMetaData.stepMetaData?.stepStatus)
@@ -53,7 +55,7 @@ class SetReadOnlyStepTests : OpenSearchTestCase() {
         runBlocking {
             val managedIndexMetaData = ManagedIndexMetaData("test", "indexUuid", "policy_id", null, null, null, null, null, null, null, null, null, null, null)
             val setReadOnlyStep = SetReadOnlyStep()
-            val context = StepContext(managedIndexMetaData, clusterService, client, null, null, scriptService, settings)
+            val context = StepContext(managedIndexMetaData, clusterService, client, null, null, scriptService, settings, jobContext)
             setReadOnlyStep.preExecute(logger, context).execute()
             val updatedManagedIndexMetaData = setReadOnlyStep.getUpdatedManagedIndexMetadata(managedIndexMetaData)
             assertEquals("Step status is not FAILED", Step.StepStatus.FAILED, updatedManagedIndexMetaData.stepMetaData?.stepStatus)
@@ -67,7 +69,7 @@ class SetReadOnlyStepTests : OpenSearchTestCase() {
         runBlocking {
             val managedIndexMetaData = ManagedIndexMetaData("test", "indexUuid", "policy_id", null, null, null, null, null, null, null, null, null, null, null)
             val setReadOnlyStep = SetReadOnlyStep()
-            val context = StepContext(managedIndexMetaData, clusterService, client, null, null, scriptService, settings)
+            val context = StepContext(managedIndexMetaData, clusterService, client, null, null, scriptService, settings, jobContext)
             setReadOnlyStep.preExecute(logger, context).execute()
             val updatedManagedIndexMetaData = setReadOnlyStep.getUpdatedManagedIndexMetadata(managedIndexMetaData)
             assertEquals("Step status is not FAILED", Step.StepStatus.FAILED, updatedManagedIndexMetaData.stepMetaData?.stepStatus)

--- a/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/SetReadWriteStepTests.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/SetReadWriteStepTests.kt
@@ -32,7 +32,7 @@ class SetReadWriteStepTests : OpenSearchTestCase() {
     private val clusterService: ClusterService = mock()
     private val scriptService: ScriptService = mock()
     private val settings: Settings = Settings.EMPTY
-    private val lockService: LockService = mock()
+    private val lockService: LockService = LockService(mock(), clusterService)
 
     fun `test read write step sets step status to failed when not acknowledged`() {
         val setReadWriteResponse = AcknowledgedResponse(false)

--- a/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/SetReadWriteStepTests.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/SetReadWriteStepTests.kt
@@ -22,6 +22,7 @@ import org.opensearch.indexmanagement.indexstatemanagement.step.readwrite.SetRea
 import org.opensearch.indexmanagement.spi.indexstatemanagement.Step
 import org.opensearch.indexmanagement.spi.indexstatemanagement.model.ManagedIndexMetaData
 import org.opensearch.indexmanagement.spi.indexstatemanagement.model.StepContext
+import org.opensearch.jobscheduler.spi.JobExecutionContext
 import org.opensearch.script.ScriptService
 import org.opensearch.test.OpenSearchTestCase
 import org.opensearch.transport.RemoteTransportException
@@ -31,6 +32,7 @@ class SetReadWriteStepTests : OpenSearchTestCase() {
     private val clusterService: ClusterService = mock()
     private val scriptService: ScriptService = mock()
     private val settings: Settings = Settings.EMPTY
+    private val jobContext: JobExecutionContext = mock()
 
     fun `test read write step sets step status to failed when not acknowledged`() {
         val setReadWriteResponse = AcknowledgedResponse(false)
@@ -39,7 +41,7 @@ class SetReadWriteStepTests : OpenSearchTestCase() {
         runBlocking {
             val managedIndexMetaData = ManagedIndexMetaData("test", "indexUuid", "policy_id", null, null, null, null, null, null, null, null, null, null, null)
             val setReadWriteStep = SetReadWriteStep()
-            val context = StepContext(managedIndexMetaData, clusterService, client, null, null, scriptService, settings)
+            val context = StepContext(managedIndexMetaData, clusterService, client, null, null, scriptService, settings, jobContext)
             setReadWriteStep.preExecute(logger, context).execute()
             val updatedManagedIndexMetaData = setReadWriteStep.getUpdatedManagedIndexMetadata(managedIndexMetaData)
             assertEquals("Step status is not FAILED", Step.StepStatus.FAILED, updatedManagedIndexMetaData.stepMetaData?.stepStatus)
@@ -53,7 +55,7 @@ class SetReadWriteStepTests : OpenSearchTestCase() {
         runBlocking {
             val managedIndexMetaData = ManagedIndexMetaData("test", "indexUuid", "policy_id", null, null, null, null, null, null, null, null, null, null, null)
             val setReadWriteStep = SetReadWriteStep()
-            val context = StepContext(managedIndexMetaData, clusterService, client, null, null, scriptService, settings)
+            val context = StepContext(managedIndexMetaData, clusterService, client, null, null, scriptService, settings, jobContext)
             setReadWriteStep.preExecute(logger, context).execute()
             val updatedManagedIndexMetaData = setReadWriteStep.getUpdatedManagedIndexMetadata(managedIndexMetaData)
             assertEquals("Step status is not FAILED", Step.StepStatus.FAILED, updatedManagedIndexMetaData.stepMetaData?.stepStatus)
@@ -67,7 +69,7 @@ class SetReadWriteStepTests : OpenSearchTestCase() {
         runBlocking {
             val managedIndexMetaData = ManagedIndexMetaData("test", "indexUuid", "policy_id", null, null, null, null, null, null, null, null, null, null, null)
             val setReadWriteStep = SetReadWriteStep()
-            val context = StepContext(managedIndexMetaData, clusterService, client, null, null, scriptService, settings)
+            val context = StepContext(managedIndexMetaData, clusterService, client, null, null, scriptService, settings, jobContext)
             setReadWriteStep.preExecute(logger, context).execute()
             val updatedManagedIndexMetaData = setReadWriteStep.getUpdatedManagedIndexMetadata(managedIndexMetaData)
             assertEquals("Step status is not FAILED", Step.StepStatus.FAILED, updatedManagedIndexMetaData.stepMetaData?.stepStatus)

--- a/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/SetReadWriteStepTests.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/SetReadWriteStepTests.kt
@@ -22,7 +22,7 @@ import org.opensearch.indexmanagement.indexstatemanagement.step.readwrite.SetRea
 import org.opensearch.indexmanagement.spi.indexstatemanagement.Step
 import org.opensearch.indexmanagement.spi.indexstatemanagement.model.ManagedIndexMetaData
 import org.opensearch.indexmanagement.spi.indexstatemanagement.model.StepContext
-import org.opensearch.jobscheduler.spi.JobExecutionContext
+import org.opensearch.jobscheduler.spi.utils.LockService
 import org.opensearch.script.ScriptService
 import org.opensearch.test.OpenSearchTestCase
 import org.opensearch.transport.RemoteTransportException
@@ -32,7 +32,7 @@ class SetReadWriteStepTests : OpenSearchTestCase() {
     private val clusterService: ClusterService = mock()
     private val scriptService: ScriptService = mock()
     private val settings: Settings = Settings.EMPTY
-    private val jobContext: JobExecutionContext = mock()
+    private val lockService: LockService = mock()
 
     fun `test read write step sets step status to failed when not acknowledged`() {
         val setReadWriteResponse = AcknowledgedResponse(false)
@@ -41,7 +41,7 @@ class SetReadWriteStepTests : OpenSearchTestCase() {
         runBlocking {
             val managedIndexMetaData = ManagedIndexMetaData("test", "indexUuid", "policy_id", null, null, null, null, null, null, null, null, null, null, null)
             val setReadWriteStep = SetReadWriteStep()
-            val context = StepContext(managedIndexMetaData, clusterService, client, null, null, scriptService, settings, jobContext)
+            val context = StepContext(managedIndexMetaData, clusterService, client, null, null, scriptService, settings, lockService)
             setReadWriteStep.preExecute(logger, context).execute()
             val updatedManagedIndexMetaData = setReadWriteStep.getUpdatedManagedIndexMetadata(managedIndexMetaData)
             assertEquals("Step status is not FAILED", Step.StepStatus.FAILED, updatedManagedIndexMetaData.stepMetaData?.stepStatus)
@@ -55,7 +55,7 @@ class SetReadWriteStepTests : OpenSearchTestCase() {
         runBlocking {
             val managedIndexMetaData = ManagedIndexMetaData("test", "indexUuid", "policy_id", null, null, null, null, null, null, null, null, null, null, null)
             val setReadWriteStep = SetReadWriteStep()
-            val context = StepContext(managedIndexMetaData, clusterService, client, null, null, scriptService, settings, jobContext)
+            val context = StepContext(managedIndexMetaData, clusterService, client, null, null, scriptService, settings, lockService)
             setReadWriteStep.preExecute(logger, context).execute()
             val updatedManagedIndexMetaData = setReadWriteStep.getUpdatedManagedIndexMetadata(managedIndexMetaData)
             assertEquals("Step status is not FAILED", Step.StepStatus.FAILED, updatedManagedIndexMetaData.stepMetaData?.stepStatus)
@@ -69,7 +69,7 @@ class SetReadWriteStepTests : OpenSearchTestCase() {
         runBlocking {
             val managedIndexMetaData = ManagedIndexMetaData("test", "indexUuid", "policy_id", null, null, null, null, null, null, null, null, null, null, null)
             val setReadWriteStep = SetReadWriteStep()
-            val context = StepContext(managedIndexMetaData, clusterService, client, null, null, scriptService, settings, jobContext)
+            val context = StepContext(managedIndexMetaData, clusterService, client, null, null, scriptService, settings, lockService)
             setReadWriteStep.preExecute(logger, context).execute()
             val updatedManagedIndexMetaData = setReadWriteStep.getUpdatedManagedIndexMetadata(managedIndexMetaData)
             assertEquals("Step status is not FAILED", Step.StepStatus.FAILED, updatedManagedIndexMetaData.stepMetaData?.stepStatus)

--- a/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/WaitForRollupCompletionStepTests.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/WaitForRollupCompletionStepTests.kt
@@ -18,6 +18,7 @@ import org.opensearch.indexmanagement.spi.indexstatemanagement.model.ActionMetaD
 import org.opensearch.indexmanagement.spi.indexstatemanagement.model.ActionProperties
 import org.opensearch.indexmanagement.spi.indexstatemanagement.model.ManagedIndexMetaData
 import org.opensearch.indexmanagement.spi.indexstatemanagement.model.StepContext
+import org.opensearch.jobscheduler.spi.JobExecutionContext
 import org.opensearch.script.ScriptService
 import org.opensearch.test.OpenSearchTestCase
 import java.time.Instant
@@ -41,11 +42,12 @@ class WaitForRollupCompletionStepTests : OpenSearchTestCase() {
     )
     private val client: Client = mock()
     private val step = WaitForRollupCompletionStep()
+    private val jobContext: JobExecutionContext = mock()
 
     fun `test wait for rollup when missing rollup id`() {
         val actionMetadata = metadata.actionMetaData!!.copy(actionProperties = ActionProperties())
         val metadata = metadata.copy(actionMetaData = actionMetadata)
-        val context = StepContext(metadata, clusterService, client, null, null, scriptService, settings)
+        val context = StepContext(metadata, clusterService, client, null, null, scriptService, settings, jobContext)
         val step = WaitForRollupCompletionStep()
 
         runBlocking {

--- a/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/WaitForRollupCompletionStepTests.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/WaitForRollupCompletionStepTests.kt
@@ -42,7 +42,7 @@ class WaitForRollupCompletionStepTests : OpenSearchTestCase() {
     )
     private val client: Client = mock()
     private val step = WaitForRollupCompletionStep()
-    private val lockService: LockService = mock()
+    private val lockService: LockService = LockService(mock(), clusterService)
 
     fun `test wait for rollup when missing rollup id`() {
         val actionMetadata = metadata.actionMetaData!!.copy(actionProperties = ActionProperties())

--- a/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/WaitForRollupCompletionStepTests.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/WaitForRollupCompletionStepTests.kt
@@ -18,7 +18,7 @@ import org.opensearch.indexmanagement.spi.indexstatemanagement.model.ActionMetaD
 import org.opensearch.indexmanagement.spi.indexstatemanagement.model.ActionProperties
 import org.opensearch.indexmanagement.spi.indexstatemanagement.model.ManagedIndexMetaData
 import org.opensearch.indexmanagement.spi.indexstatemanagement.model.StepContext
-import org.opensearch.jobscheduler.spi.JobExecutionContext
+import org.opensearch.jobscheduler.spi.utils.LockService
 import org.opensearch.script.ScriptService
 import org.opensearch.test.OpenSearchTestCase
 import java.time.Instant
@@ -42,12 +42,12 @@ class WaitForRollupCompletionStepTests : OpenSearchTestCase() {
     )
     private val client: Client = mock()
     private val step = WaitForRollupCompletionStep()
-    private val jobContext: JobExecutionContext = mock()
+    private val lockService: LockService = mock()
 
     fun `test wait for rollup when missing rollup id`() {
         val actionMetadata = metadata.actionMetaData!!.copy(actionProperties = ActionProperties())
         val metadata = metadata.copy(actionMetaData = actionMetadata)
-        val context = StepContext(metadata, clusterService, client, null, null, scriptService, settings, jobContext)
+        val context = StepContext(metadata, clusterService, client, null, null, scriptService, settings, lockService)
         val step = WaitForRollupCompletionStep()
 
         runBlocking {

--- a/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/WaitForSnapshotStepTests.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/WaitForSnapshotStepTests.kt
@@ -27,6 +27,7 @@ import org.opensearch.indexmanagement.spi.indexstatemanagement.model.ActionMetaD
 import org.opensearch.indexmanagement.spi.indexstatemanagement.model.ActionProperties
 import org.opensearch.indexmanagement.spi.indexstatemanagement.model.ManagedIndexMetaData
 import org.opensearch.indexmanagement.spi.indexstatemanagement.model.StepContext
+import org.opensearch.jobscheduler.spi.JobExecutionContext
 import org.opensearch.script.ScriptService
 import org.opensearch.snapshots.Snapshot
 import org.opensearch.snapshots.SnapshotId
@@ -38,6 +39,7 @@ class WaitForSnapshotStepTests : OpenSearchTestCase() {
     private val clusterService: ClusterService = mock()
     private val scriptService: ScriptService = mock()
     private val settings: Settings = Settings.EMPTY
+    private val jobContext: JobExecutionContext = mock()
     val snapshot = "snapshot-name"
 
     fun `test snapshot missing snapshot name in action properties`() {
@@ -48,7 +50,7 @@ class WaitForSnapshotStepTests : OpenSearchTestCase() {
             val snapshotAction = SnapshotAction("repo", snapshot, 0)
             val metadata = ManagedIndexMetaData("test", "indexUuid", "policy_id", null, null, null, null, null, null, null, ActionMetaData(WaitForSnapshotStep.name, 1, 0, false, 0, null, emptyActionProperties), null, null, null)
             val step = WaitForSnapshotStep(snapshotAction)
-            val context = StepContext(metadata, clusterService, client, null, null, scriptService, settings)
+            val context = StepContext(metadata, clusterService, client, null, null, scriptService, settings, jobContext)
             step.preExecute(logger, context).execute()
             val updatedManagedIndexMetaData = step.getUpdatedManagedIndexMetadata(metadata)
             assertEquals("Step status is not FAILED", Step.StepStatus.FAILED, updatedManagedIndexMetaData.stepMetaData?.stepStatus)
@@ -60,7 +62,7 @@ class WaitForSnapshotStepTests : OpenSearchTestCase() {
             val snapshotAction = SnapshotAction("repo", snapshot, 0)
             val metadata = ManagedIndexMetaData("test", "indexUuid", "policy_id", null, null, null, null, null, null, null, ActionMetaData(WaitForSnapshotStep.name, 1, 0, false, 0, null, nullActionProperties), null, null, null)
             val step = WaitForSnapshotStep(snapshotAction)
-            val context = StepContext(metadata, clusterService, client, null, null, scriptService, settings)
+            val context = StepContext(metadata, clusterService, client, null, null, scriptService, settings, jobContext)
             step.preExecute(logger, context).execute()
             val updatedManagedIndexMetaData = step.getUpdatedManagedIndexMetadata(metadata)
             assertEquals("Step status is not FAILED", Step.StepStatus.FAILED, updatedManagedIndexMetaData.stepMetaData?.stepStatus)
@@ -80,7 +82,7 @@ class WaitForSnapshotStepTests : OpenSearchTestCase() {
             val snapshotAction = SnapshotAction("repo", snapshot, 0)
             val metadata = ManagedIndexMetaData("test", "indexUuid", "policy_id", null, null, null, null, null, null, null, ActionMetaData(WaitForSnapshotStep.name, 1, 0, false, 0, null, ActionProperties(snapshotName = "snapshot-name")), null, null, null)
             val step = WaitForSnapshotStep(snapshotAction)
-            val context = StepContext(metadata, clusterService, client, null, null, scriptService, settings)
+            val context = StepContext(metadata, clusterService, client, null, null, scriptService, settings, jobContext)
             step.preExecute(logger, context).execute()
             val updatedManagedIndexMetaData = step.getUpdatedManagedIndexMetadata(metadata)
             assertEquals("Step status is not CONDITION_NOT_MET", Step.StepStatus.CONDITION_NOT_MET, updatedManagedIndexMetaData.stepMetaData?.stepStatus)
@@ -92,7 +94,7 @@ class WaitForSnapshotStepTests : OpenSearchTestCase() {
             val snapshotAction = SnapshotAction("repo", snapshot, 0)
             val metadata = ManagedIndexMetaData("test", "indexUuid", "policy_id", null, null, null, null, null, null, null, ActionMetaData(WaitForSnapshotStep.name, 1, 0, false, 0, null, ActionProperties(snapshotName = "snapshot-name")), null, null, null)
             val step = WaitForSnapshotStep(snapshotAction)
-            val context = StepContext(metadata, clusterService, client, null, null, scriptService, settings)
+            val context = StepContext(metadata, clusterService, client, null, null, scriptService, settings, jobContext)
             step.preExecute(logger, context).execute()
             val updatedManagedIndexMetaData = step.getUpdatedManagedIndexMetadata(metadata)
             assertEquals("Step status is not CONDITION_NOT_MET", Step.StepStatus.CONDITION_NOT_MET, updatedManagedIndexMetaData.stepMetaData?.stepStatus)
@@ -104,7 +106,7 @@ class WaitForSnapshotStepTests : OpenSearchTestCase() {
             val snapshotAction = SnapshotAction("repo", snapshot, 0)
             val metadata = ManagedIndexMetaData("test", "indexUuid", "policy_id", null, null, null, null, null, null, null, ActionMetaData(WaitForSnapshotStep.name, 1, 0, false, 0, null, ActionProperties(snapshotName = "snapshot-name")), null, null, null)
             val step = WaitForSnapshotStep(snapshotAction)
-            val context = StepContext(metadata, clusterService, client, null, null, scriptService, settings)
+            val context = StepContext(metadata, clusterService, client, null, null, scriptService, settings, jobContext)
             step.preExecute(logger, context).execute()
             val updatedManagedIndexMetaData = step.getUpdatedManagedIndexMetadata(metadata)
             assertEquals("Step status is not COMPLETED", Step.StepStatus.COMPLETED, updatedManagedIndexMetaData.stepMetaData?.stepStatus)
@@ -116,7 +118,7 @@ class WaitForSnapshotStepTests : OpenSearchTestCase() {
             val snapshotAction = SnapshotAction("repo", snapshot, 0)
             val metadata = ManagedIndexMetaData("test", "indexUuid", "policy_id", null, null, null, null, null, null, null, ActionMetaData(WaitForSnapshotStep.name, 1, 0, false, 0, null, ActionProperties(snapshotName = "snapshot-name")), null, null, null)
             val step = WaitForSnapshotStep(snapshotAction)
-            val context = StepContext(metadata, clusterService, client, null, null, scriptService, settings)
+            val context = StepContext(metadata, clusterService, client, null, null, scriptService, settings, jobContext)
             step.preExecute(logger, context).execute()
             val updatedManagedIndexMetaData = step.getUpdatedManagedIndexMetadata(metadata)
             assertEquals("Step status is not FAILED", Step.StepStatus.FAILED, updatedManagedIndexMetaData.stepMetaData?.stepStatus)
@@ -128,7 +130,7 @@ class WaitForSnapshotStepTests : OpenSearchTestCase() {
             val snapshotAction = SnapshotAction("repo", snapshot, 0)
             val metadata = ManagedIndexMetaData("test", "indexUuid", "policy_id", null, null, null, null, null, null, null, ActionMetaData(WaitForSnapshotStep.name, 1, 0, false, 0, null, ActionProperties(snapshotName = "snapshot-name")), null, null, null)
             val step = WaitForSnapshotStep(snapshotAction)
-            val context = StepContext(metadata, clusterService, client, null, null, scriptService, settings)
+            val context = StepContext(metadata, clusterService, client, null, null, scriptService, settings, jobContext)
             step.preExecute(logger, context).execute()
             val updatedManagedIndexMetaData = step.getUpdatedManagedIndexMetadata(metadata)
             assertEquals("Step status is not FAILED", Step.StepStatus.FAILED, updatedManagedIndexMetaData.stepMetaData?.stepStatus)
@@ -147,7 +149,7 @@ class WaitForSnapshotStepTests : OpenSearchTestCase() {
             val snapshotAction = SnapshotAction("repo", snapshot, 0)
             val metadata = ManagedIndexMetaData("test", "indexUuid", "policy_id", null, null, null, null, null, null, null, ActionMetaData(WaitForSnapshotStep.name, 1, 0, false, 0, null, ActionProperties(snapshotName = "snapshot-name")), null, null, null)
             val step = WaitForSnapshotStep(snapshotAction)
-            val context = StepContext(metadata, clusterService, client, null, null, scriptService, settings)
+            val context = StepContext(metadata, clusterService, client, null, null, scriptService, settings, jobContext)
             step.preExecute(logger, context).execute()
             val updatedManagedIndexMetaData = step.getUpdatedManagedIndexMetadata(metadata)
             assertEquals("Step status is not FAILED", Step.StepStatus.FAILED, updatedManagedIndexMetaData.stepMetaData?.stepStatus)
@@ -162,7 +164,7 @@ class WaitForSnapshotStepTests : OpenSearchTestCase() {
             val snapshotAction = SnapshotAction("repo", snapshot, 0)
             val metadata = ManagedIndexMetaData("test", "indexUuid", "policy_id", null, null, null, null, null, null, null, ActionMetaData(WaitForSnapshotStep.name, 1, 0, false, 0, null, ActionProperties(snapshotName = "snapshot-name")), null, null, null)
             val step = WaitForSnapshotStep(snapshotAction)
-            val context = StepContext(metadata, clusterService, client, null, null, scriptService, settings)
+            val context = StepContext(metadata, clusterService, client, null, null, scriptService, settings, jobContext)
             step.preExecute(logger, context).execute()
             val updatedManagedIndexMetaData = step.getUpdatedManagedIndexMetadata(metadata)
             assertEquals("Step status is not FAILED", Step.StepStatus.FAILED, updatedManagedIndexMetaData.stepMetaData?.stepStatus)
@@ -177,7 +179,7 @@ class WaitForSnapshotStepTests : OpenSearchTestCase() {
             val snapshotAction = SnapshotAction("repo", snapshot, 0)
             val metadata = ManagedIndexMetaData("test", "indexUuid", "policy_id", null, null, null, null, null, null, null, ActionMetaData(WaitForSnapshotStep.name, 1, 0, false, 0, null, ActionProperties(snapshotName = "snapshot-name")), null, null, null)
             val step = WaitForSnapshotStep(snapshotAction)
-            val context = StepContext(metadata, clusterService, client, null, null, scriptService, settings)
+            val context = StepContext(metadata, clusterService, client, null, null, scriptService, settings, jobContext)
             step.preExecute(logger, context).execute()
             val updatedManagedIndexMetaData = step.getUpdatedManagedIndexMetadata(metadata)
             assertEquals("Step status is not FAILED", Step.StepStatus.FAILED, updatedManagedIndexMetaData.stepMetaData?.stepStatus)

--- a/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/WaitForSnapshotStepTests.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/WaitForSnapshotStepTests.kt
@@ -39,7 +39,7 @@ class WaitForSnapshotStepTests : OpenSearchTestCase() {
     private val clusterService: ClusterService = mock()
     private val scriptService: ScriptService = mock()
     private val settings: Settings = Settings.EMPTY
-    private val lockService: LockService = mock()
+    private val lockService: LockService = LockService(mock(), clusterService)
     val snapshot = "snapshot-name"
 
     fun `test snapshot missing snapshot name in action properties`() {

--- a/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/WaitForSnapshotStepTests.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/WaitForSnapshotStepTests.kt
@@ -27,7 +27,7 @@ import org.opensearch.indexmanagement.spi.indexstatemanagement.model.ActionMetaD
 import org.opensearch.indexmanagement.spi.indexstatemanagement.model.ActionProperties
 import org.opensearch.indexmanagement.spi.indexstatemanagement.model.ManagedIndexMetaData
 import org.opensearch.indexmanagement.spi.indexstatemanagement.model.StepContext
-import org.opensearch.jobscheduler.spi.JobExecutionContext
+import org.opensearch.jobscheduler.spi.utils.LockService
 import org.opensearch.script.ScriptService
 import org.opensearch.snapshots.Snapshot
 import org.opensearch.snapshots.SnapshotId
@@ -39,7 +39,7 @@ class WaitForSnapshotStepTests : OpenSearchTestCase() {
     private val clusterService: ClusterService = mock()
     private val scriptService: ScriptService = mock()
     private val settings: Settings = Settings.EMPTY
-    private val jobContext: JobExecutionContext = mock()
+    private val lockService: LockService = mock()
     val snapshot = "snapshot-name"
 
     fun `test snapshot missing snapshot name in action properties`() {
@@ -50,7 +50,7 @@ class WaitForSnapshotStepTests : OpenSearchTestCase() {
             val snapshotAction = SnapshotAction("repo", snapshot, 0)
             val metadata = ManagedIndexMetaData("test", "indexUuid", "policy_id", null, null, null, null, null, null, null, ActionMetaData(WaitForSnapshotStep.name, 1, 0, false, 0, null, emptyActionProperties), null, null, null)
             val step = WaitForSnapshotStep(snapshotAction)
-            val context = StepContext(metadata, clusterService, client, null, null, scriptService, settings, jobContext)
+            val context = StepContext(metadata, clusterService, client, null, null, scriptService, settings, lockService)
             step.preExecute(logger, context).execute()
             val updatedManagedIndexMetaData = step.getUpdatedManagedIndexMetadata(metadata)
             assertEquals("Step status is not FAILED", Step.StepStatus.FAILED, updatedManagedIndexMetaData.stepMetaData?.stepStatus)
@@ -62,7 +62,7 @@ class WaitForSnapshotStepTests : OpenSearchTestCase() {
             val snapshotAction = SnapshotAction("repo", snapshot, 0)
             val metadata = ManagedIndexMetaData("test", "indexUuid", "policy_id", null, null, null, null, null, null, null, ActionMetaData(WaitForSnapshotStep.name, 1, 0, false, 0, null, nullActionProperties), null, null, null)
             val step = WaitForSnapshotStep(snapshotAction)
-            val context = StepContext(metadata, clusterService, client, null, null, scriptService, settings, jobContext)
+            val context = StepContext(metadata, clusterService, client, null, null, scriptService, settings, lockService)
             step.preExecute(logger, context).execute()
             val updatedManagedIndexMetaData = step.getUpdatedManagedIndexMetadata(metadata)
             assertEquals("Step status is not FAILED", Step.StepStatus.FAILED, updatedManagedIndexMetaData.stepMetaData?.stepStatus)
@@ -82,7 +82,7 @@ class WaitForSnapshotStepTests : OpenSearchTestCase() {
             val snapshotAction = SnapshotAction("repo", snapshot, 0)
             val metadata = ManagedIndexMetaData("test", "indexUuid", "policy_id", null, null, null, null, null, null, null, ActionMetaData(WaitForSnapshotStep.name, 1, 0, false, 0, null, ActionProperties(snapshotName = "snapshot-name")), null, null, null)
             val step = WaitForSnapshotStep(snapshotAction)
-            val context = StepContext(metadata, clusterService, client, null, null, scriptService, settings, jobContext)
+            val context = StepContext(metadata, clusterService, client, null, null, scriptService, settings, lockService)
             step.preExecute(logger, context).execute()
             val updatedManagedIndexMetaData = step.getUpdatedManagedIndexMetadata(metadata)
             assertEquals("Step status is not CONDITION_NOT_MET", Step.StepStatus.CONDITION_NOT_MET, updatedManagedIndexMetaData.stepMetaData?.stepStatus)
@@ -94,7 +94,7 @@ class WaitForSnapshotStepTests : OpenSearchTestCase() {
             val snapshotAction = SnapshotAction("repo", snapshot, 0)
             val metadata = ManagedIndexMetaData("test", "indexUuid", "policy_id", null, null, null, null, null, null, null, ActionMetaData(WaitForSnapshotStep.name, 1, 0, false, 0, null, ActionProperties(snapshotName = "snapshot-name")), null, null, null)
             val step = WaitForSnapshotStep(snapshotAction)
-            val context = StepContext(metadata, clusterService, client, null, null, scriptService, settings, jobContext)
+            val context = StepContext(metadata, clusterService, client, null, null, scriptService, settings, lockService)
             step.preExecute(logger, context).execute()
             val updatedManagedIndexMetaData = step.getUpdatedManagedIndexMetadata(metadata)
             assertEquals("Step status is not CONDITION_NOT_MET", Step.StepStatus.CONDITION_NOT_MET, updatedManagedIndexMetaData.stepMetaData?.stepStatus)
@@ -106,7 +106,7 @@ class WaitForSnapshotStepTests : OpenSearchTestCase() {
             val snapshotAction = SnapshotAction("repo", snapshot, 0)
             val metadata = ManagedIndexMetaData("test", "indexUuid", "policy_id", null, null, null, null, null, null, null, ActionMetaData(WaitForSnapshotStep.name, 1, 0, false, 0, null, ActionProperties(snapshotName = "snapshot-name")), null, null, null)
             val step = WaitForSnapshotStep(snapshotAction)
-            val context = StepContext(metadata, clusterService, client, null, null, scriptService, settings, jobContext)
+            val context = StepContext(metadata, clusterService, client, null, null, scriptService, settings, lockService)
             step.preExecute(logger, context).execute()
             val updatedManagedIndexMetaData = step.getUpdatedManagedIndexMetadata(metadata)
             assertEquals("Step status is not COMPLETED", Step.StepStatus.COMPLETED, updatedManagedIndexMetaData.stepMetaData?.stepStatus)
@@ -118,7 +118,7 @@ class WaitForSnapshotStepTests : OpenSearchTestCase() {
             val snapshotAction = SnapshotAction("repo", snapshot, 0)
             val metadata = ManagedIndexMetaData("test", "indexUuid", "policy_id", null, null, null, null, null, null, null, ActionMetaData(WaitForSnapshotStep.name, 1, 0, false, 0, null, ActionProperties(snapshotName = "snapshot-name")), null, null, null)
             val step = WaitForSnapshotStep(snapshotAction)
-            val context = StepContext(metadata, clusterService, client, null, null, scriptService, settings, jobContext)
+            val context = StepContext(metadata, clusterService, client, null, null, scriptService, settings, lockService)
             step.preExecute(logger, context).execute()
             val updatedManagedIndexMetaData = step.getUpdatedManagedIndexMetadata(metadata)
             assertEquals("Step status is not FAILED", Step.StepStatus.FAILED, updatedManagedIndexMetaData.stepMetaData?.stepStatus)
@@ -130,7 +130,7 @@ class WaitForSnapshotStepTests : OpenSearchTestCase() {
             val snapshotAction = SnapshotAction("repo", snapshot, 0)
             val metadata = ManagedIndexMetaData("test", "indexUuid", "policy_id", null, null, null, null, null, null, null, ActionMetaData(WaitForSnapshotStep.name, 1, 0, false, 0, null, ActionProperties(snapshotName = "snapshot-name")), null, null, null)
             val step = WaitForSnapshotStep(snapshotAction)
-            val context = StepContext(metadata, clusterService, client, null, null, scriptService, settings, jobContext)
+            val context = StepContext(metadata, clusterService, client, null, null, scriptService, settings, lockService)
             step.preExecute(logger, context).execute()
             val updatedManagedIndexMetaData = step.getUpdatedManagedIndexMetadata(metadata)
             assertEquals("Step status is not FAILED", Step.StepStatus.FAILED, updatedManagedIndexMetaData.stepMetaData?.stepStatus)
@@ -149,7 +149,7 @@ class WaitForSnapshotStepTests : OpenSearchTestCase() {
             val snapshotAction = SnapshotAction("repo", snapshot, 0)
             val metadata = ManagedIndexMetaData("test", "indexUuid", "policy_id", null, null, null, null, null, null, null, ActionMetaData(WaitForSnapshotStep.name, 1, 0, false, 0, null, ActionProperties(snapshotName = "snapshot-name")), null, null, null)
             val step = WaitForSnapshotStep(snapshotAction)
-            val context = StepContext(metadata, clusterService, client, null, null, scriptService, settings, jobContext)
+            val context = StepContext(metadata, clusterService, client, null, null, scriptService, settings, lockService)
             step.preExecute(logger, context).execute()
             val updatedManagedIndexMetaData = step.getUpdatedManagedIndexMetadata(metadata)
             assertEquals("Step status is not FAILED", Step.StepStatus.FAILED, updatedManagedIndexMetaData.stepMetaData?.stepStatus)
@@ -164,7 +164,7 @@ class WaitForSnapshotStepTests : OpenSearchTestCase() {
             val snapshotAction = SnapshotAction("repo", snapshot, 0)
             val metadata = ManagedIndexMetaData("test", "indexUuid", "policy_id", null, null, null, null, null, null, null, ActionMetaData(WaitForSnapshotStep.name, 1, 0, false, 0, null, ActionProperties(snapshotName = "snapshot-name")), null, null, null)
             val step = WaitForSnapshotStep(snapshotAction)
-            val context = StepContext(metadata, clusterService, client, null, null, scriptService, settings, jobContext)
+            val context = StepContext(metadata, clusterService, client, null, null, scriptService, settings, lockService)
             step.preExecute(logger, context).execute()
             val updatedManagedIndexMetaData = step.getUpdatedManagedIndexMetadata(metadata)
             assertEquals("Step status is not FAILED", Step.StepStatus.FAILED, updatedManagedIndexMetaData.stepMetaData?.stepStatus)
@@ -179,7 +179,7 @@ class WaitForSnapshotStepTests : OpenSearchTestCase() {
             val snapshotAction = SnapshotAction("repo", snapshot, 0)
             val metadata = ManagedIndexMetaData("test", "indexUuid", "policy_id", null, null, null, null, null, null, null, ActionMetaData(WaitForSnapshotStep.name, 1, 0, false, 0, null, ActionProperties(snapshotName = "snapshot-name")), null, null, null)
             val step = WaitForSnapshotStep(snapshotAction)
-            val context = StepContext(metadata, clusterService, client, null, null, scriptService, settings, jobContext)
+            val context = StepContext(metadata, clusterService, client, null, null, scriptService, settings, lockService)
             step.preExecute(logger, context).execute()
             val updatedManagedIndexMetaData = step.getUpdatedManagedIndexMetadata(metadata)
             assertEquals("Step status is not FAILED", Step.StepStatus.FAILED, updatedManagedIndexMetaData.stepMetaData?.stepStatus)

--- a/src/test/resources/mappings/cached-opendistro-ism-config.json
+++ b/src/test/resources/mappings/cached-opendistro-ism-config.json
@@ -441,8 +441,9 @@
                     "percentage_of_source_shards": {
                       "type": "double"
                     },
-                    "target_index_suffix": {
-                      "type": "text"
+                    "target_index_name_template": {
+                      "type": "object",
+                      "enabled": false
                     },
                     "aliases": {
                       "type": "object",

--- a/src/test/resources/mappings/cached-opendistro-ism-config.json
+++ b/src/test/resources/mappings/cached-opendistro-ism-config.json
@@ -438,7 +438,7 @@
                     "max_shard_size": {
                       "type": "keyword"
                     },
-                    "percentage_decrease": {
+                    "percentage_of_source_shards": {
                       "type": "double"
                     },
                     "target_index_suffix": {

--- a/src/test/resources/mappings/cached-opendistro-ism-config.json
+++ b/src/test/resources/mappings/cached-opendistro-ism-config.json
@@ -1,6 +1,6 @@
 {
   "_meta" : {
-    "schema_version": 13
+    "schema_version": 14
   },
   "dynamic": "strict",
   "properties": {
@@ -430,6 +430,29 @@
                     }
                   }
                 },
+                "shrink": {
+                  "properties": {
+                    "num_new_shards": {
+                      "type": "integer"
+                    },
+                    "max_shard_size": {
+                      "type": "keyword"
+                    },
+                    "percentage_decrease": {
+                      "type": "double"
+                    },
+                    "target_index_suffix": {
+                      "type": "text"
+                    },
+                    "aliases": {
+                      "type": "object",
+                      "enabled": false
+                    },
+                    "force_unsafe": {
+                      "type": "boolean"
+                    }
+                  }
+                },
                 "custom": {
                   "enabled": false,
                   "type":  "object"
@@ -733,6 +756,10 @@
                 },
                 "has_rollup_failed": {
                   "type": "boolean"
+                },
+                "shrink_action_properties": {
+                  "type": "object",
+                  "enabled": false
                 }
               }
             }

--- a/src/test/resources/mappings/cached-opendistro-ism-history.json
+++ b/src/test/resources/mappings/cached-opendistro-ism-history.json
@@ -1,6 +1,6 @@
 {
   "_meta" : {
-    "schema_version": 4
+    "schema_version": 5
   },
   "dynamic": "strict",
   "properties": {
@@ -108,6 +108,10 @@
                 },
                 "has_rollup_failed": {
                   "type": "boolean"
+                },
+                "shrink_action_properties": {
+                  "type": "object",
+                  "enabled": false
                 }
               }
             }


### PR DESCRIPTION
Tests are passing for me locally. As the job scheduler changes in this PR https://github.com/opensearch-project/job-scheduler/pull/164 have not yet been merged, they are expected to fail in this github action

*Issue #, if available:*
https://github.com/opensearch-project/index-management/issues/40

### Description of changes:
Adds implementation for the shrink action in ISM.

The shrink action allows users to reduce the number of primary shards in their indices using ISM policies, and provides many additional safety checks to make sure the index, nodes, or even cluster is not harmed by the action. When shrinking an index, you may provide either the number of new shards, the percentage of the original shards, or the maximum shard size for the shrunken index. While the shrink action is ongoing, the source index will be set to readonly, and a copy of each of the shards in the index will need to be on a single node with at least 2*(source index size) free disk space below the high disk watermark level.  The shrunken index name will, by default, consist of a prefix of the source index name, and a suffix of "_shrunken". Alternatively, you may provide a mustache template script to generate the target index name using the index name or uuid. The shrink action does not delete the source index after completion.

### Configuration:
Exactly one of num_new_shards, max_shard_size, and percentage_of_source_shards is required. If you provide multiple, the action will fail.
* *num_new_shards (int):* the maximum number of primary shards in the shrunken index. 
* *max_shard_size (byte size value e.g. "5gb"):* the maximum size of a shard on in the target index.
* *percentage_of_source_shards (double):* % of the number of original primary shards. This will indicate the minimum percentage by which the number of primary shards will shrink. This value must be between 0.0 and 1.0 exclusive.
* *target_index_name_template (optional script):* the shrunken index name will be generated with this [mustache template](https://mustache.github.io/mustache.5.html) script if provided. The mustache template may access the index and indexUuid from the ctx object. An example would be `"target_index_name_template":{"source": "{{ctx.index}}_shrink"}`
* *aliases (optional list of Aliases):* aliases to be added to the new target index. 
* *force_unsafe (optional boolean):* If this boolean is set to true, the action will execute even if there are no replicas.

### Steps:
A failure in any step will result in the shrink action starting over from the first step with a blank slate.
*attempt_move_shards_step:*
This step performs safety checks, calculates the number of shards to shrink to, selects a node to shrink on, sets the source index to readonly, and begins moving a copy of each shard to the target node.
Checks:
- The target index name, which the shrunken index will be created with, does not exist
- The source index is green
- The source index either has replicas or the policy had force_unsafe set to true
- The shrink will not result in the shards on the target index having greater than the maximum number of documents on any shard (2^31)
- Some node in the cluster has at least 2*(source index size) free disk space below the high disk watermark level, and a dry run of allocating one of each shard in the source index to that node passes. Additionally, only one node may be selected for a shrink action at one time.
If all of these checks pass, the shards will be set to allocate to the selected node and the index will be set to read only.

*wait_for_move_shards_step:*
This step waits for a copy of each shard in the source index to be moved onto the node selected in the first step. Additionally, this step waits for all replicas to be in sync with the primaries, as any shard copy may have been moved to the selected node, and shrinking using an out of sync replica would result in missing operations on the shrunken index.
Checks:
- All source index shards are in sync
- At least one copy of each shard successfully was routed to the selected node
- If this step waits for longer than the configured timeout, or the default of 12 hours, the action fails.

*attempt_shrink_step:*
This step verifies that the index is still green and that the selected node still has space for the shrink, and then calls the [resize index api](https://opensearch.org/docs/1.3/opensearch/rest-api/index-apis/shrink-index/).
Checks:
- The source index is green
- The selected node still has enough space to shrink to
If all of these checks pass, the shrink will begin.

*wait_for_shrink_step:*
This step waits for waits until the shrunken index is created and all of its primary shards have started accepting operations.
Checks:
- all primary shards on the shrunken index have started accepting operations
- If this step waits for longer than the configured timeout, or the default of 12 hours, the action fails.

### Example policy:
```
{
    "policy_id": "shrink_then_delete",
    "description": "A sample description of the policy",
    "last_updated_time": 1649990327715,
    "schema_version": 14,
    "error_notification": null,
    "default_state": "shrink",
    "states": [
        {
            "name": "shrink",
            "actions": [
                {
                    "retry": {
                        "count": 3,
                        "backoff": "exponential",
                        "delay": "1m"
                    },
                    "shrink": {
                        "num_new_shards": 1,
                        "target_index_name_template": {
                            "source": "shrunken_{{ctx.index}}",
                            "lang": "mustache"
                        },
                        "aliases": [],
                        "force_unsafe": true
                    }
                }
            ],
            "transitions": [
                {
                    "state_name": "delete"
                }
            ]
        },
        {
            "name": "delete",
            "actions": [
                {
                    "retry": {
                        "count": 3,
                        "backoff": "exponential",
                        "delay": "1m"
                    },
                    "delete": {}
                }
            ],
            "transitions": []
        }
    ],
    "ism_template": []
}
```

TODOs before release:
- Unit tests for steps and util functions
- Explicitly deny or allow a group of nodes to be considered for use.
- Job scheduler sweeper to clean up stale locks

*CheckList:*
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/index-management/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
