### PR TITLE
Refactors shrink action steps and adds unit tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ http
 .settings
 src/test/resources/job-scheduler/
 src/test/resources/bwc/
+src/test/resources/notifications-core/
+src/test/resources/notifications/

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/shrink/AttemptMoveShardsStep.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/shrink/AttemptMoveShardsStep.kt
@@ -57,6 +57,7 @@ import kotlin.math.sqrt
 @SuppressWarnings("TooManyFunctions")
 class AttemptMoveShardsStep(private val action: ShrinkAction) : ShrinkStep(name) {
 
+    @Suppress("ReturnCount")
     override suspend fun wrappedExecute(context: StepContext): AttemptMoveShardsStep {
         val client = context.client
         val indexName = context.metadata.index

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/shrink/AttemptMoveShardsStep.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/shrink/AttemptMoveShardsStep.kt
@@ -55,7 +55,7 @@ import kotlin.math.min
 import kotlin.math.sqrt
 
 @SuppressWarnings("TooManyFunctions")
-class AttemptMoveShardsStep(private val action: ShrinkAction) : ShrinkStep(name) {
+class AttemptMoveShardsStep(private val action: ShrinkAction) : ShrinkStep(name, false, false, false) {
 
     @Suppress("ReturnCount")
     override suspend fun wrappedExecute(context: StepContext): AttemptMoveShardsStep {
@@ -113,10 +113,6 @@ class AttemptMoveShardsStep(private val action: ShrinkAction) : ShrinkStep(name)
         info = mapOf("message" to getSuccessMessage(nodeName))
         stepStatus = StepStatus.COMPLETED
         return this
-    }
-
-    override suspend fun cleanupAndFail(infoMessage: String, logMessage: String?, cause: String?, e: Exception?) {
-        fail(infoMessage, logMessage, cause, e)
     }
 
     override fun getGenericFailureMessage(): String = FAILURE_MESSAGE

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/shrink/AttemptShrinkStep.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/shrink/AttemptShrinkStep.kt
@@ -22,9 +22,8 @@ import org.opensearch.indexmanagement.spi.indexstatemanagement.model.ManagedInde
 import org.opensearch.indexmanagement.spi.indexstatemanagement.model.ShrinkActionProperties
 import org.opensearch.indexmanagement.spi.indexstatemanagement.model.StepContext
 import org.opensearch.indexmanagement.spi.indexstatemanagement.model.StepMetaData
-import java.lang.Exception
 
-class AttemptShrinkStep(private val action: ShrinkAction) : ShrinkStep(name) {
+class AttemptShrinkStep(private val action: ShrinkAction) : ShrinkStep(name, true, true, false) {
 
     @Suppress("ReturnCount")
     override suspend fun wrappedExecute(context: StepContext): AttemptShrinkStep {
@@ -44,12 +43,6 @@ class AttemptShrinkStep(private val action: ShrinkAction) : ShrinkStep(name) {
         info = mapOf("message" to getSuccessMessage(localShrinkActionProperties.targetIndexName))
         stepStatus = StepStatus.COMPLETED
         return this
-    }
-
-    // Sets the action to failed, clears the readonly and allocation settings on the source index, and releases the shrink lock
-    override suspend fun cleanupAndFail(infoMessage: String, logMessage: String?, cause: String?, e: Exception?) {
-        cleanupResources(resetSettings = true, releaseLock = true, deleteTargetIndex = false)
-        fail(infoMessage, logMessage, cause, e)
     }
 
     override fun getGenericFailureMessage(): String = FAILURE_MESSAGE

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/shrink/AttemptShrinkStep.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/shrink/AttemptShrinkStep.kt
@@ -26,6 +26,7 @@ import java.lang.Exception
 
 class AttemptShrinkStep(private val action: ShrinkAction) : ShrinkStep(name) {
 
+    @Suppress("ReturnCount")
     override suspend fun wrappedExecute(context: StepContext): AttemptShrinkStep {
         val indexName = context.metadata.index
         // If the returned shrinkActionProperties are null, then the status has been set to failed, just return

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/shrink/ShrinkStep.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/shrink/ShrinkStep.kt
@@ -22,7 +22,12 @@ import org.opensearch.indexmanagement.spi.indexstatemanagement.model.ShrinkActio
 import org.opensearch.indexmanagement.spi.indexstatemanagement.model.StepContext
 import org.opensearch.transport.RemoteTransportException
 
-abstract class ShrinkStep(name: String) : Step(name) {
+abstract class ShrinkStep(
+    name: String,
+    private val cleanupSettings: Boolean,
+    private val cleanupLock: Boolean,
+    private val cleanupTargetIndex: Boolean
+) : Step(name) {
     protected val logger: Logger = LogManager.getLogger(javaClass)
     protected var stepStatus = StepStatus.STARTING
     protected var info: Map<String, Any>? = null
@@ -48,7 +53,10 @@ abstract class ShrinkStep(name: String) : Step(name) {
         return this
     }
 
-    abstract suspend fun cleanupAndFail(infoMessage: String, logMessage: String? = null, cause: String? = null, e: Exception? = null)
+    protected suspend fun cleanupAndFail(infoMessage: String, logMessage: String? = null, cause: String? = null, e: Exception? = null) {
+        cleanupResources(cleanupSettings, cleanupLock, cleanupTargetIndex)
+        fail(infoMessage, logMessage, cause, e)
+    }
 
     abstract fun getGenericFailureMessage(): String
 

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/shrink/ShrinkStep.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/shrink/ShrinkStep.kt
@@ -61,7 +61,6 @@ abstract class ShrinkStep(name: String) : Step(name) {
             cleanupAndFail(METADATA_FAILURE_MESSAGE, METADATA_FAILURE_MESSAGE)
             return null
         }
-        println("${localShrinkActionProperties.lockPrimaryTerm} ${localShrinkActionProperties.lockSeqNo}")
         val lock = renewShrinkLock(localShrinkActionProperties, context.lockService, logger)
         if (lock == null) {
             cleanupAndFail(
@@ -72,7 +71,6 @@ abstract class ShrinkStep(name: String) : Step(name) {
         }
         // After renewing the lock we need to update the primary term and sequence number
         localShrinkActionProperties = getUpdatedShrinkActionProperties(localShrinkActionProperties, lock)
-        println("${localShrinkActionProperties.lockPrimaryTerm} ${localShrinkActionProperties.lockSeqNo}")
         shrinkActionProperties = localShrinkActionProperties
         return localShrinkActionProperties
     }
@@ -143,7 +141,6 @@ abstract class ShrinkStep(name: String) : Step(name) {
         val lockService = context?.lockService
         try {
             if (lockService != null) {
-                println("Trying to release lock")
                 val released = releaseShrinkLock(shrinkActionProperties, lockService)
                 if (!released) logger.error("Failed to release Shrink action lock on node [${shrinkActionProperties.nodeName}]")
             } else {

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/shrink/ShrinkStep.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/shrink/ShrinkStep.kt
@@ -1,0 +1,103 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.indexmanagement.indexstatemanagement.step.shrink
+
+import org.apache.logging.log4j.LogManager
+import org.apache.logging.log4j.Logger
+import org.opensearch.action.admin.indices.delete.DeleteIndexRequest
+import org.opensearch.action.support.master.AcknowledgedResponse
+import org.opensearch.indexmanagement.indexstatemanagement.util.releaseShrinkLock
+import org.opensearch.indexmanagement.indexstatemanagement.util.resetReadOnlyAndRouting
+import org.opensearch.indexmanagement.opensearchapi.suspendUntil
+import org.opensearch.indexmanagement.spi.indexstatemanagement.Step
+import org.opensearch.indexmanagement.spi.indexstatemanagement.model.ShrinkActionProperties
+
+abstract class ShrinkStep(name: String) : Step(name) {
+    protected val logger: Logger = LogManager.getLogger(javaClass)
+    protected var stepStatus = StepStatus.STARTING
+    protected var info: Map<String, Any>? = null
+    protected var shrinkActionProperties: ShrinkActionProperties? = null
+
+    protected fun fail(infoMessage: String, logMessage: String? = null, cause: String? = null, e: Exception? = null) {
+        if (logMessage != null) {
+            if (e != null) {
+                logger.error(logMessage, e)
+            } else {
+                logger.error(logMessage)
+            }
+        }
+        info = if (cause == null) mapOf("message" to infoMessage) else mapOf("message" to infoMessage, "cause" to cause)
+        stepStatus = StepStatus.FAILED
+        shrinkActionProperties = null
+    }
+
+    protected suspend fun cleanupResources(resetSettings: Boolean, releaseLock: Boolean, deleteTargetIndex: Boolean) {
+        val shrinkActionProperties = context?.metadata?.actionMetaData?.actionProperties?.shrinkActionProperties
+        if (shrinkActionProperties != null) {
+            if (resetSettings) resetIndexSettings(shrinkActionProperties)
+            if (deleteTargetIndex) deleteTargetIndex(shrinkActionProperties)
+            if (releaseLock) releaseLock(shrinkActionProperties)
+        } else {
+            logger.error("Shrink action failed to clean up resources due to null shrink action properties.")
+        }
+    }
+
+    private suspend fun resetIndexSettings(shrinkActionProperties: ShrinkActionProperties) {
+        val originalIndexSettings = shrinkActionProperties.originalIndexSettings
+        val indexName = context?.metadata?.index
+        val client = context?.client
+        try {
+            if (indexName != null && client != null) {
+                val reset = resetReadOnlyAndRouting(indexName, client, originalIndexSettings)
+                if (!reset) logger.error("Shrink action failed to reset index settings on [$indexName]")
+            } else {
+                logger.error("Shrink action failed to reset index settings on [$indexName] due to uninitialized metadata values.")
+            }
+        } catch (e: Exception) {
+            logger.error("Shrink action failed while trying to clean up routing and readonly setting on [$indexName] due to failure: $e")
+        }
+    }
+
+    private suspend fun deleteTargetIndex(shrinkActionProperties: ShrinkActionProperties) {
+        val client = context?.client
+        val targetIndexName = shrinkActionProperties.targetIndexName
+        try {
+            if (client != null) {
+                // Use plugin level permissions when deleting the failed target shrink index after a failure
+                client.threadPool().threadContext.stashContext().use {
+                    val deleteRequest = DeleteIndexRequest(targetIndexName)
+                    val response: AcknowledgedResponse =
+                        client.admin().indices().suspendUntil { delete(deleteRequest, it) }
+                    if (!response.isAcknowledged) {
+                        logger.error("Shrink action failed to delete target index [$targetIndexName] during cleanup after a failure")
+                    }
+                }
+            } else {
+                logger.error("Shrink action failed to delete target index [$targetIndexName] after a failure due to a null client in the step context")
+            }
+        } catch (e: Exception) {
+            logger.error("Shrink action failed while trying to delete the target index [$targetIndexName] after a failure: $e")
+        }
+    }
+
+    private suspend fun releaseLock(shrinkActionProperties: ShrinkActionProperties) {
+        val lockService = context?.lockService
+        try {
+            if (lockService != null) {
+                val released = releaseShrinkLock(shrinkActionProperties, lockService)
+                if (!released) logger.error("Failed to release Shrink action lock on node [${shrinkActionProperties.nodeName}]")
+            } else {
+                logger.error("Shrink action failed to release lock on node [${shrinkActionProperties.nodeName}] due to uninitialized metadata values.")
+            }
+        } catch (e: Exception) {
+            logger.error("Failed to release Shrink action lock on node [${shrinkActionProperties.nodeName}]: $e")
+        }
+    }
+
+    companion object {
+        const val METADATA_FAILURE_MESSAGE = "Shrink action properties are null, metadata was not properly populated"
+    }
+}

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/shrink/ShrinkStep.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/shrink/ShrinkStep.kt
@@ -28,6 +28,7 @@ abstract class ShrinkStep(name: String) : Step(name) {
     protected var info: Map<String, Any>? = null
     protected var shrinkActionProperties: ShrinkActionProperties? = null
 
+    @Suppress("ReturnCount")
     override suspend fun execute(): Step {
         val context = this.context ?: return this
         try {
@@ -53,6 +54,7 @@ abstract class ShrinkStep(name: String) : Step(name) {
 
     abstract suspend fun wrappedExecute(context: StepContext): Step
 
+    @Suppress("ReturnCount")
     protected suspend fun updateAndGetShrinkActionProperties(context: StepContext): ShrinkActionProperties? {
         val actionMetadata = context.metadata.actionMetaData
         var localShrinkActionProperties = actionMetadata?.actionProperties?.shrinkActionProperties
@@ -115,6 +117,7 @@ abstract class ShrinkStep(name: String) : Step(name) {
         }
     }
 
+    @Suppress("NestedBlockDepth")
     private suspend fun deleteTargetIndex(shrinkActionProperties: ShrinkActionProperties) {
         val client = context?.client
         val targetIndexName = shrinkActionProperties.targetIndexName
@@ -130,7 +133,9 @@ abstract class ShrinkStep(name: String) : Step(name) {
                     }
                 }
             } else {
-                logger.error("Shrink action failed to delete target index [$targetIndexName] after a failure due to a null client in the step context")
+                logger.error(
+                    "Shrink action failed to delete target index [$targetIndexName] after a failure due to a null client in the step context"
+                )
             }
         } catch (e: Exception) {
             logger.error("Shrink action failed while trying to delete the target index [$targetIndexName] after a failure: $e")
@@ -144,7 +149,9 @@ abstract class ShrinkStep(name: String) : Step(name) {
                 val released = releaseShrinkLock(shrinkActionProperties, lockService)
                 if (!released) logger.error("Failed to release Shrink action lock on node [${shrinkActionProperties.nodeName}]")
             } else {
-                logger.error("Shrink action failed to release lock on node [${shrinkActionProperties.nodeName}] due to uninitialized metadata values.")
+                logger.error(
+                    "Shrink action failed to release lock on node [${shrinkActionProperties.nodeName}] due to uninitialized metadata values."
+                )
             }
         } catch (e: Exception) {
             logger.error("Failed to release Shrink action lock on node [${shrinkActionProperties.nodeName}]: $e")

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/shrink/WaitForMoveShardsStep.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/shrink/WaitForMoveShardsStep.kt
@@ -5,7 +5,6 @@
 
 package org.opensearch.indexmanagement.indexstatemanagement.step.shrink
 
-import org.apache.logging.log4j.LogManager
 import org.opensearch.ExceptionsHelper
 import org.opensearch.OpenSearchSecurityException
 import org.opensearch.action.admin.indices.stats.IndicesStatsRequest
@@ -13,16 +12,12 @@ import org.opensearch.action.admin.indices.stats.IndicesStatsResponse
 import org.opensearch.action.admin.indices.stats.ShardStats
 import org.opensearch.indexmanagement.indexstatemanagement.action.ShrinkAction
 import org.opensearch.indexmanagement.indexstatemanagement.action.ShrinkAction.Companion.getSecurityFailureMessage
-import org.opensearch.indexmanagement.indexstatemanagement.util.resetReadOnlyAndRouting
 import org.opensearch.indexmanagement.indexstatemanagement.util.getActionStartTime
-import org.opensearch.indexmanagement.indexstatemanagement.util.releaseShrinkLock
 import org.opensearch.indexmanagement.indexstatemanagement.util.renewShrinkLock
 import org.opensearch.indexmanagement.indexstatemanagement.util.getUpdatedShrinkActionProperties
 import org.opensearch.indexmanagement.opensearchapi.suspendUntil
-import org.opensearch.indexmanagement.spi.indexstatemanagement.Step
 import org.opensearch.indexmanagement.spi.indexstatemanagement.model.ActionProperties
 import org.opensearch.indexmanagement.spi.indexstatemanagement.model.ManagedIndexMetaData
-import org.opensearch.indexmanagement.spi.indexstatemanagement.model.ShrinkActionProperties
 import org.opensearch.indexmanagement.spi.indexstatemanagement.model.StepContext
 import org.opensearch.indexmanagement.spi.indexstatemanagement.model.StepMetaData
 import org.opensearch.transport.RemoteTransportException
@@ -30,11 +25,7 @@ import java.lang.Exception
 import java.time.Duration
 import java.time.Instant
 
-class WaitForMoveShardsStep(private val action: ShrinkAction) : Step(name) {
-    private val logger = LogManager.getLogger(javaClass)
-    private var stepStatus = StepStatus.STARTING
-    private var info: Map<String, Any>? = null
-    private var shrinkActionProperties: ShrinkActionProperties? = null
+class WaitForMoveShardsStep(private val action: ShrinkAction) : ShrinkStep(name) {
 
     @Suppress("TooGenericExceptionCaught", "ComplexMethod", "ReturnCount", "NestedBlockDepth")
     override suspend fun execute(): WaitForMoveShardsStep {
@@ -44,14 +35,15 @@ class WaitForMoveShardsStep(private val action: ShrinkAction) : Step(name) {
         val localShrinkActionProperties = actionMetadata?.actionProperties?.shrinkActionProperties
         shrinkActionProperties = localShrinkActionProperties
         if (localShrinkActionProperties == null) {
-            logger.error(METADATA_FAILURE_MESSAGE)
-            cleanupAndFail(METADATA_FAILURE_MESSAGE)
+            cleanupAndFail(METADATA_FAILURE_MESSAGE, METADATA_FAILURE_MESSAGE)
             return this
         }
         val lock = renewShrinkLock(localShrinkActionProperties, context.lockService, logger)
         if (lock == null) {
-            logger.error("Shrink action failed to renew lock on node [${localShrinkActionProperties.nodeName}]")
-            cleanupAndFail("Failed to renew lock on node [${localShrinkActionProperties.nodeName}]")
+            cleanupAndFail(
+                "Failed to renew lock on node [${localShrinkActionProperties.nodeName}]",
+                "Shrink action failed to renew lock on node [${localShrinkActionProperties.nodeName}]"
+            )
             return this
         }
         // After renewing the lock we need to update the primary term and sequence number
@@ -90,35 +82,23 @@ class WaitForMoveShardsStep(private val action: ShrinkAction) : Step(name) {
             }
             return this
         } catch (e: OpenSearchSecurityException) {
-            cleanupAndFail(getSecurityFailureMessage(e.localizedMessage), e.message, e)
+            val securityFailureMessage = getSecurityFailureMessage(e.localizedMessage)
+            cleanupAndFail(securityFailureMessage, securityFailureMessage, e.message, e)
             return this
         } catch (e: RemoteTransportException) {
             val unwrappedException = ExceptionsHelper.unwrapCause(e)
-            cleanupAndFail(FAILURE_MESSAGE, cause = e.message, e = unwrappedException as Exception)
+            cleanupAndFail(FAILURE_MESSAGE, FAILURE_MESSAGE, cause = e.message, e = unwrappedException as Exception)
             return this
         } catch (e: Exception) {
-            cleanupAndFail(FAILURE_MESSAGE, cause = e.message, e)
+            cleanupAndFail(FAILURE_MESSAGE, FAILURE_MESSAGE, cause = e.message, e)
             return this
         }
     }
 
     // Sets the action to failed, clears the readonly and allocation settings on the source index, and releases the shrink lock
-    private suspend fun cleanupAndFail(message: String, cause: String? = null, e: Exception? = null) {
-        e?.let { logger.error(message, e) }
-        info = if (cause == null) mapOf("message" to message) else mapOf("message" to message, "cause" to cause)
-        stepStatus = StepStatus.FAILED
-        // Non-null assertion !! is used to throw an exception on null which would just be caught and logged
-        try {
-            resetReadOnlyAndRouting(context!!.metadata.index, context!!.client, shrinkActionProperties!!.originalIndexSettings)
-        } catch (e: Exception) {
-            logger.error("Shrink action failed while trying to clean up routing and readonly setting after a failure: $e")
-        }
-        try {
-            releaseShrinkLock(shrinkActionProperties!!, context!!.lockService, logger)
-        } catch (e: Exception) {
-            logger.error("Shrink action failed while trying to release the node lock after a failure: $e")
-        }
-        shrinkActionProperties = null
+    private suspend fun cleanupAndFail(infoMessage: String, logMessage: String? = null, cause: String? = null, e: Exception? = null) {
+        cleanupResources(resetSettings = true, releaseLock = true, deleteTargetIndex = false)
+        fail(infoMessage, logMessage, cause, e)
     }
 
     override fun getUpdatedManagedIndexMetadata(currentMetadata: ManagedIndexMetaData): ManagedIndexMetaData {
@@ -146,11 +126,7 @@ class WaitForMoveShardsStep(private val action: ShrinkAction) : Step(name) {
         val timeOutInSeconds = action.configTimeout?.timeout?.seconds ?: MOVE_SHARDS_TIMEOUT_IN_SECONDS
         // Get ActionTimeout if given, otherwise use default timeout of 12 hours
         if (timeSinceActionStarted.toSeconds() > timeOutInSeconds) {
-            logger.error(
-                "Shrink Action move shards failed on [$indexName], the action timed out with [$numShardsNotOnNode] shards not yet " +
-                    "moved and [$numShardsNotInSync] shards without an in sync replica."
-            )
-            cleanupAndFail(getTimeoutFailure(nodeToMoveOnto))
+            cleanupAndFail(getTimeoutFailure(nodeToMoveOnto), getLoggedTimeoutError(indexName, numShardsNotOnNode, numShardsNotInSync))
         } else {
             logger.debug(
                 "Shrink action move shards step running on [$indexName], [$numShardsNotOnNode] shards need to be moved, " +
@@ -168,8 +144,9 @@ class WaitForMoveShardsStep(private val action: ShrinkAction) : Step(name) {
         fun getSuccessMessage(node: String) = "The shards successfully moved to $node."
         fun getTimeoutFailure(node: String) = "Shrink failed because it took too long to move shards to $node"
         fun getTimeoutDelay(node: String) = "Shrink delayed because it took too long to move shards to $node"
+        fun getLoggedTimeoutError(index: String, numShardsNotOnNode: Int, numShardsNotInSync: Int) = "Shrink Action move shards failed on [$index]," +
+            " the action timed out with [$numShardsNotOnNode] shards not yet moved and [$numShardsNotInSync] shards without an in sync replica."
         const val FAILURE_MESSAGE = "Shrink failed when waiting for shards to move."
-        const val METADATA_FAILURE_MESSAGE = "Shrink action properties are null, metadata was not properly populated"
         const val MOVE_SHARDS_TIMEOUT_IN_SECONDS = 43200L // 12hrs in seconds
     }
 }

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/shrink/WaitForMoveShardsStep.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/shrink/WaitForMoveShardsStep.kt
@@ -23,6 +23,7 @@ import java.time.Instant
 
 class WaitForMoveShardsStep(private val action: ShrinkAction) : ShrinkStep(name) {
 
+    @Suppress("ReturnCount")
     override suspend fun wrappedExecute(context: StepContext): WaitForMoveShardsStep {
         val indexName = context.metadata.index
         // If the returned shrinkActionProperties are null, then the status has been set to failed, just return
@@ -73,6 +74,7 @@ class WaitForMoveShardsStep(private val action: ShrinkAction) : ShrinkStep(name)
     }
 
     // Returns the number of shard IDs which have either a primary or replica on the target node
+    @Suppress("LoopWithTooManyJumpStatements")
     private fun getNumShardsWithCopyOnNode(shardStats: Array<ShardStats>, clusterState: ClusterState, nodeToMoveOnto: String): Int {
         val shardIdStartedOnNode: MutableMap<Int, Boolean> = mutableMapOf()
         for (shard in shardStats) {

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/shrink/WaitForMoveShardsStep.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/shrink/WaitForMoveShardsStep.kt
@@ -17,11 +17,10 @@ import org.opensearch.indexmanagement.spi.indexstatemanagement.model.ActionPrope
 import org.opensearch.indexmanagement.spi.indexstatemanagement.model.ManagedIndexMetaData
 import org.opensearch.indexmanagement.spi.indexstatemanagement.model.StepContext
 import org.opensearch.indexmanagement.spi.indexstatemanagement.model.StepMetaData
-import java.lang.Exception
 import java.time.Duration
 import java.time.Instant
 
-class WaitForMoveShardsStep(private val action: ShrinkAction) : ShrinkStep(name) {
+class WaitForMoveShardsStep(private val action: ShrinkAction) : ShrinkStep(name, true, true, false) {
 
     @Suppress("ReturnCount")
     override suspend fun wrappedExecute(context: StepContext): WaitForMoveShardsStep {
@@ -46,12 +45,6 @@ class WaitForMoveShardsStep(private val action: ShrinkAction) : ShrinkStep(name)
             checkTimeOut(context, numShardsNotOnNode, numShardsNotInSync, nodeToMoveOnto)
         }
         return this
-    }
-
-    // Sets the action to failed, clears the readonly and allocation settings on the source index, and releases the shrink lock
-    override suspend fun cleanupAndFail(infoMessage: String, logMessage: String?, cause: String?, e: Exception?) {
-        cleanupResources(resetSettings = true, releaseLock = true, deleteTargetIndex = false)
-        fail(infoMessage, logMessage, cause, e)
     }
 
     // Returns the number of shard IDs where all primary and replicas are in sync

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/shrink/WaitForMoveShardsStep.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/shrink/WaitForMoveShardsStep.kt
@@ -5,101 +5,100 @@
 
 package org.opensearch.indexmanagement.indexstatemanagement.step.shrink
 
-import org.opensearch.ExceptionsHelper
-import org.opensearch.OpenSearchSecurityException
 import org.opensearch.action.admin.indices.stats.IndicesStatsRequest
 import org.opensearch.action.admin.indices.stats.IndicesStatsResponse
 import org.opensearch.action.admin.indices.stats.ShardStats
+import org.opensearch.client.Client
+import org.opensearch.cluster.ClusterState
 import org.opensearch.indexmanagement.indexstatemanagement.action.ShrinkAction
-import org.opensearch.indexmanagement.indexstatemanagement.action.ShrinkAction.Companion.getSecurityFailureMessage
 import org.opensearch.indexmanagement.indexstatemanagement.util.getActionStartTime
-import org.opensearch.indexmanagement.indexstatemanagement.util.renewShrinkLock
-import org.opensearch.indexmanagement.indexstatemanagement.util.getUpdatedShrinkActionProperties
 import org.opensearch.indexmanagement.opensearchapi.suspendUntil
 import org.opensearch.indexmanagement.spi.indexstatemanagement.model.ActionProperties
 import org.opensearch.indexmanagement.spi.indexstatemanagement.model.ManagedIndexMetaData
 import org.opensearch.indexmanagement.spi.indexstatemanagement.model.StepContext
 import org.opensearch.indexmanagement.spi.indexstatemanagement.model.StepMetaData
-import org.opensearch.transport.RemoteTransportException
 import java.lang.Exception
 import java.time.Duration
 import java.time.Instant
 
 class WaitForMoveShardsStep(private val action: ShrinkAction) : ShrinkStep(name) {
 
-    @Suppress("TooGenericExceptionCaught", "ComplexMethod", "ReturnCount", "NestedBlockDepth")
-    override suspend fun execute(): WaitForMoveShardsStep {
-        val context = this.context ?: return this
+    override suspend fun wrappedExecute(context: StepContext): WaitForMoveShardsStep {
         val indexName = context.metadata.index
-        val actionMetadata = context.metadata.actionMetaData
-        val localShrinkActionProperties = actionMetadata?.actionProperties?.shrinkActionProperties
-        shrinkActionProperties = localShrinkActionProperties
-        if (localShrinkActionProperties == null) {
-            cleanupAndFail(METADATA_FAILURE_MESSAGE, METADATA_FAILURE_MESSAGE)
-            return this
+        // If the returned shrinkActionProperties are null, then the status has been set to failed, just return
+        val localShrinkActionProperties = updateAndGetShrinkActionProperties(context) ?: return this
+
+        val shardStats = getShardStats(indexName, context.client) ?: return this
+
+        val numShardsInSync = getNumShardsInSync(shardStats, context.clusterService.state(), indexName)
+        val nodeToMoveOnto = localShrinkActionProperties.nodeName
+        val numShardsOnNode = getNumShardsWithCopyOnNode(shardStats, context.clusterService.state(), nodeToMoveOnto)
+        val numPrimaryShards = context.clusterService.state().metadata.indices[indexName].numberOfShards
+
+        // If a copy of each shard is on the node, and all shards are in sync, move on
+        if (numShardsOnNode >= numPrimaryShards && numShardsInSync >= numPrimaryShards) {
+            info = mapOf("message" to getSuccessMessage(nodeToMoveOnto))
+            stepStatus = StepStatus.COMPLETED
+        } else {
+            val numShardsNotOnNode = numPrimaryShards - numShardsOnNode
+            val numShardsNotInSync = numPrimaryShards - numShardsInSync
+            checkTimeOut(context, numShardsNotOnNode, numShardsNotInSync, nodeToMoveOnto)
         }
-        val lock = renewShrinkLock(localShrinkActionProperties, context.lockService, logger)
-        if (lock == null) {
-            cleanupAndFail(
-                "Failed to renew lock on node [${localShrinkActionProperties.nodeName}]",
-                "Shrink action failed to renew lock on node [${localShrinkActionProperties.nodeName}]"
-            )
-            return this
-        }
-        // After renewing the lock we need to update the primary term and sequence number
-        shrinkActionProperties = getUpdatedShrinkActionProperties(localShrinkActionProperties, lock)
-        try {
-            val indexStatsRequests: IndicesStatsRequest = IndicesStatsRequest().indices(indexName)
-            val response: IndicesStatsResponse = context.client.admin().indices().suspendUntil { stats(indexStatsRequests, it) }
-            val numPrimaryShards = context.clusterService.state().metadata.indices[indexName].numberOfShards
-            val nodeToMoveOnto = localShrinkActionProperties.nodeName
-            val inSyncAllocations = context.clusterService.state().metadata.indices[indexName].inSyncAllocationIds
-            val numReplicas = context.clusterService.state().metadata.indices[indexName].numberOfReplicas
-            val shardIdOnNode: MutableMap<Int, Boolean> = mutableMapOf()
-            var numShardsInSync = 0
-            for (shard: ShardStats in response.shards) {
-                val routingInfo = shard.shardRouting
-                val nodeIdShardIsOn = routingInfo.currentNodeId()
-                val nodeNameShardIsOn = context.clusterService.state().nodes()[nodeIdShardIsOn].name
-                if (nodeNameShardIsOn.equals(nodeToMoveOnto) && routingInfo.started()) {
-                    shardIdOnNode[shard.shardRouting.id] = true
-                }
-                if (routingInfo.primary()) {
-                    // Either there must be no replicas (force unsafe must have been set) or all replicas must be in sync as
-                    // it isn't known which shard (any replica or primary) will be moved to the target node and used in the shrink.
-                    if (numReplicas == 0 || inSyncAllocations[routingInfo.id].size == (numReplicas + 1)) {
-                        numShardsInSync++
-                    }
-                }
-            }
-            if (shardIdOnNode.values.all { it } && numShardsInSync >= numPrimaryShards) {
-                info = mapOf("message" to getSuccessMessage(nodeToMoveOnto))
-                stepStatus = StepStatus.COMPLETED
-            } else {
-                val numShardsNotOnNode = shardIdOnNode.values.count { !it }
-                val numShardsNotInSync = numPrimaryShards - numShardsInSync
-                checkTimeOut(context, numShardsNotOnNode, numShardsNotInSync, nodeToMoveOnto)
-            }
-            return this
-        } catch (e: OpenSearchSecurityException) {
-            val securityFailureMessage = getSecurityFailureMessage(e.localizedMessage)
-            cleanupAndFail(securityFailureMessage, securityFailureMessage, e.message, e)
-            return this
-        } catch (e: RemoteTransportException) {
-            val unwrappedException = ExceptionsHelper.unwrapCause(e)
-            cleanupAndFail(FAILURE_MESSAGE, FAILURE_MESSAGE, cause = e.message, e = unwrappedException as Exception)
-            return this
-        } catch (e: Exception) {
-            cleanupAndFail(FAILURE_MESSAGE, FAILURE_MESSAGE, cause = e.message, e)
-            return this
-        }
+        return this
     }
 
     // Sets the action to failed, clears the readonly and allocation settings on the source index, and releases the shrink lock
-    private suspend fun cleanupAndFail(infoMessage: String, logMessage: String? = null, cause: String? = null, e: Exception? = null) {
+    override suspend fun cleanupAndFail(infoMessage: String, logMessage: String?, cause: String?, e: Exception?) {
         cleanupResources(resetSettings = true, releaseLock = true, deleteTargetIndex = false)
         fail(infoMessage, logMessage, cause, e)
     }
+
+    // Returns the number of shard IDs where all primary and replicas are in sync
+    private fun getNumShardsInSync(shardStats: Array<ShardStats>, state: ClusterState, indexName: String): Int {
+        val numReplicas = state.metadata.indices[indexName].numberOfReplicas
+        val inSyncAllocations = state.metadata.indices[indexName].inSyncAllocationIds
+        var numShardsInSync = 0
+        for (shard: ShardStats in shardStats) {
+            val routingInfo = shard.shardRouting
+            // Only check primaries so that we only check once for each shardID
+            if (routingInfo.primary()) {
+                // All shards must be in sync as it isn't known which shard (replica or primary) will be
+                // moved to the target node and used in the shrink.
+                if (inSyncAllocations[routingInfo.id].size == (numReplicas + 1)) {
+                    numShardsInSync++
+                }
+            }
+        }
+        return numShardsInSync
+    }
+
+    // Returns the number of shard IDs which have either a primary or replica on the target node
+    private fun getNumShardsWithCopyOnNode(shardStats: Array<ShardStats>, clusterState: ClusterState, nodeToMoveOnto: String): Int {
+        val shardIdStartedOnNode: MutableMap<Int, Boolean> = mutableMapOf()
+        for (shard in shardStats) {
+            val routingInfo = shard.shardRouting
+            val shardId = routingInfo.shardId().id
+            // If we have already confirmed a copy of the shard is on the node and started, move on
+            if (shardIdStartedOnNode[shardId] == true) continue
+            // If nodeName is null, then the nodes could have changed since the indicesStatsResponse, just skip adding it
+            val nodeName: String = clusterState.nodes[routingInfo.currentNodeId()].name ?: continue
+            shardIdStartedOnNode[shardId] = nodeName == nodeToMoveOnto && routingInfo.started()
+        }
+        return shardIdStartedOnNode.values.count { it }
+    }
+
+    private suspend fun getShardStats(indexName: String, client: Client): Array<ShardStats>? {
+        val indexStatsRequests: IndicesStatsRequest = IndicesStatsRequest().indices(indexName)
+        val response: IndicesStatsResponse = client.admin().indices().suspendUntil { stats(indexStatsRequests, it) }
+        val shardStats = response.shards
+        if (shardStats == null) {
+            fail(AttemptMoveShardsStep.FAILURE_MESSAGE, "Failed to move shards in shrink action as shard stats were null.")
+            return null
+        }
+        return shardStats
+    }
+
+    override fun getGenericFailureMessage(): String = FAILURE_MESSAGE
 
     override fun getUpdatedManagedIndexMetadata(currentMetadata: ManagedIndexMetaData): ManagedIndexMetaData {
         return currentMetadata.copy(

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/shrink/WaitForShrinkStep.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/shrink/WaitForShrinkStep.kt
@@ -5,97 +5,71 @@
 
 package org.opensearch.indexmanagement.indexstatemanagement.step.shrink
 
-import org.opensearch.ExceptionsHelper
-import org.opensearch.OpenSearchSecurityException
 import org.opensearch.action.admin.indices.stats.IndicesStatsRequest
 import org.opensearch.action.admin.indices.stats.IndicesStatsResponse
 import org.opensearch.action.support.master.AcknowledgedResponse
 import org.opensearch.client.Client
+import org.opensearch.cluster.service.ClusterService
 import org.opensearch.common.settings.Settings
 import org.opensearch.indexmanagement.indexstatemanagement.action.ShrinkAction
-import org.opensearch.indexmanagement.indexstatemanagement.action.ShrinkAction.Companion.getSecurityFailureMessage
 import org.opensearch.indexmanagement.indexstatemanagement.util.resetReadOnlyAndRouting
 import org.opensearch.indexmanagement.indexstatemanagement.util.deleteShrinkLock
 import org.opensearch.indexmanagement.indexstatemanagement.util.getActionStartTime
 import org.opensearch.indexmanagement.indexstatemanagement.util.issueUpdateSettingsRequest
-import org.opensearch.indexmanagement.indexstatemanagement.util.renewShrinkLock
-import org.opensearch.indexmanagement.indexstatemanagement.util.getUpdatedShrinkActionProperties
 import org.opensearch.indexmanagement.opensearchapi.suspendUntil
 import org.opensearch.indexmanagement.spi.indexstatemanagement.model.ActionProperties
 import org.opensearch.indexmanagement.spi.indexstatemanagement.model.ManagedIndexMetaData
 import org.opensearch.indexmanagement.spi.indexstatemanagement.model.StepContext
 import org.opensearch.indexmanagement.spi.indexstatemanagement.model.StepMetaData
-import org.opensearch.transport.RemoteTransportException
 import java.time.Duration
 import java.time.Instant
 
 class WaitForShrinkStep(private val action: ShrinkAction) : ShrinkStep(name) {
 
-    @Suppress("TooGenericExceptionCaught", "ComplexMethod", "ReturnCount", "LongMethod")
-    override suspend fun execute(): WaitForShrinkStep {
-        val context = this.context ?: return this
-        val actionMetadata = context.metadata.actionMetaData
-        val localShrinkActionProperties = actionMetadata?.actionProperties?.shrinkActionProperties
-        shrinkActionProperties = localShrinkActionProperties
-        if (localShrinkActionProperties == null) {
-            logger.error(METADATA_FAILURE_MESSAGE)
-            cleanupAndFail(METADATA_FAILURE_MESSAGE)
-            return this
-        }
-        val lock = renewShrinkLock(localShrinkActionProperties, context.lockService, logger)
-        if (lock == null) {
-            cleanupAndFail(
-                "Failed to renew lock on node [${localShrinkActionProperties.nodeName}]",
-                "Shrink action failed to renew lock on node [${localShrinkActionProperties.nodeName}]"
-            )
-            return this
-        }
-        shrinkActionProperties = getUpdatedShrinkActionProperties(localShrinkActionProperties, lock)
-        try {
-            val targetIndex = localShrinkActionProperties.targetIndexName
-            val numPrimaryShardsStarted = getNumPrimaryShardsStarted(context.client, targetIndex)
-            val numPrimaryShards = context.clusterService.state().metadata.indices[targetIndex].numberOfShards
-            val targetNumShards = localShrinkActionProperties.targetNumShards
-            if (numPrimaryShards != targetNumShards || numPrimaryShardsStarted != targetNumShards) {
-                checkTimeOut(context, targetIndex)
-                return this
-            }
+    override suspend fun wrappedExecute(context: StepContext): WaitForShrinkStep {
+        val indexName = context.metadata.index
+        // If the returned shrinkActionProperties are null, then the status has been set to failed, just return
+        val localShrinkActionProperties = updateAndGetShrinkActionProperties(context) ?: return this
 
-            // Clear source and target allocation, if either fails the step will be set to failed and the function will return false
-            if (!clearAllocationSettings(context, targetIndex)) return this
-            if (!resetReadOnlyAndRouting(context.metadata.index, context.client, localShrinkActionProperties.originalIndexSettings)) return this
-
-            deleteShrinkLock(localShrinkActionProperties, context.lockService, logger)
-            stepStatus = StepStatus.COMPLETED
-            info = mapOf("message" to SUCCESS_MESSAGE)
-            return this
-        } catch (e: OpenSearchSecurityException) {
-            val securityFailureMessage = getSecurityFailureMessage(e.localizedMessage)
-            cleanupAndFail(securityFailureMessage, securityFailureMessage, e.message, e)
-            return this
-        } catch (e: RemoteTransportException) {
-            val unwrappedException = ExceptionsHelper.unwrapCause(e)
-            cleanupAndFail(GENERIC_FAILURE_MESSAGE, GENERIC_FAILURE_MESSAGE, cause = e.message, e = unwrappedException as java.lang.Exception)
-            return this
-        } catch (e: Exception) {
-            cleanupAndFail(GENERIC_FAILURE_MESSAGE, GENERIC_FAILURE_MESSAGE, e.message, e)
+        val targetIndex = localShrinkActionProperties.targetIndexName
+        if (shrinkNotDone(targetIndex, localShrinkActionProperties.targetNumShards, context.client, context.clusterService)) {
+            checkTimeOut(context, targetIndex)
             return this
         }
+
+        // Clear source and target allocation, if either fails the step will be set to failed and the function will return false
+        if (!clearAllocationSettings(context, targetIndex)) return this
+        if (!resetReadOnlyAndRouting(indexName, context.client, localShrinkActionProperties.originalIndexSettings)) return this
+
+        deleteShrinkLock(localShrinkActionProperties, context.lockService, logger)
+        stepStatus = StepStatus.COMPLETED
+        info = mapOf("message" to SUCCESS_MESSAGE)
+        return this
     }
 
     // Sets the action to failed, clears the readonly and allocation settings on the source index, deletes the target index,
     // and releases the shrink lock
-    private suspend fun cleanupAndFail(infoMessage: String, logMessage: String? = null, cause: String? = null, e: Exception? = null) {
+    override suspend fun cleanupAndFail(infoMessage: String, logMessage: String?, cause: String?, e: Exception?) {
         cleanupResources(resetSettings = true, releaseLock = true, deleteTargetIndex = true)
         fail(infoMessage, logMessage, cause, e)
+    }
+
+    override fun getGenericFailureMessage(): String = GENERIC_FAILURE_MESSAGE
+
+    private suspend fun shrinkNotDone(targetIndex: String, targetNumShards: Int, client: Client, clusterService: ClusterService): Boolean {
+        val numPrimaryShardsStarted = getNumPrimaryShardsStarted(client, targetIndex)
+        val numPrimaryShards = clusterService.state().metadata.indices[targetIndex].numberOfShards
+        return numPrimaryShards != targetNumShards || numPrimaryShardsStarted != targetNumShards
     }
 
     private suspend fun clearAllocationSettings(context: StepContext, index: String): Boolean {
         val allocationSettings = Settings.builder().putNull(AttemptMoveShardsStep.ROUTING_SETTING).build()
         val response: AcknowledgedResponse = issueUpdateSettingsRequest(context.client, index, allocationSettings)
         if (!response.isAcknowledged) {
-            logger.error("Shrink action to clear the allocation settings on index [$index] following shrinking.")
-            cleanupAndFail(getFailureMessage(index))
+            cleanupAndFail(
+                getFailureMessage(index),
+                "Shrink action to clear the allocation settings on index [$index] following shrinking."
+            )
             return false
         }
         return true
@@ -113,8 +87,8 @@ class WaitForShrinkStep(private val action: ShrinkAction) : ShrinkStep(name) {
         val timeOutInSeconds = action.configTimeout?.timeout?.seconds ?: WaitForMoveShardsStep.MOVE_SHARDS_TIMEOUT_IN_SECONDS
         // Get ActionTimeout if given, otherwise use default timeout of 12 hours
         if (timeFromActionStarted.toSeconds() > timeOutInSeconds) {
-            logger.error(getTimeoutFailure(targetIndex))
-            cleanupAndFail(getTimeoutFailure(targetIndex))
+            val timeoutFailure = getTimeoutFailure(targetIndex)
+            cleanupAndFail(timeoutFailure, timeoutFailure)
         } else {
             info = mapOf("message" to getDelayedMessage(targetIndex))
             stepStatus = StepStatus.CONDITION_NOT_MET

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/shrink/WaitForShrinkStep.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/shrink/WaitForShrinkStep.kt
@@ -24,7 +24,7 @@ import org.opensearch.indexmanagement.spi.indexstatemanagement.model.StepMetaDat
 import java.time.Duration
 import java.time.Instant
 
-class WaitForShrinkStep(private val action: ShrinkAction) : ShrinkStep(name) {
+class WaitForShrinkStep(private val action: ShrinkAction) : ShrinkStep(name, true, true, true) {
 
     @Suppress("ReturnCount")
     override suspend fun wrappedExecute(context: StepContext): WaitForShrinkStep {
@@ -48,13 +48,6 @@ class WaitForShrinkStep(private val action: ShrinkAction) : ShrinkStep(name) {
         stepStatus = StepStatus.COMPLETED
         info = mapOf("message" to SUCCESS_MESSAGE)
         return this
-    }
-
-    // Sets the action to failed, clears the readonly and allocation settings on the source index, deletes the target index,
-    // and releases the shrink lock
-    override suspend fun cleanupAndFail(infoMessage: String, logMessage: String?, cause: String?, e: Exception?) {
-        cleanupResources(resetSettings = true, releaseLock = true, deleteTargetIndex = true)
-        fail(infoMessage, logMessage, cause, e)
     }
 
     override fun getGenericFailureMessage(): String = GENERIC_FAILURE_MESSAGE

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/shrink/WaitForShrinkStep.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/shrink/WaitForShrinkStep.kt
@@ -26,6 +26,7 @@ import java.time.Instant
 
 class WaitForShrinkStep(private val action: ShrinkAction) : ShrinkStep(name) {
 
+    @Suppress("ReturnCount")
     override suspend fun wrappedExecute(context: StepContext): WaitForShrinkStep {
         val indexName = context.metadata.index
         // If the returned shrinkActionProperties are null, then the status has been set to failed, just return

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/shrink/WaitForShrinkStep.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/shrink/WaitForShrinkStep.kt
@@ -41,7 +41,9 @@ class WaitForShrinkStep(private val action: ShrinkAction) : ShrinkStep(name) {
         if (!clearAllocationSettings(context, targetIndex)) return this
         if (!resetReadOnlyAndRouting(indexName, context.client, localShrinkActionProperties.originalIndexSettings)) return this
 
-        deleteShrinkLock(localShrinkActionProperties, context.lockService, logger)
+        if (!deleteShrinkLock(localShrinkActionProperties, context.lockService)) {
+            logger.error("Failed to delete Shrink action lock on node [${localShrinkActionProperties.nodeName}]")
+        }
         stepStatus = StepStatus.COMPLETED
         info = mapOf("message" to SUCCESS_MESSAGE)
         return this

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/util/StepUtils.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/util/StepUtils.kt
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+@file:Suppress("TooManyFunctions")
+
 package org.opensearch.indexmanagement.indexstatemanagement.util
 
 import org.apache.logging.log4j.Logger

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/util/StepUtils.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/util/StepUtils.kt
@@ -45,20 +45,15 @@ suspend fun releaseShrinkLock(
     lockService: LockService
 ): Boolean {
     val lock: LockModel = getShrinkLockModel(shrinkActionProperties)
-    println("Lock $lock, ${lock.lockId}, ${lock.isReleased}")
     return lockService.suspendUntil { release(lock, it) }
 }
 
 suspend fun deleteShrinkLock(
     shrinkActionProperties: ShrinkActionProperties,
-    lockService: LockService,
-    logger: Logger
-) {
+    lockService: LockService
+): Boolean {
     val lockID = getShrinkLockID(shrinkActionProperties.nodeName)
-    val deleted: Boolean = lockService.suspendUntil { deleteLock(lockID, it) }
-    if (!deleted) {
-        logger.error("Failed to delete Shrink action lock on node [${shrinkActionProperties.nodeName}]")
-    }
+    return lockService.suspendUntil { deleteLock(lockID, it) }
 }
 
 suspend fun renewShrinkLock(

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/util/StepUtils.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/util/StepUtils.kt
@@ -10,7 +10,7 @@ import org.opensearch.action.admin.cluster.health.ClusterHealthRequest
 import org.opensearch.action.admin.cluster.health.ClusterHealthResponse
 import org.opensearch.action.admin.cluster.node.stats.NodeStats
 import org.opensearch.action.admin.indices.settings.put.UpdateSettingsRequest
-import org.opensearch.action.admin.indices.stats.IndicesStatsResponse
+import org.opensearch.action.admin.indices.stats.ShardStats
 import org.opensearch.action.support.master.AcknowledgedResponse
 import org.opensearch.client.Client
 import org.opensearch.cluster.metadata.IndexMetadata
@@ -209,9 +209,9 @@ fun getShrinkLockID(nodeName: String): String {
 
 // Creates a map of shardIds to the set of node names which the shard copies reside on. For example, with 2 replicas
 // each shardId would have a set containing 3 node names, for the nodes of the primary and two replicas.
-fun getShardIdToNodeNameSet(indicesStatsResponse: IndicesStatsResponse, nodes: DiscoveryNodes): Map<Int, Set<String>> {
+fun getShardIdToNodeNameSet(shardStats: Array<ShardStats>, nodes: DiscoveryNodes): Map<Int, Set<String>> {
     val shardIdToNodeList: MutableMap<Int, MutableSet<String>> = mutableMapOf()
-    for (shard in indicesStatsResponse.shards) {
+    for (shard in shardStats) {
         val shardId = shard.shardRouting.shardId().id
         // If nodeName is null, then the nodes could have changed since the indicesStatsResponse, just skip adding it
         val nodeName: String = nodes[shard.shardRouting.currentNodeId()].name ?: continue

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/util/StepUtils.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/util/StepUtils.kt
@@ -45,6 +45,7 @@ suspend fun releaseShrinkLock(
     lockService: LockService
 ): Boolean {
     val lock: LockModel = getShrinkLockModel(shrinkActionProperties)
+    println("Lock $lock, ${lock.lockId}, ${lock.isReleased}")
     return lockService.suspendUntil { release(lock, it) }
 }
 

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/util/StepUtils.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/util/StepUtils.kt
@@ -42,14 +42,10 @@ suspend fun issueUpdateSettingsRequest(client: Client, indexName: String, settin
 
 suspend fun releaseShrinkLock(
     shrinkActionProperties: ShrinkActionProperties,
-    lockService: LockService,
-    logger: Logger
-) {
+    lockService: LockService
+): Boolean {
     val lock: LockModel = getShrinkLockModel(shrinkActionProperties)
-    val released: Boolean = lockService.suspendUntil { release(lock, it) }
-    if (!released) {
-        logger.error("Failed to release Shrink action lock on node [${shrinkActionProperties.nodeName}]")
-    }
+    return lockService.suspendUntil { release(lock, it) }
 }
 
 suspend fun deleteShrinkLock(

--- a/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/util/StepUtilsTests.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/util/StepUtilsTests.kt
@@ -1,0 +1,137 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.indexmanagement.indexstatemanagement.util
+
+import com.nhaarman.mockitokotlin2.mock
+import org.mockito.Mockito
+import org.opensearch.action.admin.cluster.node.stats.NodeStats
+import org.opensearch.cluster.routing.allocation.DiskThresholdSettings
+import org.opensearch.common.settings.ClusterSettings
+import org.opensearch.common.settings.Settings
+import org.opensearch.common.unit.ByteSizeValue
+import org.opensearch.indexmanagement.IndexManagementPlugin.Companion.INDEX_MANAGEMENT_INDEX
+import org.opensearch.indexmanagement.indexstatemanagement.randomByteSizeValue
+import org.opensearch.indexmanagement.randomInstant
+import org.opensearch.indexmanagement.spi.indexstatemanagement.model.ActionMetaData
+import org.opensearch.indexmanagement.spi.indexstatemanagement.model.ManagedIndexMetaData
+import org.opensearch.indexmanagement.spi.indexstatemanagement.model.ShrinkActionProperties
+import org.opensearch.jobscheduler.spi.LockModel
+import org.opensearch.monitor.os.OsStats
+import org.opensearch.test.OpenSearchTestCase
+
+class StepUtilsTests : OpenSearchTestCase() {
+
+    fun `test get shrink lock model`() {
+        val shrinkActionProperties = ShrinkActionProperties(
+            randomAlphaOfLength(10),
+            randomAlphaOfLength(10),
+            randomInt(),
+            randomNonNegativeLong(),
+            randomNonNegativeLong(),
+            randomInstant().toEpochMilli(),
+            randomInstant().toEpochMilli(),
+            mapOf()
+        )
+        val lockModel = getShrinkLockModel(shrinkActionProperties)
+        assertEquals("Incorrect lock model job index name", INDEX_MANAGEMENT_INDEX, lockModel.jobIndexName)
+        assertEquals("Incorrect lock model jobID", getShrinkLockID(shrinkActionProperties.nodeName), lockModel.jobId)
+        assertEquals("Incorrect lock model duration", shrinkActionProperties.lockDurationSecond, lockModel.lockDurationSeconds)
+        assertEquals("Incorrect lock model lockID", "${lockModel.jobIndexName}-${lockModel.jobId}", lockModel.lockId)
+        assertEquals("Incorrect lock model sequence number", shrinkActionProperties.lockSeqNo, lockModel.seqNo)
+        assertEquals("Incorrect lock model primary term", shrinkActionProperties.lockPrimaryTerm, lockModel.primaryTerm)
+        assertEquals("Lock should not be expired when created", false, lockModel.isExpired)
+        assertEquals("Lock should not be released when created", false, lockModel.isReleased)
+    }
+
+    fun `test get updated shrink action properties`() {
+        val shrinkActionProperties = ShrinkActionProperties(
+            randomAlphaOfLength(10),
+            randomAlphaOfLength(10),
+            randomInt(),
+            randomNonNegativeLong(),
+            randomNonNegativeLong(),
+            randomInstant().toEpochMilli(),
+            randomInstant().toEpochMilli(),
+            mapOf()
+        )
+        val lockModel = LockModel(
+            randomAlphaOfLength(10),
+            getShrinkLockID(shrinkActionProperties.nodeName),
+            randomInstant(),
+            randomInstant().toEpochMilli(),
+            false,
+            randomNonNegativeLong(),
+            randomNonNegativeLong()
+        )
+        val updatedProperties = getUpdatedShrinkActionProperties(shrinkActionProperties, lockModel)
+
+        assertEquals("Node name should not have updated", updatedProperties.nodeName, shrinkActionProperties.nodeName)
+        assertEquals("Index name should not have updated", updatedProperties.targetIndexName, shrinkActionProperties.targetIndexName)
+        assertEquals("Num shards should not have updated", updatedProperties.targetNumShards, shrinkActionProperties.targetNumShards)
+        assertEquals("Settings should not have updated", updatedProperties.originalIndexSettings, shrinkActionProperties.originalIndexSettings)
+        assertEquals("Lock sequence number should have updated", updatedProperties.lockSeqNo, lockModel.seqNo)
+        assertEquals("Lock primary term should have updated", updatedProperties.lockPrimaryTerm, lockModel.primaryTerm)
+        assertEquals("Lock epoch time should have updated", updatedProperties.lockEpochSecond, lockModel.lockTime.epochSecond)
+        assertEquals("Lock duration should have updated", updatedProperties.lockDurationSecond, lockModel.lockDurationSeconds)
+    }
+
+    fun `test get action start time`() {
+        val metadata = ManagedIndexMetaData(
+            "indexName", "indexUuid", "policy_id", null, null, null, null, null, null, null,
+            ActionMetaData("name", randomInstant().toEpochMilli(), 0, false, 0, null, null), null, null, null
+        )
+        assertEquals("Action start time was not extracted correctly", metadata.actionMetaData?.startTime, getActionStartTime(metadata).toEpochMilli())
+    }
+
+    fun `test get free bytes threshold high`() {
+        val settings = Settings.builder()
+        val nodeBytes = randomByteSizeValue().bytes
+        val expected: Long = if (randomBoolean()) {
+            val bytes = randomLongBetween(10, 100000000)
+            val highDisk = ByteSizeValue(bytes).stringRep
+            val lowDisk = ByteSizeValue(bytes + 1).stringRep
+            val floodDisk = ByteSizeValue(bytes - 1).stringRep
+            settings.put(DiskThresholdSettings.CLUSTER_ROUTING_ALLOCATION_HIGH_DISK_WATERMARK_SETTING.key, highDisk)
+            settings.put(DiskThresholdSettings.CLUSTER_ROUTING_ALLOCATION_LOW_DISK_WATERMARK_SETTING.key, lowDisk)
+            settings.put(DiskThresholdSettings.CLUSTER_ROUTING_ALLOCATION_DISK_FLOOD_STAGE_WATERMARK_SETTING.key, floodDisk)
+            bytes
+        } else {
+            val percentage = randomDoubleBetween(0.005, 0.995, false)
+            settings.put(DiskThresholdSettings.CLUSTER_ROUTING_ALLOCATION_HIGH_DISK_WATERMARK_SETTING.key, "${percentage * 100}%")
+            settings.put(DiskThresholdSettings.CLUSTER_ROUTING_ALLOCATION_LOW_DISK_WATERMARK_SETTING.key, "${(percentage - 0.001) * 100}%")
+            settings.put(DiskThresholdSettings.CLUSTER_ROUTING_ALLOCATION_DISK_FLOOD_STAGE_WATERMARK_SETTING.key, "${(percentage + 0.001) * 100}%")
+            (nodeBytes * (1 - percentage)).toLong()
+        }
+        val clusterSettings = ClusterSettings(settings.build(), ClusterSettings.BUILT_IN_CLUSTER_SETTINGS)
+        val thresholdHigh = getFreeBytesThresholdHigh(clusterSettings, nodeBytes)
+        assertEquals(expected, thresholdHigh)
+    }
+
+    fun `test free memory after shrink`() {
+        val nodeStats: NodeStats = mock()
+        val osStats: OsStats = mock()
+        Mockito.`when`(nodeStats.os).thenReturn(osStats)
+        val memStats: OsStats.Mem = mock()
+        Mockito.`when`(osStats.mem).thenReturn(memStats)
+        val totalBytes = randomNonNegativeLong()
+        val freeBytes = randomLongBetween(0, totalBytes)
+        val indexSize = randomLongBetween(0, totalBytes / 2)
+        val threshold = randomLongBetween(0, totalBytes / 2)
+        Mockito.`when`(memStats.free).thenReturn(ByteSizeValue(freeBytes))
+        Mockito.`when`(memStats.total).thenReturn(ByteSizeValue(totalBytes))
+        val settings = Settings.builder()
+            .put(DiskThresholdSettings.CLUSTER_ROUTING_ALLOCATION_HIGH_DISK_WATERMARK_SETTING.key, ByteSizeValue(threshold).stringRep)
+            .put(DiskThresholdSettings.CLUSTER_ROUTING_ALLOCATION_LOW_DISK_WATERMARK_SETTING.key, ByteSizeValue(threshold + 1).stringRep)
+            .put(DiskThresholdSettings.CLUSTER_ROUTING_ALLOCATION_DISK_FLOOD_STAGE_WATERMARK_SETTING.key, ByteSizeValue(threshold - 1).stringRep)
+        val clusterSettings = ClusterSettings(settings.build(), ClusterSettings.BUILT_IN_CLUSTER_SETTINGS)
+        val remainingSpace = freeBytes - ((2 * indexSize) + threshold)
+        if (remainingSpace > 0) {
+            assertEquals(remainingSpace, getNodeFreeMemoryAfterShrink(nodeStats, indexSize, clusterSettings))
+        } else {
+            assertEquals(-1L, getNodeFreeMemoryAfterShrink(nodeStats, indexSize, clusterSettings))
+        }
+    }
+}

--- a/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/util/StepUtilsTests.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/util/StepUtilsTests.kt
@@ -116,7 +116,7 @@ class StepUtilsTests : OpenSearchTestCase() {
         Mockito.`when`(nodeStats.os).thenReturn(osStats)
         val memStats: OsStats.Mem = mock()
         Mockito.`when`(osStats.mem).thenReturn(memStats)
-        val totalBytes = randomNonNegativeLong()
+        val totalBytes = randomLongBetween(10, 100000000)
         val freeBytes = randomLongBetween(0, totalBytes)
         val indexSize = randomLongBetween(0, totalBytes / 2)
         val threshold = randomLongBetween(0, totalBytes / 2)


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/opensearch-project/index-management/issues/40

*Description of changes:*
Adds additional unit tests for the shrink action step util functions and refactors the shrink action steps for readability and reduced code duplication. Also fixes a bug where the shrink action would not wait for a copy of each shard to move to the selected node before initiating the shrink.

*CheckList:*
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/index-management/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
