### PR TITLE
Adds workflow to create documentation issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/documentation.md
+++ b/.github/ISSUE_TEMPLATE/documentation.md
@@ -1,15 +1,11 @@
 **Is your feature request related to a problem?**
-
-_A clear and concise description of what the problem is, e.g. I'm always frustrated when [...]._
+A new feature has been added.
 
 **What solution would you like?**
-
-_A clear and concise description of what you want to happen._
+Document the usage of the new feature.
 
 **What alternatives have you considered?**
-
-_A clear and concise description of any alternative solutions or features you've considered._
+N/A
 
 **Do you have any additional context?**
-
 _Add any other context or screenshots about the feature request here._

--- a/.github/ISSUE_TEMPLATE/documentation.md
+++ b/.github/ISSUE_TEMPLATE/documentation.md
@@ -1,0 +1,15 @@
+**Is your feature request related to a problem?**
+
+_A clear and concise description of what the problem is, e.g. I'm always frustrated when [...]._
+
+**What solution would you like?**
+
+_A clear and concise description of what you want to happen._
+
+**What alternatives have you considered?**
+
+_A clear and concise description of any alternative solutions or features you've considered._
+
+**Do you have any additional context?**
+
+_Add any other context or screenshots about the feature request here._

--- a/.github/workflows/create-documentation-issue.yml
+++ b/.github/workflows/create-documentation-issue.yml
@@ -1,0 +1,41 @@
+name: Create Documentation Issue
+on:
+  pull_request:
+    types:
+      - labeled
+env:
+  PR_NUMBER: ${{ github.event.number }}
+
+jobs:
+  create-issue:
+    if: ${{ github.event.label.name == 'needs-documentation' }}
+    runs-on: ubuntu-latest
+    name: Create Documentation Issue
+    steps:
+      - name: GitHub App token
+        id: github_app_token
+        uses: tibdex/github-app-token@v1.5.0
+        with:
+          app_id: ${{ secrets.APP_ID }}
+          private_key: ${{ secrets.APP_PRIVATE_KEY }}
+          installation_id: 22958780
+
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Edit the issue template
+        run: |
+          echo "https://github.com/opensearch-project/index-management/pull/${{ env.PR_NUMBER }}." >> ./.github/ISSUE_TEMPLATE/documentation.md
+
+      - name: Create Issue From File
+        id: create-issue
+        uses: peter-evans/create-issue-from-file@v4
+        with:
+          title: Add documentation related to new feature
+          content-filepath: ./.github/ISSUE_TEMPLATE/documentation.md
+          labels: documentation
+          repository: opensearch-project/documentation-website
+          token: ${{ steps.github_app_token.outputs.token }}
+
+      - name: Print Issue
+        run: echo Created related documentation issue ${{ steps.create-issue.outputs.issue-number }}


### PR DESCRIPTION
Signed-off-by: Clay Downs <downsrob@amazon.com>

*Issue #, if available:*
https://github.com/opensearch-project/index-management/issues/346

*Description of changes:*
Adds a workflow to open issues in the documentation-website repo when the "needs-documentation" label is added.

*CheckList:*
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/index-management/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
