### PR TITLE
Strengthen scroll search in Coordinator

### DIFF
--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/ManagedIndexCoordinator.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/ManagedIndexCoordinator.kt
@@ -633,28 +633,47 @@ class ManagedIndexCoordinator(
     suspend fun sweepManagedIndexJobs(client: Client): List<String> {
         val managedIndexUuids = mutableListOf<String>()
 
-        val managedIndexSearchRequest = getSweptManagedIndexSearchRequest()
-        var response: SearchResponse = client.suspendUntil { search(managedIndexSearchRequest, it) }
-        var uuids = response.hits.map { it.id }
-        val scrollIDsToClear = mutableSetOf<String>()
+        // if # of documents below 10k, don't use scroll search
+        val countReq = getSweptManagedIndexSearchRequest(size = 0)
+        val countRes: SearchResponse = client.suspendUntil { search(countReq, it) }
+        val totalHits = countRes.hits.totalHits ?: return managedIndexUuids
 
-        while (uuids.isNotEmpty()) {
-            managedIndexUuids.addAll(uuids)
-            val scrollID = response.scrollId
-            scrollIDsToClear.add(scrollID)
-            val scrollRequest = SearchScrollRequest().scrollId(scrollID).scroll(TimeValue.timeValueMinutes(1))
-            response = client.suspendUntil { searchScroll(scrollRequest, it) }
-            uuids = response.hits.map { it.id }
+        if (totalHits.value >= MAX_HITS) {
+            val managedIndexSearchRequest = getSweptManagedIndexSearchRequest(scroll = true)
+            var response: SearchResponse = client.suspendUntil { search(managedIndexSearchRequest, it) }
+            var uuids = transformManagedIndexSearchRes(response)
+            val scrollIDsToClear = mutableSetOf<String>()
+
+            while (uuids.isNotEmpty()) {
+                managedIndexUuids.addAll(uuids)
+                val scrollID = response.scrollId
+                scrollIDsToClear.add(scrollID)
+                val scrollRequest = SearchScrollRequest().scrollId(scrollID).scroll(TimeValue.timeValueMinutes(1))
+                response = client.suspendUntil { searchScroll(scrollRequest, it) }
+                uuids = transformManagedIndexSearchRes(response)
+            }
+
+            if (scrollIDsToClear.isNotEmpty()) {
+                val clearScrollRequest = ClearScrollRequest()
+                clearScrollRequest.scrollIds(scrollIDsToClear.toList())
+                val clearScrollResponse: ClearScrollResponse =
+                    client.suspendUntil { execute(ClearScrollAction.INSTANCE, clearScrollRequest, it) }
+            }
+            return managedIndexUuids
         }
 
-        if (scrollIDsToClear.isNotEmpty()) {
-            val clearScrollRequest = ClearScrollRequest()
-            clearScrollRequest.scrollIds(scrollIDsToClear.toList())
-            val clearScrollResponse: ClearScrollResponse =
-                client.suspendUntil { execute(ClearScrollAction.INSTANCE, clearScrollRequest, it) }
-        }
+        val response: SearchResponse = client.suspendUntil { search(getSweptManagedIndexSearchRequest(), it) }
+        return transformManagedIndexSearchRes(response)
+    }
 
-        return managedIndexUuids
+    fun transformManagedIndexSearchRes(response: SearchResponse): List<String> {
+        if (response.isTimedOut || response.failedShards > 0 || response.skippedShards > 0) {
+            throw Exception(
+                "Sweep managed indices failed. Timed out: ${response.isTimedOut} | " +
+                    "Failed shards: ${response.failedShards} | Skipped shards: ${response.skippedShards}."
+            )
+        }
+        return response.hits.map { it.id }
     }
 
     /**

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/ManagedIndexCoordinator.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/ManagedIndexCoordinator.kt
@@ -639,25 +639,27 @@ class ManagedIndexCoordinator(
         val totalHits = countRes.hits.totalHits ?: return managedIndexUuids
 
         if (totalHits.value >= MAX_HITS) {
-            val managedIndexSearchRequest = getSweptManagedIndexSearchRequest(scroll = true)
-            var response: SearchResponse = client.suspendUntil { search(managedIndexSearchRequest, it) }
-            var uuids = transformManagedIndexSearchRes(response)
             val scrollIDsToClear = mutableSetOf<String>()
+            try {
+                val managedIndexSearchRequest = getSweptManagedIndexSearchRequest(scroll = true)
+                var response: SearchResponse = client.suspendUntil { search(managedIndexSearchRequest, it) }
+                var uuids = transformManagedIndexSearchRes(response)
 
-            while (uuids.isNotEmpty()) {
-                managedIndexUuids.addAll(uuids)
-                val scrollID = response.scrollId
-                scrollIDsToClear.add(scrollID)
-                val scrollRequest = SearchScrollRequest().scrollId(scrollID).scroll(TimeValue.timeValueMinutes(1))
-                response = client.suspendUntil { searchScroll(scrollRequest, it) }
-                uuids = transformManagedIndexSearchRes(response)
-            }
-
-            if (scrollIDsToClear.isNotEmpty()) {
-                val clearScrollRequest = ClearScrollRequest()
-                clearScrollRequest.scrollIds(scrollIDsToClear.toList())
-                val clearScrollResponse: ClearScrollResponse =
-                    client.suspendUntil { execute(ClearScrollAction.INSTANCE, clearScrollRequest, it) }
+                while (uuids.isNotEmpty()) {
+                    managedIndexUuids.addAll(uuids)
+                    val scrollID = response.scrollId
+                    scrollIDsToClear.add(scrollID)
+                    val scrollRequest = SearchScrollRequest().scrollId(scrollID).scroll(TimeValue.timeValueMinutes(1))
+                    response = client.suspendUntil { searchScroll(scrollRequest, it) }
+                    uuids = transformManagedIndexSearchRes(response)
+                }
+            } finally {
+                if (scrollIDsToClear.isNotEmpty()) {
+                    val clearScrollRequest = ClearScrollRequest()
+                    clearScrollRequest.scrollIds(scrollIDsToClear.toList())
+                    val clearScrollResponse: ClearScrollResponse =
+                        client.suspendUntil { execute(ClearScrollAction.INSTANCE, clearScrollRequest, it) }
+                }
             }
             return managedIndexUuids
         }
@@ -668,10 +670,10 @@ class ManagedIndexCoordinator(
 
     fun transformManagedIndexSearchRes(response: SearchResponse): List<String> {
         if (response.isTimedOut || response.failedShards > 0 || response.skippedShards > 0) {
-            throw Exception(
-                "Sweep managed indices failed. Timed out: ${response.isTimedOut} | " +
-                    "Failed shards: ${response.failedShards} | Skipped shards: ${response.skippedShards}."
-            )
+            val errorMsg = "Sweep managed indices failed. Timed out: ${response.isTimedOut} | " +
+                "Failed shards: ${response.failedShards} | Skipped shards: ${response.skippedShards}."
+            logger.error(errorMsg)
+            throw ISMCoordinatorSearchException(message = errorMsg)
         }
         return response.hits.map { it.id }
     }
@@ -755,3 +757,5 @@ class ManagedIndexCoordinator(
         const val BUFFER = 20L
     }
 }
+
+class ISMCoordinatorSearchException(message: String, cause: Throwable? = null) : Exception(message, cause)

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/util/ManagedIndexUtils.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/util/ManagedIndexUtils.kt
@@ -196,15 +196,7 @@ fun getSweptManagedIndexSearchRequest(scroll: Boolean = false, size: Int = Manag
             SearchSourceBuilder.searchSource()
                 .size(size)
                 .seqNoAndPrimaryTerm(true)
-                .fetchSource(
-                    arrayOf(
-                        "${ManagedIndexConfig.MANAGED_INDEX_TYPE}.${ManagedIndexConfig.INDEX_FIELD}",
-                        "${ManagedIndexConfig.MANAGED_INDEX_TYPE}.${ManagedIndexConfig.INDEX_UUID_FIELD}",
-                        "${ManagedIndexConfig.MANAGED_INDEX_TYPE}.${ManagedIndexConfig.POLICY_ID_FIELD}",
-                        "${ManagedIndexConfig.MANAGED_INDEX_TYPE}.${ManagedIndexConfig.CHANGE_POLICY_FIELD}"
-                    ),
-                    emptyArray()
-                )
+                .fetchSource(emptyArray(), emptyArray())
                 .query(boolQueryBuilder)
         )
     if (scroll) req.scroll(TimeValue.timeValueMinutes(1))


### PR DESCRIPTION
Signed-off-by: bowenlan-amzn <bowenlan23@gmail.com>

*Issue #, if available:*

*Description of changes:*

Normally user won't have >10k ISM jobs, so we don't want to use scroll search every time.

For getting accurate total hits, there's a param [`track_total_hits`](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-your-data.html#track-total-hits), just keep a note here.

*CheckList:*
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/index-management/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
