### PR TITLE
Removes rc1 qualifier

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,9 +14,9 @@ import java.util.function.Predicate
 buildscript {
     ext {
         isSnapshot = "true" == System.getProperty("build.snapshot", "true")
-        opensearch_version = System.getProperty("opensearch.version", "2.0.0-rc1-SNAPSHOT")
-        buildVersionQualifier = System.getProperty("build.version_qualifier", "rc1")
-        // 2.0.0-rc1-SNAPSHOT -> 2.0.0.0-rc1-SNAPSHOT
+        opensearch_version = System.getProperty("opensearch.version", "2.0.0-SNAPSHOT")
+        buildVersionQualifier = System.getProperty("build.version_qualifier", "")
+        // 2.0.0-SNAPSHOT -> 2.0.0.0-SNAPSHOT
         version_tokens = opensearch_version.tokenize('-')
         opensearch_build = version_tokens[0] + '.0'
         job_scheduler_no_snapshot = opensearch_build

--- a/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/model/ActionTests.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/model/ActionTests.kt
@@ -46,6 +46,7 @@ import org.opensearch.indexmanagement.spi.indexstatemanagement.model.ActionTimeo
 import org.opensearch.test.OpenSearchTestCase
 import java.io.ByteArrayInputStream
 import java.io.ByteArrayOutputStream
+import java.lang.Math.abs
 import kotlin.test.assertFailsWith
 
 class ActionTests : OpenSearchTestCase() {
@@ -191,7 +192,9 @@ class ActionTests : OpenSearchTestCase() {
         val totalNodeBytes = randomByteSizeValue().bytes
         val thresholdBytes = getFreeBytesThresholdHigh(clusterSettings, totalNodeBytes)
         val expectedThreshold: Long = ((1 - (rawPercentage.toDouble() / 100.0)) * totalNodeBytes).toLong()
-        assertEquals("Free bytes threshold not being calculated correctly for percentage setting.", thresholdBytes, expectedThreshold)
+        // To account for some rounding issues, allow an error of 1
+        val approximatelyEqual = kotlin.math.abs(thresholdBytes - expectedThreshold) <= 1
+        assertTrue("Free bytes threshold not being calculated correctly for percentage setting.", approximatelyEqual)
     }
 
     fun `test shrink disk threshold byte settings`() {


### PR DESCRIPTION
Signed-off-by: Clay Downs <downsrob@amazon.com>

*Issue #, if available:*
https://github.com/opensearch-project/index-management/issues/351

*Description of changes:*
Removes rc1 qualifier as we move from the 2.0 rc1 release to the 2.0 GA release
*CheckList:*
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/index-management/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
