### PR TITLE
Only download JS zip when integTest is running

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -378,11 +378,15 @@ String bwcFilePath = "src/test/resources/bwc/"
 String bwc_js_resource_location = bwcFilePath + "job-scheduler/" + bwcJobSchedulerVersion
 String bwc_im_resource_location = bwcFilePath + "indexmanagement/" + bwcVersion
 
+// Downloads the bwc job scheduler version
 String bwc_js_download_url = "https://github.com/opendistro-for-elasticsearch/job-scheduler/releases/download/v" +
         bwcJobSchedulerVersion + "/job-scheduler-artifacts.zip"
+getPluginResource(bwc_js_resource_location, bwc_js_download_url)
 
+// Downloads the bwc index management version
 String bwc_im_download_url = "https://github.com/opendistro-for-elasticsearch/index-management/releases/download/v" +
         bwcVersion + "/index-management-artifacts.zip"
+getPluginResource(bwc_im_resource_location, bwc_im_download_url)
 
 2.times {i ->
     testClusters {
@@ -390,6 +394,29 @@ String bwc_im_download_url = "https://github.com/opendistro-for-elasticsearch/in
             testDistribution = "ARCHIVE"
             versions = ["7.10.2", opensearch_version]
             numberOfNodes = 3
+            plugin(provider(new Callable<RegularFile>(){
+                @Override
+                RegularFile call() throws Exception {
+                    return new RegularFile() {
+                        @Override
+                        File getAsFile() {
+                            return fileTree(bwc_js_resource_location).getSingleFile()
+                        }
+                    }
+                }
+            }))
+
+            plugin(provider(new Callable<RegularFile>(){
+                @Override
+                RegularFile call() throws Exception {
+                    return new RegularFile() {
+                        @Override
+                        File getAsFile() {
+                            return fileTree(bwc_im_resource_location).getSingleFile()
+                        }
+                    }
+                }
+            }))
             setting 'path.repo', "${buildDir}/cluster/shared/repo/${baseName}"
             setting 'http.content_type.required', 'true'
         }
@@ -404,32 +431,8 @@ List<Provider<RegularFile>> plugins = []
 task prepareBwcTests {
     dependsOn bundlePlugin
     doLast {
-        getPluginResource(bwc_js_resource_location, bwc_js_download_url)
-        getPluginResource(bwc_im_resource_location, bwc_im_download_url)
         getPluginResource(job_scheduler_resource_folder, job_scheduler_build_download)
         plugins = [
-                provider(new Callable<RegularFile>(){
-                    @Override
-                    RegularFile call() throws Exception {
-                        return new RegularFile() {
-                            @Override
-                            File getAsFile() {
-                                return fileTree(bwc_js_resource_location).getSingleFile()
-                            }
-                        }
-                    }
-                }),
-                provider(new Callable<RegularFile>(){
-                    @Override
-                    RegularFile call() throws Exception {
-                        return new RegularFile() {
-                            @Override
-                            File getAsFile() {
-                                return fileTree(bwc_im_resource_location).getSingleFile()
-                            }
-                        }
-                    }
-                }),
                 provider(new Callable<RegularFile>(){
                     @Override
                     RegularFile call() throws Exception {

--- a/build.gradle
+++ b/build.gradle
@@ -425,7 +425,6 @@ getPluginResource(bwc_im_resource_location, bwc_im_download_url)
 
 List<Provider<RegularFile>> plugins = []
 
-
 // Ensure the artifact for the current project version is available to be used for the bwc tests
 
 task prepareBwcTests {
@@ -542,7 +541,6 @@ task "${baseName}#fullRestartClusterTask"(type: StandaloneRestIntegTestTask) {
 
 // A bwc test suite which runs all the bwc tasks combined
 task bwcTestSuite(type: StandaloneRestIntegTestTask) {
-    project.logger.lifecycle('bwcrun')
     exclude '**/*Test*'
     exclude '**/*IT*'
     dependsOn tasks.named("${baseName}#mixedClusterTask")

--- a/build.gradle
+++ b/build.gradle
@@ -248,8 +248,6 @@ ext.getPluginResource = { download_to_folder, download_from_src ->
     return fileTree(download_to_folder).getSingleFile()
 }
 
-// Download the job scheduler test dependency
-getPluginResource(job_scheduler_resource_folder, job_scheduler_build_download)
 
 File repo = file("$buildDir/testclusters/repo")
 def _numNodes = findProperty('numNodes') as Integer ?: 1
@@ -297,6 +295,8 @@ integTest {
     // Tell the test JVM if the cluster JVM is running under a debugger so that tests can use longer timeouts for
     // requests. The 'doFirst' delays reading the debug setting on the cluster till execution time.
     doFirst {
+        // Download the job scheduler test dependency
+        getPluginResource(job_scheduler_resource_folder, job_scheduler_build_download)
         systemProperty 'cluster.debug', getDebug()
         // Set number of nodes system property to be used in tests
         systemProperty 'cluster.number_of_nodes', "${_numNodes}"

--- a/build.gradle
+++ b/build.gradle
@@ -448,29 +448,6 @@ List<Provider<RegularFile>> plugins = [
             testDistribution = "ARCHIVE"
             versions = ["7.10.2", opensearch_version]
             numberOfNodes = 3
-            plugin(provider(new Callable<RegularFile>(){
-                @Override
-                RegularFile call() throws Exception {
-                    return new RegularFile() {
-                        @Override
-                        File getAsFile() {
-                            return fileTree(bwc_js_resource_location).getSingleFile()
-                        }
-                    }
-                }
-            }))
-
-            plugin(provider(new Callable<RegularFile>(){
-                @Override
-                RegularFile call() throws Exception {
-                    return new RegularFile() {
-                        @Override
-                        File getAsFile() {
-                            return fileTree(bwc_im_resource_location).getSingleFile()
-                        }
-                    }
-                }
-            }))
             setting 'path.repo', "${buildDir}/cluster/shared/repo/${baseName}"
             setting 'http.content_type.required', 'true'
         }

--- a/build.gradle
+++ b/build.gradle
@@ -396,62 +396,7 @@ String bwc_im_download_url = "https://github.com/opendistro-for-elasticsearch/in
     }
 }
 
-List<Provider<RegularFile>> plugins = [
-        provider(new Callable<RegularFile>(){
-            @Override
-            RegularFile call() throws Exception {
-                return new RegularFile() {
-                    @Override
-                    File getAsFile() {
-                        if (new File("$project.rootDir/$bwc_js_resource_location").exists()) {
-                            project.delete(files("$project.rootDir/$bwc_js_resource_location"))
-                        }
-                        project.mkdir bwc_js_resource_location
-                        ant.get(src: bwc_js_download_url,
-                                dest: bwc_js_resource_location,
-                                httpusecaches: false)
-                        return fileTree(bwc_js_resource_location).getSingleFile()
-                    }
-                }
-            }
-        }),
-        provider(new Callable<RegularFile>(){
-            @Override
-            RegularFile call() throws Exception {
-                return new RegularFile() {
-                    @Override
-                    File getAsFile() {
-                        if (new File("$project.rootDir/$bwc_im_resource_location").exists()) {
-                            project.delete(files("$project.rootDir/$bwc_im_resource_location"))
-                        }
-                        project.mkdir bwc_im_resource_location
-                        ant.get(src: bwc_im_download_url,
-                                dest: bwc_im_resource_location,
-                                httpusecaches: false)
-                        return fileTree(bwc_im_resource_location).getSingleFile()
-                    }
-                }
-            }
-        }),
-        provider(new Callable<RegularFile>(){
-            @Override
-            RegularFile call() throws Exception {
-                return new RegularFile() {
-                    @Override
-                    File getAsFile() {
-                        if (new File("$project.rootDir/$job_scheduler_resource_folder").exists()) {
-                            project.delete(files("$project.rootDir/$job_scheduler_resource_folder"))
-                        }
-                        project.mkdir job_scheduler_resource_folder
-                        ant.get(src: job_scheduler_build_download,
-                                dest: job_scheduler_resource_folder,
-                                httpusecaches: false)
-                        return fileTree(job_scheduler_resource_folder).getSingleFile()
-                    }
-                }
-            }
-        })
-    ]
+List<Provider<RegularFile>> plugins = []
 
 
 // Ensure the artifact for the current project version is available to be used for the bwc tests
@@ -459,7 +404,32 @@ List<Provider<RegularFile>> plugins = [
 task prepareBwcTests {
     dependsOn bundlePlugin
     doLast {
+        getPluginResource(bwc_js_resource_location, bwc_js_download_url)
+        getPluginResource(bwc_im_resource_location, bwc_im_download_url)
+        getPluginResource(job_scheduler_resource_folder, job_scheduler_build_download)
         plugins = [
+                provider(new Callable<RegularFile>(){
+                    @Override
+                    RegularFile call() throws Exception {
+                        return new RegularFile() {
+                            @Override
+                            File getAsFile() {
+                                return fileTree(bwc_js_resource_location).getSingleFile()
+                            }
+                        }
+                    }
+                }),
+                provider(new Callable<RegularFile>(){
+                    @Override
+                    RegularFile call() throws Exception {
+                        return new RegularFile() {
+                            @Override
+                            File getAsFile() {
+                                return fileTree(bwc_im_resource_location).getSingleFile()
+                            }
+                        }
+                    }
+                }),
                 provider(new Callable<RegularFile>(){
                     @Override
                     RegularFile call() throws Exception {
@@ -569,6 +539,7 @@ task "${baseName}#fullRestartClusterTask"(type: StandaloneRestIntegTestTask) {
 
 // A bwc test suite which runs all the bwc tasks combined
 task bwcTestSuite(type: StandaloneRestIntegTestTask) {
+    project.logger.lifecycle('bwcrun')
     exclude '**/*Test*'
     exclude '**/*IT*'
     dependsOn tasks.named("${baseName}#mixedClusterTask")

--- a/build.gradle
+++ b/build.gradle
@@ -378,15 +378,69 @@ String bwcFilePath = "src/test/resources/bwc/"
 String bwc_js_resource_location = bwcFilePath + "job-scheduler/" + bwcJobSchedulerVersion
 String bwc_im_resource_location = bwcFilePath + "indexmanagement/" + bwcVersion
 
-// Downloads the bwc job scheduler version
 String bwc_js_download_url = "https://github.com/opendistro-for-elasticsearch/job-scheduler/releases/download/v" +
         bwcJobSchedulerVersion + "/job-scheduler-artifacts.zip"
-getPluginResource(bwc_js_resource_location, bwc_js_download_url)
 
-// Downloads the bwc index management version
 String bwc_im_download_url = "https://github.com/opendistro-for-elasticsearch/index-management/releases/download/v" +
         bwcVersion + "/index-management-artifacts.zip"
-getPluginResource(bwc_im_resource_location, bwc_im_download_url)
+
+
+List<Provider<RegularFile>> plugins = [
+        provider(new Callable<RegularFile>(){
+            @Override
+            RegularFile call() throws Exception {
+                return new RegularFile() {
+                    @Override
+                    File getAsFile() {
+                        if (new File("$project.rootDir/$bwc_js_resource_location").exists()) {
+                            project.delete(files("$project.rootDir/$bwc_js_resource_location"))
+                        }
+                        project.mkdir bwc_js_resource_location
+                        ant.get(src: bwc_js_download_url,
+                                dest: bwc_js_resource_location,
+                                httpusecaches: false)
+                        return fileTree(bwc_js_resource_location).getSingleFile()
+                    }
+                }
+            }
+        }),
+        provider(new Callable<RegularFile>(){
+            @Override
+            RegularFile call() throws Exception {
+                return new RegularFile() {
+                    @Override
+                    File getAsFile() {
+                        if (new File("$project.rootDir/$bwc_im_resource_location").exists()) {
+                            project.delete(files("$project.rootDir/$bwc_im_resource_location"))
+                        }
+                        project.mkdir bwc_im_resource_location
+                        ant.get(src: bwc_im_download_url,
+                                dest: bwc_im_resource_location,
+                                httpusecaches: false)
+                        return fileTree(bwc_im_resource_location).getSingleFile()
+                    }
+                }
+            }
+        }),
+        provider(new Callable<RegularFile>(){
+            @Override
+            RegularFile call() throws Exception {
+                return new RegularFile() {
+                    @Override
+                    File getAsFile() {
+                        if (new File("$project.rootDir/$job_scheduler_resource_folder").exists()) {
+                            project.delete(files("$project.rootDir/$job_scheduler_resource_folder"))
+                        }
+                        project.mkdir job_scheduler_resource_folder
+                        ant.get(src: job_scheduler_build_download,
+                                dest: job_scheduler_resource_folder,
+                                httpusecaches: false)
+                        return fileTree(job_scheduler_resource_folder).getSingleFile()
+                    }
+                }
+            }
+        })
+    ]
 
 2.times {i ->
     testClusters {
@@ -423,7 +477,6 @@ getPluginResource(bwc_im_resource_location, bwc_im_download_url)
     }
 }
 
-List<Provider<RegularFile>> plugins = []
 
 // Ensure the artifact for the current project version is available to be used for the bwc tests
 

--- a/build.gradle
+++ b/build.gradle
@@ -266,10 +266,23 @@ testClusters.integTest {
             debugPort += 1
         }
     }
-    plugin(provider({
-        new RegularFile() {
-            @Override
-            File getAsFile() { fileTree(job_scheduler_resource_folder).getSingleFile() }
+
+    plugin(provider(new Callable<RegularFile>(){
+        @Override
+        RegularFile call() throws Exception {
+            return new RegularFile() {
+                @Override
+                File getAsFile() {
+                    if (new File("$project.rootDir/$job_scheduler_resource_folder").exists()) {
+                        project.delete(files("$project.rootDir/$job_scheduler_resource_folder"))
+                    }
+                    project.mkdir job_scheduler_resource_folder
+                    ant.get(src: job_scheduler_build_download,
+                            dest: job_scheduler_resource_folder,
+                            httpusecaches: false)
+                    return fileTree(job_scheduler_resource_folder).getSingleFile()
+                }
+            }
         }
     }))
 
@@ -295,8 +308,6 @@ integTest {
     // Tell the test JVM if the cluster JVM is running under a debugger so that tests can use longer timeouts for
     // requests. The 'doFirst' delays reading the debug setting on the cluster till execution time.
     doFirst {
-        // Download the job scheduler test dependency
-        getPluginResource(job_scheduler_resource_folder, job_scheduler_build_download)
         systemProperty 'cluster.debug', getDebug()
         // Set number of nodes system property to be used in tests
         systemProperty 'cluster.number_of_nodes', "${_numNodes}"

--- a/build.gradle
+++ b/build.gradle
@@ -430,6 +430,7 @@ List<Provider<RegularFile>> plugins = []
 task prepareBwcTests {
     dependsOn bundlePlugin
     doLast {
+        // Download the job scheduler test dependency
         getPluginResource(job_scheduler_resource_folder, job_scheduler_build_download)
         plugins = [
                 provider(new Callable<RegularFile>(){

--- a/build.gradle
+++ b/build.gradle
@@ -384,6 +384,17 @@ String bwc_js_download_url = "https://github.com/opendistro-for-elasticsearch/jo
 String bwc_im_download_url = "https://github.com/opendistro-for-elasticsearch/index-management/releases/download/v" +
         bwcVersion + "/index-management-artifacts.zip"
 
+2.times {i ->
+    testClusters {
+        "${baseName}$i" {
+            testDistribution = "ARCHIVE"
+            versions = ["7.10.2", opensearch_version]
+            numberOfNodes = 3
+            setting 'path.repo', "${buildDir}/cluster/shared/repo/${baseName}"
+            setting 'http.content_type.required', 'true'
+        }
+    }
+}
 
 List<Provider<RegularFile>> plugins = [
         provider(new Callable<RegularFile>(){
@@ -441,18 +452,6 @@ List<Provider<RegularFile>> plugins = [
             }
         })
     ]
-
-2.times {i ->
-    testClusters {
-        "${baseName}$i" {
-            testDistribution = "ARCHIVE"
-            versions = ["7.10.2", opensearch_version]
-            numberOfNodes = 3
-            setting 'path.repo', "${buildDir}/cluster/shared/repo/${baseName}"
-            setting 'http.content_type.required', 'true'
-        }
-    }
-}
 
 
 // Ensure the artifact for the current project version is available to be used for the bwc tests


### PR DESCRIPTION
Signed-off-by: Peter Zhu <zhujiaxi@amazon.com>

*Issue #, if available:*
#333

*Description of changes:*
Only download JS zip when integTest is running

*CheckList:*
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/index-management/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
