### PR TITLE
Snapshot management security integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ src/test/resources/job-scheduler/
 src/test/resources/bwc/
 bin/
 spi/bin/
+src/test/resources/notifications*

--- a/src/main/kotlin/org/opensearch/indexmanagement/IndexManagementPlugin.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/IndexManagementPlugin.kt
@@ -426,7 +426,7 @@ class IndexManagementPlugin : JobSchedulerExtension, NetworkPlugin, ActionPlugin
             client, clusterService, threadPool, indexManagementIndices, metadataService, templateService, indexMetadataProvider
         )
 
-        SMRunner.init(client)
+        val smRunner = SMRunner.init(client, threadPool, settings)
 
         return listOf(
             managedIndexRunner,
@@ -435,7 +435,8 @@ class IndexManagementPlugin : JobSchedulerExtension, NetworkPlugin, ActionPlugin
             indexManagementIndices,
             managedIndexCoordinator,
             indexStateManagementHistory,
-            indexMetadataProvider
+            indexMetadataProvider,
+            smRunner
         )
     }
 

--- a/src/main/kotlin/org/opensearch/indexmanagement/IndexManagementPlugin.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/IndexManagementPlugin.kt
@@ -129,6 +129,7 @@ import org.opensearch.indexmanagement.snapshotmanagement.api.transport.stop.Tran
 import org.opensearch.indexmanagement.snapshotmanagement.SMRunner
 import org.opensearch.indexmanagement.snapshotmanagement.model.SMMetadata
 import org.opensearch.indexmanagement.snapshotmanagement.model.SMPolicy
+import org.opensearch.indexmanagement.snapshotmanagement.settings.SnapshotManagementSettings
 import org.opensearch.indexmanagement.spi.IndexManagementExtension
 import org.opensearch.indexmanagement.spi.indexstatemanagement.IndexMetadataService
 import org.opensearch.indexmanagement.spi.indexstatemanagement.StatusChecker
@@ -507,7 +508,8 @@ class IndexManagementPlugin : JobSchedulerExtension, NetworkPlugin, ActionPlugin
             LegacyOpenDistroRollupSettings.ROLLUP_INDEX,
             LegacyOpenDistroRollupSettings.ROLLUP_ENABLED,
             LegacyOpenDistroRollupSettings.ROLLUP_SEARCH_ENABLED,
-            LegacyOpenDistroRollupSettings.ROLLUP_DASHBOARDS
+            LegacyOpenDistroRollupSettings.ROLLUP_DASHBOARDS,
+            SnapshotManagementSettings.FILTER_BY_BACKEND_ROLES
         )
     }
 

--- a/src/main/kotlin/org/opensearch/indexmanagement/snapshotmanagement/api/transport/delete/TransportDeleteSMPolicyAction.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/snapshotmanagement/api/transport/delete/TransportDeleteSMPolicyAction.kt
@@ -54,7 +54,7 @@ class TransportDeleteSMPolicyAction @Inject constructor(
         val smPolicy = client.getSMPolicy(request.id())
 
         // Check if the requested user has permission on the resource, throwing an exception if the user does not
-        verifyUserHasPermissionForResource(user, smPolicy.user, filterByEnabled, "snapshot management policy", smPolicy.name)
+        verifyUserHasPermissionForResource(user, smPolicy.user, filterByEnabled, "snapshot management policy", smPolicy.policyName)
 
         val deleteReq = request.index(INDEX_MANAGEMENT_INDEX)
         try {

--- a/src/main/kotlin/org/opensearch/indexmanagement/snapshotmanagement/api/transport/delete/TransportDeleteSMPolicyAction.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/snapshotmanagement/api/transport/delete/TransportDeleteSMPolicyAction.kt
@@ -18,10 +18,10 @@ import org.opensearch.commons.authuser.User
 import org.opensearch.index.engine.VersionConflictEngineException
 import org.opensearch.indexmanagement.IndexManagementPlugin.Companion.INDEX_MANAGEMENT_INDEX
 import org.opensearch.indexmanagement.opensearchapi.suspendUntil
-import org.opensearch.indexmanagement.settings.IndexManagementSettings
 import org.opensearch.indexmanagement.snapshotmanagement.api.transport.BaseTransportAction
 import org.opensearch.indexmanagement.snapshotmanagement.api.transport.SMActions.DELETE_SM_POLICY_ACTION_NAME
 import org.opensearch.indexmanagement.snapshotmanagement.getSMPolicy
+import org.opensearch.indexmanagement.snapshotmanagement.settings.SnapshotManagementSettings.Companion.FILTER_BY_BACKEND_ROLES
 import org.opensearch.indexmanagement.util.SecurityUtils.Companion.verifyUserHasPermissionForResource
 import org.opensearch.rest.RestStatus
 import org.opensearch.transport.TransportService
@@ -38,10 +38,10 @@ class TransportDeleteSMPolicyAction @Inject constructor(
 
     private val log = LogManager.getLogger(javaClass)
 
-    @Volatile private var filterByEnabled = IndexManagementSettings.FILTER_BY_BACKEND_ROLES.get(settings)
+    @Volatile private var filterByEnabled = FILTER_BY_BACKEND_ROLES.get(settings)
 
     init {
-        clusterService.clusterSettings.addSettingsUpdateConsumer(IndexManagementSettings.FILTER_BY_BACKEND_ROLES) {
+        clusterService.clusterSettings.addSettingsUpdateConsumer(FILTER_BY_BACKEND_ROLES) {
             filterByEnabled = it
         }
     }

--- a/src/main/kotlin/org/opensearch/indexmanagement/snapshotmanagement/api/transport/delete/TransportDeleteSMPolicyAction.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/snapshotmanagement/api/transport/delete/TransportDeleteSMPolicyAction.kt
@@ -53,6 +53,7 @@ class TransportDeleteSMPolicyAction @Inject constructor(
     ): DeleteResponse {
         val smPolicy = client.getSMPolicy(request.id())
 
+        // Check if the requested user has permission on the resource, throwing an exception if the user does not
         verifyUserHasPermissionForResource(user, smPolicy.user, filterByEnabled, "snapshot management policy", smPolicy.name)
 
         val deleteReq = request.index(INDEX_MANAGEMENT_INDEX)

--- a/src/main/kotlin/org/opensearch/indexmanagement/snapshotmanagement/api/transport/delete/TransportDeleteSMPolicyAction.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/snapshotmanagement/api/transport/delete/TransportDeleteSMPolicyAction.kt
@@ -10,15 +10,19 @@ import org.opensearch.OpenSearchStatusException
 import org.opensearch.action.delete.DeleteResponse
 import org.opensearch.action.support.ActionFilters
 import org.opensearch.client.Client
+import org.opensearch.cluster.service.ClusterService
 import org.opensearch.common.inject.Inject
+import org.opensearch.common.settings.Settings
 import org.opensearch.common.util.concurrent.ThreadContext
 import org.opensearch.commons.authuser.User
 import org.opensearch.index.engine.VersionConflictEngineException
 import org.opensearch.indexmanagement.IndexManagementPlugin.Companion.INDEX_MANAGEMENT_INDEX
 import org.opensearch.indexmanagement.opensearchapi.suspendUntil
+import org.opensearch.indexmanagement.settings.IndexManagementSettings
 import org.opensearch.indexmanagement.snapshotmanagement.api.transport.BaseTransportAction
 import org.opensearch.indexmanagement.snapshotmanagement.api.transport.SMActions.DELETE_SM_POLICY_ACTION_NAME
 import org.opensearch.indexmanagement.snapshotmanagement.getSMPolicy
+import org.opensearch.indexmanagement.util.SecurityUtils.Companion.verifyUserHasPermissionForResource
 import org.opensearch.rest.RestStatus
 import org.opensearch.transport.TransportService
 
@@ -26,11 +30,21 @@ class TransportDeleteSMPolicyAction @Inject constructor(
     client: Client,
     transportService: TransportService,
     actionFilters: ActionFilters,
+    val clusterService: ClusterService,
+    val settings: Settings,
 ) : BaseTransportAction<DeleteSMPolicyRequest, DeleteResponse>(
     DELETE_SM_POLICY_ACTION_NAME, transportService, client, actionFilters, ::DeleteSMPolicyRequest
 ) {
 
     private val log = LogManager.getLogger(javaClass)
+
+    @Volatile private var filterByEnabled = IndexManagementSettings.FILTER_BY_BACKEND_ROLES.get(settings)
+
+    init {
+        clusterService.clusterSettings.addSettingsUpdateConsumer(IndexManagementSettings.FILTER_BY_BACKEND_ROLES) {
+            filterByEnabled = it
+        }
+    }
 
     override suspend fun executeRequest(
         request: DeleteSMPolicyRequest,
@@ -39,7 +53,7 @@ class TransportDeleteSMPolicyAction @Inject constructor(
     ): DeleteResponse {
         val smPolicy = client.getSMPolicy(request.id())
 
-        // TODO sm verify permissions
+        verifyUserHasPermissionForResource(user, smPolicy.user, filterByEnabled, "snapshot management policy", smPolicy.name)
 
         val deleteReq = request.index(INDEX_MANAGEMENT_INDEX)
         try {

--- a/src/main/kotlin/org/opensearch/indexmanagement/snapshotmanagement/api/transport/explain/TransportExplainSMAction.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/snapshotmanagement/api/transport/explain/TransportExplainSMAction.kt
@@ -28,7 +28,6 @@ import org.opensearch.indexmanagement.indexstatemanagement.ManagedIndexCoordinat
 import org.opensearch.indexmanagement.opensearchapi.contentParser
 import org.opensearch.indexmanagement.opensearchapi.parseWithType
 import org.opensearch.indexmanagement.opensearchapi.suspendUntil
-import org.opensearch.indexmanagement.settings.IndexManagementSettings
 import org.opensearch.indexmanagement.snapshotmanagement.api.transport.BaseTransportAction
 import org.opensearch.indexmanagement.snapshotmanagement.api.transport.SMActions
 import org.opensearch.indexmanagement.snapshotmanagement.model.ExplainSMPolicy
@@ -37,6 +36,7 @@ import org.opensearch.indexmanagement.snapshotmanagement.model.SMMetadata.Compan
 import org.opensearch.indexmanagement.snapshotmanagement.model.SMPolicy
 import org.opensearch.indexmanagement.snapshotmanagement.model.SMPolicy.Companion.ENABLED_FIELD
 import org.opensearch.indexmanagement.snapshotmanagement.model.SMPolicy.Companion.NAME_FIELD
+import org.opensearch.indexmanagement.snapshotmanagement.settings.SnapshotManagementSettings.Companion.FILTER_BY_BACKEND_ROLES
 import org.opensearch.indexmanagement.snapshotmanagement.smMetadataIdToPolicyName
 import org.opensearch.indexmanagement.util.SecurityUtils
 import org.opensearch.rest.RestStatus
@@ -56,10 +56,10 @@ class TransportExplainSMAction @Inject constructor(
 
     private val log = LogManager.getLogger(javaClass)
 
-    @Volatile private var filterByEnabled = IndexManagementSettings.FILTER_BY_BACKEND_ROLES.get(settings)
+    @Volatile private var filterByEnabled = FILTER_BY_BACKEND_ROLES.get(settings)
 
     init {
-        clusterService.clusterSettings.addSettingsUpdateConsumer(IndexManagementSettings.FILTER_BY_BACKEND_ROLES) {
+        clusterService.clusterSettings.addSettingsUpdateConsumer(FILTER_BY_BACKEND_ROLES) {
             filterByEnabled = it
         }
     }

--- a/src/main/kotlin/org/opensearch/indexmanagement/snapshotmanagement/api/transport/get/TransportGetSMPoliciesAction.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/snapshotmanagement/api/transport/get/TransportGetSMPoliciesAction.kt
@@ -26,10 +26,10 @@ import org.opensearch.indexmanagement.common.model.rest.SearchParams
 import org.opensearch.indexmanagement.opensearchapi.contentParser
 import org.opensearch.indexmanagement.opensearchapi.parseWithType
 import org.opensearch.indexmanagement.opensearchapi.suspendUntil
-import org.opensearch.indexmanagement.settings.IndexManagementSettings
 import org.opensearch.indexmanagement.snapshotmanagement.api.transport.BaseTransportAction
 import org.opensearch.indexmanagement.snapshotmanagement.api.transport.SMActions.GET_SM_POLICIES_ACTION_NAME
 import org.opensearch.indexmanagement.snapshotmanagement.model.SMPolicy
+import org.opensearch.indexmanagement.snapshotmanagement.settings.SnapshotManagementSettings.Companion.FILTER_BY_BACKEND_ROLES
 import org.opensearch.indexmanagement.snapshotmanagement.util.SM_POLICY_NAME_KEYWORD
 import org.opensearch.indexmanagement.util.SecurityUtils
 import org.opensearch.rest.RestStatus
@@ -48,10 +48,10 @@ class TransportGetSMPoliciesAction @Inject constructor(
 
     private val log = LogManager.getLogger(javaClass)
 
-    @Volatile private var filterByEnabled = IndexManagementSettings.FILTER_BY_BACKEND_ROLES.get(settings)
+    @Volatile private var filterByEnabled = FILTER_BY_BACKEND_ROLES.get(settings)
 
     init {
-        clusterService.clusterSettings.addSettingsUpdateConsumer(IndexManagementSettings.FILTER_BY_BACKEND_ROLES) {
+        clusterService.clusterSettings.addSettingsUpdateConsumer(FILTER_BY_BACKEND_ROLES) {
             filterByEnabled = it
         }
     }

--- a/src/main/kotlin/org/opensearch/indexmanagement/snapshotmanagement/api/transport/get/TransportGetSMPoliciesAction.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/snapshotmanagement/api/transport/get/TransportGetSMPoliciesAction.kt
@@ -11,7 +11,9 @@ import org.opensearch.action.search.SearchRequest
 import org.opensearch.action.search.SearchResponse
 import org.opensearch.action.support.ActionFilters
 import org.opensearch.client.Client
+import org.opensearch.cluster.service.ClusterService
 import org.opensearch.common.inject.Inject
+import org.opensearch.common.settings.Settings
 import org.opensearch.common.util.concurrent.ThreadContext
 import org.opensearch.commons.authuser.User
 import org.opensearch.index.IndexNotFoundException
@@ -24,10 +26,12 @@ import org.opensearch.indexmanagement.common.model.rest.SearchParams
 import org.opensearch.indexmanagement.opensearchapi.contentParser
 import org.opensearch.indexmanagement.opensearchapi.parseWithType
 import org.opensearch.indexmanagement.opensearchapi.suspendUntil
+import org.opensearch.indexmanagement.settings.IndexManagementSettings
 import org.opensearch.indexmanagement.snapshotmanagement.api.transport.BaseTransportAction
 import org.opensearch.indexmanagement.snapshotmanagement.api.transport.SMActions.GET_SM_POLICIES_ACTION_NAME
 import org.opensearch.indexmanagement.snapshotmanagement.model.SMPolicy
 import org.opensearch.indexmanagement.snapshotmanagement.util.SM_POLICY_NAME_KEYWORD
+import org.opensearch.indexmanagement.util.SecurityUtils
 import org.opensearch.rest.RestStatus
 import org.opensearch.search.builder.SearchSourceBuilder
 import org.opensearch.transport.TransportService
@@ -36,11 +40,21 @@ class TransportGetSMPoliciesAction @Inject constructor(
     client: Client,
     transportService: TransportService,
     actionFilters: ActionFilters,
+    val clusterService: ClusterService,
+    val settings: Settings,
 ) : BaseTransportAction<GetSMPoliciesRequest, GetSMPoliciesResponse>(
     GET_SM_POLICIES_ACTION_NAME, transportService, client, actionFilters, ::GetSMPoliciesRequest
 ) {
 
     private val log = LogManager.getLogger(javaClass)
+
+    @Volatile private var filterByEnabled = IndexManagementSettings.FILTER_BY_BACKEND_ROLES.get(settings)
+
+    init {
+        clusterService.clusterSettings.addSettingsUpdateConsumer(IndexManagementSettings.FILTER_BY_BACKEND_ROLES) {
+            filterByEnabled = it
+        }
+    }
 
     override suspend fun executeRequest(
         request: GetSMPoliciesRequest,
@@ -48,13 +62,13 @@ class TransportGetSMPoliciesAction @Inject constructor(
         threadContext: ThreadContext.StoredContext
     ): GetSMPoliciesResponse {
         val searchParams = request.searchParams
-        val (policies, totalPoliciesCount) = getAllPolicies(searchParams)
+        val (policies, totalPoliciesCount) = getAllPolicies(searchParams, user)
 
         return GetSMPoliciesResponse(policies, totalPoliciesCount)
     }
 
-    private suspend fun getAllPolicies(searchParams: SearchParams): Pair<List<SMPolicy>, Long> {
-        val searchRequest = getAllPoliciesRequest(searchParams)
+    private suspend fun getAllPolicies(searchParams: SearchParams, user: User?): Pair<List<SMPolicy>, Long> {
+        val searchRequest = getAllPoliciesRequest(searchParams, user)
         val searchResponse: SearchResponse = try {
             client.suspendUntil { search(searchRequest, it) }
         } catch (e: IndexNotFoundException) {
@@ -63,7 +77,7 @@ class TransportGetSMPoliciesAction @Inject constructor(
         return parseGetAllPoliciesResponse(searchResponse)
     }
 
-    private fun getAllPoliciesRequest(searchParams: SearchParams): SearchRequest {
+    private fun getAllPoliciesRequest(searchParams: SearchParams, user: User?): SearchRequest {
         val sortBuilder = searchParams.getSortBuilder()
 
         val queryBuilder = BoolQueryBuilder()
@@ -73,7 +87,9 @@ class TransportGetSMPoliciesAction @Inject constructor(
                     .defaultOperator(Operator.AND)
                     .field(SM_POLICY_NAME_KEYWORD)
             )
-        // TODO SM add user filter
+
+        // Add user filter if enabled
+        SecurityUtils.addUserFilter(user, queryBuilder, filterByEnabled, "sm_policy.user")
 
         val searchSourceBuilder = SearchSourceBuilder()
             .size(searchParams.size)

--- a/src/main/kotlin/org/opensearch/indexmanagement/snapshotmanagement/api/transport/get/TransportGetSMPolicyAction.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/snapshotmanagement/api/transport/get/TransportGetSMPolicyAction.kt
@@ -69,7 +69,7 @@ class TransportGetSMPolicyAction @Inject constructor(
         }
 
         // Check if the requested user has permission on the resource, throwing an exception if the user does not
-        verifyUserHasPermissionForResource(user, smPolicy.user, filterByEnabled, "snapshot management policy", smPolicy.name)
+        verifyUserHasPermissionForResource(user, smPolicy.user, filterByEnabled, "snapshot management policy", smPolicy.policyName)
 
         log.info("sm dev: Parsed SM policy: $smPolicy")
         return GetSMPolicyResponse(getResponse.id, getResponse.version, getResponse.seqNo, getResponse.primaryTerm, smPolicy)

--- a/src/main/kotlin/org/opensearch/indexmanagement/snapshotmanagement/api/transport/get/TransportGetSMPolicyAction.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/snapshotmanagement/api/transport/get/TransportGetSMPolicyAction.kt
@@ -11,15 +11,19 @@ import org.opensearch.action.get.GetRequest
 import org.opensearch.action.get.GetResponse
 import org.opensearch.action.support.ActionFilters
 import org.opensearch.client.Client
+import org.opensearch.cluster.service.ClusterService
 import org.opensearch.common.inject.Inject
+import org.opensearch.common.settings.Settings
 import org.opensearch.common.util.concurrent.ThreadContext
 import org.opensearch.commons.authuser.User
 import org.opensearch.index.IndexNotFoundException
 import org.opensearch.indexmanagement.IndexManagementPlugin
 import org.opensearch.indexmanagement.opensearchapi.suspendUntil
+import org.opensearch.indexmanagement.settings.IndexManagementSettings
 import org.opensearch.indexmanagement.snapshotmanagement.api.transport.BaseTransportAction
 import org.opensearch.indexmanagement.snapshotmanagement.api.transport.SMActions.GET_SM_POLICY_ACTION_NAME
 import org.opensearch.indexmanagement.snapshotmanagement.parseSMPolicy
+import org.opensearch.indexmanagement.util.SecurityUtils.Companion.verifyUserHasPermissionForResource
 import org.opensearch.rest.RestStatus
 import org.opensearch.transport.TransportService
 
@@ -27,11 +31,21 @@ class TransportGetSMPolicyAction @Inject constructor(
     client: Client,
     transportService: TransportService,
     actionFilters: ActionFilters,
+    val clusterService: ClusterService,
+    val settings: Settings,
 ) : BaseTransportAction<GetSMPolicyRequest, GetSMPolicyResponse>(
     GET_SM_POLICY_ACTION_NAME, transportService, client, actionFilters, ::GetSMPolicyRequest
 ) {
 
     private val log = LogManager.getLogger(javaClass)
+
+    @Volatile private var filterByEnabled = IndexManagementSettings.FILTER_BY_BACKEND_ROLES.get(settings)
+
+    init {
+        clusterService.clusterSettings.addSettingsUpdateConsumer(IndexManagementSettings.FILTER_BY_BACKEND_ROLES) {
+            filterByEnabled = it
+        }
+    }
 
     override suspend fun executeRequest(
         request: GetSMPolicyRequest,
@@ -53,7 +67,8 @@ class TransportGetSMPolicyAction @Inject constructor(
             log.error("Error while parsing snapshot management policy ${request.policyID}", e)
             throw OpenSearchStatusException("Snapshot management policy not found", RestStatus.INTERNAL_SERVER_ERROR)
         }
-        // TODO SM security integration
+
+        verifyUserHasPermissionForResource(user, smPolicy.user, filterByEnabled, "snapshot management policy", smPolicy.name)
 
         log.info("sm dev: Parsed SM policy: $smPolicy")
         return GetSMPolicyResponse(getResponse.id, getResponse.version, getResponse.seqNo, getResponse.primaryTerm, smPolicy)

--- a/src/main/kotlin/org/opensearch/indexmanagement/snapshotmanagement/api/transport/get/TransportGetSMPolicyAction.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/snapshotmanagement/api/transport/get/TransportGetSMPolicyAction.kt
@@ -19,10 +19,10 @@ import org.opensearch.commons.authuser.User
 import org.opensearch.index.IndexNotFoundException
 import org.opensearch.indexmanagement.IndexManagementPlugin
 import org.opensearch.indexmanagement.opensearchapi.suspendUntil
-import org.opensearch.indexmanagement.settings.IndexManagementSettings
 import org.opensearch.indexmanagement.snapshotmanagement.api.transport.BaseTransportAction
 import org.opensearch.indexmanagement.snapshotmanagement.api.transport.SMActions.GET_SM_POLICY_ACTION_NAME
 import org.opensearch.indexmanagement.snapshotmanagement.parseSMPolicy
+import org.opensearch.indexmanagement.snapshotmanagement.settings.SnapshotManagementSettings.Companion.FILTER_BY_BACKEND_ROLES
 import org.opensearch.indexmanagement.util.SecurityUtils.Companion.verifyUserHasPermissionForResource
 import org.opensearch.rest.RestStatus
 import org.opensearch.transport.TransportService
@@ -39,10 +39,10 @@ class TransportGetSMPolicyAction @Inject constructor(
 
     private val log = LogManager.getLogger(javaClass)
 
-    @Volatile private var filterByEnabled = IndexManagementSettings.FILTER_BY_BACKEND_ROLES.get(settings)
+    @Volatile private var filterByEnabled = FILTER_BY_BACKEND_ROLES.get(settings)
 
     init {
-        clusterService.clusterSettings.addSettingsUpdateConsumer(IndexManagementSettings.FILTER_BY_BACKEND_ROLES) {
+        clusterService.clusterSettings.addSettingsUpdateConsumer(FILTER_BY_BACKEND_ROLES) {
             filterByEnabled = it
         }
     }

--- a/src/main/kotlin/org/opensearch/indexmanagement/snapshotmanagement/api/transport/get/TransportGetSMPolicyAction.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/snapshotmanagement/api/transport/get/TransportGetSMPolicyAction.kt
@@ -68,6 +68,7 @@ class TransportGetSMPolicyAction @Inject constructor(
             throw OpenSearchStatusException("Snapshot management policy not found", RestStatus.INTERNAL_SERVER_ERROR)
         }
 
+        // Check if the requested user has permission on the resource, throwing an exception if the user does not
         verifyUserHasPermissionForResource(user, smPolicy.user, filterByEnabled, "snapshot management policy", smPolicy.name)
 
         log.info("sm dev: Parsed SM policy: $smPolicy")

--- a/src/main/kotlin/org/opensearch/indexmanagement/snapshotmanagement/api/transport/index/TransportIndexSMPolicyAction.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/snapshotmanagement/api/transport/index/TransportIndexSMPolicyAction.kt
@@ -19,9 +19,9 @@ import org.opensearch.commons.authuser.User
 import org.opensearch.indexmanagement.IndexManagementIndices
 import org.opensearch.indexmanagement.IndexManagementPlugin.Companion.INDEX_MANAGEMENT_INDEX
 import org.opensearch.indexmanagement.opensearchapi.suspendUntil
-import org.opensearch.indexmanagement.settings.IndexManagementSettings
 import org.opensearch.indexmanagement.snapshotmanagement.api.transport.BaseTransportAction
 import org.opensearch.indexmanagement.snapshotmanagement.api.transport.SMActions.INDEX_SM_POLICY_ACTION_NAME
+import org.opensearch.indexmanagement.snapshotmanagement.settings.SnapshotManagementSettings.Companion.FILTER_BY_BACKEND_ROLES
 import org.opensearch.indexmanagement.util.IndexUtils
 import org.opensearch.indexmanagement.util.SecurityUtils
 import org.opensearch.transport.TransportService
@@ -39,10 +39,10 @@ class TransportIndexSMPolicyAction @Inject constructor(
 
     private val log = LogManager.getLogger(javaClass)
 
-    @Volatile private var filterByEnabled = IndexManagementSettings.FILTER_BY_BACKEND_ROLES.get(settings)
+    @Volatile private var filterByEnabled = FILTER_BY_BACKEND_ROLES.get(settings)
 
     init {
-        clusterService.clusterSettings.addSettingsUpdateConsumer(IndexManagementSettings.FILTER_BY_BACKEND_ROLES) {
+        clusterService.clusterSettings.addSettingsUpdateConsumer(FILTER_BY_BACKEND_ROLES) {
             filterByEnabled = it
         }
     }

--- a/src/main/kotlin/org/opensearch/indexmanagement/snapshotmanagement/api/transport/index/TransportIndexSMPolicyAction.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/snapshotmanagement/api/transport/index/TransportIndexSMPolicyAction.kt
@@ -9,7 +9,9 @@ import org.apache.logging.log4j.LogManager
 import org.opensearch.action.index.IndexResponse
 import org.opensearch.action.support.ActionFilters
 import org.opensearch.client.Client
+import org.opensearch.cluster.service.ClusterService
 import org.opensearch.common.inject.Inject
+import org.opensearch.common.settings.Settings
 import org.opensearch.common.util.concurrent.ThreadContext
 import org.opensearch.common.xcontent.ToXContent
 import org.opensearch.common.xcontent.XContentFactory
@@ -17,8 +19,11 @@ import org.opensearch.commons.authuser.User
 import org.opensearch.indexmanagement.IndexManagementIndices
 import org.opensearch.indexmanagement.IndexManagementPlugin.Companion.INDEX_MANAGEMENT_INDEX
 import org.opensearch.indexmanagement.opensearchapi.suspendUntil
+import org.opensearch.indexmanagement.settings.IndexManagementSettings
 import org.opensearch.indexmanagement.snapshotmanagement.api.transport.BaseTransportAction
 import org.opensearch.indexmanagement.snapshotmanagement.api.transport.SMActions.INDEX_SM_POLICY_ACTION_NAME
+import org.opensearch.indexmanagement.util.IndexUtils
+import org.opensearch.indexmanagement.util.SecurityUtils
 import org.opensearch.transport.TransportService
 
 class TransportIndexSMPolicyAction @Inject constructor(
@@ -26,23 +31,36 @@ class TransportIndexSMPolicyAction @Inject constructor(
     transportService: TransportService,
     val indexManagementIndices: IndexManagementIndices,
     actionFilters: ActionFilters,
+    val clusterService: ClusterService,
+    val settings: Settings,
 ) : BaseTransportAction<IndexSMPolicyRequest, IndexSMPolicyResponse>(
     INDEX_SM_POLICY_ACTION_NAME, transportService, client, actionFilters, ::IndexSMPolicyRequest
 ) {
 
     private val log = LogManager.getLogger(javaClass)
 
+    @Volatile private var filterByEnabled = IndexManagementSettings.FILTER_BY_BACKEND_ROLES.get(settings)
+
+    init {
+        clusterService.clusterSettings.addSettingsUpdateConsumer(IndexManagementSettings.FILTER_BY_BACKEND_ROLES) {
+            filterByEnabled = it
+        }
+    }
+
     override suspend fun executeRequest(
         request: IndexSMPolicyRequest,
         user: User?,
         threadContext: ThreadContext.StoredContext
     ): IndexSMPolicyResponse {
+        // If filterBy is enabled and security is disabled or if filter by is enabled and backend role are empty an exception will be thrown
+        SecurityUtils.validateUserConfiguration(user, filterByEnabled)
+
         indexManagementIndices.checkAndUpdateIMConfigIndex(log)
-        return indexSMPolicy(request)
+        return indexSMPolicy(request, user)
     }
 
-    private suspend fun indexSMPolicy(request: IndexSMPolicyRequest): IndexSMPolicyResponse {
-        val policy = request.policy
+    private suspend fun indexSMPolicy(request: IndexSMPolicyRequest, user: User?): IndexSMPolicyResponse {
+        val policy = request.policy.copy(schemaVersion = IndexUtils.indexManagementConfigSchemaVersion, user = user)
         val indexReq = request.index(INDEX_MANAGEMENT_INDEX)
             .source(policy.toXContent(XContentFactory.jsonBuilder(), ToXContent.EMPTY_PARAMS))
             .id(policy.id)

--- a/src/main/kotlin/org/opensearch/indexmanagement/snapshotmanagement/api/transport/start/TransportStartSMAction.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/snapshotmanagement/api/transport/start/TransportStartSMAction.kt
@@ -59,7 +59,7 @@ class TransportStartSMAction @Inject constructor(
         val smPolicy = client.getSMPolicy(request.id())
 
         // Check if the requested user has permission on the resource, throwing an exception if the user does not
-        verifyUserHasPermissionForResource(user, smPolicy.user, filterByEnabled, "snapshot management policy", smPolicy.name)
+        verifyUserHasPermissionForResource(user, smPolicy.user, filterByEnabled, "snapshot management policy", smPolicy.policyName)
 
         if (smPolicy.jobEnabled) {
             log.debug("Snapshot management policy is already enabled")

--- a/src/main/kotlin/org/opensearch/indexmanagement/snapshotmanagement/api/transport/start/TransportStartSMAction.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/snapshotmanagement/api/transport/start/TransportStartSMAction.kt
@@ -21,11 +21,11 @@ import org.opensearch.commons.authuser.User
 import org.opensearch.index.engine.VersionConflictEngineException
 import org.opensearch.indexmanagement.IndexManagementPlugin.Companion.INDEX_MANAGEMENT_INDEX
 import org.opensearch.indexmanagement.opensearchapi.suspendUntil
-import org.opensearch.indexmanagement.settings.IndexManagementSettings
 import org.opensearch.indexmanagement.snapshotmanagement.api.transport.BaseTransportAction
 import org.opensearch.indexmanagement.snapshotmanagement.api.transport.SMActions
 import org.opensearch.indexmanagement.snapshotmanagement.getSMPolicy
 import org.opensearch.indexmanagement.snapshotmanagement.model.SMPolicy
+import org.opensearch.indexmanagement.snapshotmanagement.settings.SnapshotManagementSettings.Companion.FILTER_BY_BACKEND_ROLES
 import org.opensearch.indexmanagement.util.SecurityUtils.Companion.verifyUserHasPermissionForResource
 import org.opensearch.rest.RestStatus
 import org.opensearch.transport.TransportService
@@ -43,10 +43,10 @@ class TransportStartSMAction @Inject constructor(
 
     private val log = LogManager.getLogger(javaClass)
 
-    @Volatile private var filterByEnabled = IndexManagementSettings.FILTER_BY_BACKEND_ROLES.get(settings)
+    @Volatile private var filterByEnabled = FILTER_BY_BACKEND_ROLES.get(settings)
 
     init {
-        clusterService.clusterSettings.addSettingsUpdateConsumer(IndexManagementSettings.FILTER_BY_BACKEND_ROLES) {
+        clusterService.clusterSettings.addSettingsUpdateConsumer(FILTER_BY_BACKEND_ROLES) {
             filterByEnabled = it
         }
     }

--- a/src/main/kotlin/org/opensearch/indexmanagement/snapshotmanagement/api/transport/start/TransportStartSMAction.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/snapshotmanagement/api/transport/start/TransportStartSMAction.kt
@@ -58,6 +58,7 @@ class TransportStartSMAction @Inject constructor(
     ): AcknowledgedResponse {
         val smPolicy = client.getSMPolicy(request.id())
 
+        // Check if the requested user has permission on the resource, throwing an exception if the user does not
         verifyUserHasPermissionForResource(user, smPolicy.user, filterByEnabled, "snapshot management policy", smPolicy.name)
 
         if (smPolicy.jobEnabled) {

--- a/src/main/kotlin/org/opensearch/indexmanagement/snapshotmanagement/api/transport/stop/TransportStopSMAction.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/snapshotmanagement/api/transport/stop/TransportStopSMAction.kt
@@ -58,6 +58,7 @@ class TransportStopSMAction @Inject constructor(
     ): AcknowledgedResponse {
         val smPolicy = client.getSMPolicy(request.id())
 
+        // Check if the requested user has permission on the resource, throwing an exception if the user does not
         verifyUserHasPermissionForResource(user, smPolicy.user, filterByEnabled, "snapshot management policy", smPolicy.name)
 
         if (!smPolicy.jobEnabled) {

--- a/src/main/kotlin/org/opensearch/indexmanagement/snapshotmanagement/api/transport/stop/TransportStopSMAction.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/snapshotmanagement/api/transport/stop/TransportStopSMAction.kt
@@ -59,7 +59,7 @@ class TransportStopSMAction @Inject constructor(
         val smPolicy = client.getSMPolicy(request.id())
 
         // Check if the requested user has permission on the resource, throwing an exception if the user does not
-        verifyUserHasPermissionForResource(user, smPolicy.user, filterByEnabled, "snapshot management policy", smPolicy.name)
+        verifyUserHasPermissionForResource(user, smPolicy.user, filterByEnabled, "snapshot management policy", smPolicy.policyName)
 
         if (!smPolicy.jobEnabled) {
             log.debug("Snapshot management policy is already disabled")

--- a/src/main/kotlin/org/opensearch/indexmanagement/snapshotmanagement/api/transport/stop/TransportStopSMAction.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/snapshotmanagement/api/transport/stop/TransportStopSMAction.kt
@@ -13,16 +13,20 @@ import org.opensearch.action.support.ActionFilters
 import org.opensearch.action.support.master.AcknowledgedResponse
 import org.opensearch.action.update.UpdateResponse
 import org.opensearch.client.Client
+import org.opensearch.cluster.service.ClusterService
 import org.opensearch.common.inject.Inject
+import org.opensearch.common.settings.Settings
 import org.opensearch.common.util.concurrent.ThreadContext
 import org.opensearch.commons.authuser.User
 import org.opensearch.index.engine.VersionConflictEngineException
 import org.opensearch.indexmanagement.IndexManagementPlugin.Companion.INDEX_MANAGEMENT_INDEX
 import org.opensearch.indexmanagement.opensearchapi.suspendUntil
+import org.opensearch.indexmanagement.settings.IndexManagementSettings
 import org.opensearch.indexmanagement.snapshotmanagement.api.transport.BaseTransportAction
 import org.opensearch.indexmanagement.snapshotmanagement.api.transport.SMActions
 import org.opensearch.indexmanagement.snapshotmanagement.getSMPolicy
 import org.opensearch.indexmanagement.snapshotmanagement.model.SMPolicy
+import org.opensearch.indexmanagement.util.SecurityUtils.Companion.verifyUserHasPermissionForResource
 import org.opensearch.rest.RestStatus
 import org.opensearch.transport.TransportService
 import java.time.Instant
@@ -30,12 +34,22 @@ import java.time.Instant
 class TransportStopSMAction @Inject constructor(
     client: Client,
     transportService: TransportService,
-    actionFilters: ActionFilters
+    actionFilters: ActionFilters,
+    val clusterService: ClusterService,
+    val settings: Settings,
 ) : BaseTransportAction<StopSMRequest, AcknowledgedResponse>(
     SMActions.STOP_SM_POLICY_ACTION_NAME, transportService, client, actionFilters, ::StopSMRequest
 ) {
 
     private val log = LogManager.getLogger(javaClass)
+
+    @Volatile private var filterByEnabled = IndexManagementSettings.FILTER_BY_BACKEND_ROLES.get(settings)
+
+    init {
+        clusterService.clusterSettings.addSettingsUpdateConsumer(IndexManagementSettings.FILTER_BY_BACKEND_ROLES) {
+            filterByEnabled = it
+        }
+    }
 
     override suspend fun executeRequest(
         request: StopSMRequest,
@@ -43,6 +57,9 @@ class TransportStopSMAction @Inject constructor(
         threadContext: ThreadContext.StoredContext
     ): AcknowledgedResponse {
         val smPolicy = client.getSMPolicy(request.id())
+
+        verifyUserHasPermissionForResource(user, smPolicy.user, filterByEnabled, "snapshot management policy", smPolicy.name)
+
         if (!smPolicy.jobEnabled) {
             log.debug("Snapshot management policy is already disabled")
             return AcknowledgedResponse(true)

--- a/src/main/kotlin/org/opensearch/indexmanagement/snapshotmanagement/api/transport/stop/TransportStopSMAction.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/snapshotmanagement/api/transport/stop/TransportStopSMAction.kt
@@ -21,11 +21,11 @@ import org.opensearch.commons.authuser.User
 import org.opensearch.index.engine.VersionConflictEngineException
 import org.opensearch.indexmanagement.IndexManagementPlugin.Companion.INDEX_MANAGEMENT_INDEX
 import org.opensearch.indexmanagement.opensearchapi.suspendUntil
-import org.opensearch.indexmanagement.settings.IndexManagementSettings
 import org.opensearch.indexmanagement.snapshotmanagement.api.transport.BaseTransportAction
 import org.opensearch.indexmanagement.snapshotmanagement.api.transport.SMActions
 import org.opensearch.indexmanagement.snapshotmanagement.getSMPolicy
 import org.opensearch.indexmanagement.snapshotmanagement.model.SMPolicy
+import org.opensearch.indexmanagement.snapshotmanagement.settings.SnapshotManagementSettings.Companion.FILTER_BY_BACKEND_ROLES
 import org.opensearch.indexmanagement.util.SecurityUtils.Companion.verifyUserHasPermissionForResource
 import org.opensearch.rest.RestStatus
 import org.opensearch.transport.TransportService
@@ -43,10 +43,10 @@ class TransportStopSMAction @Inject constructor(
 
     private val log = LogManager.getLogger(javaClass)
 
-    @Volatile private var filterByEnabled = IndexManagementSettings.FILTER_BY_BACKEND_ROLES.get(settings)
+    @Volatile private var filterByEnabled = FILTER_BY_BACKEND_ROLES.get(settings)
 
     init {
-        clusterService.clusterSettings.addSettingsUpdateConsumer(IndexManagementSettings.FILTER_BY_BACKEND_ROLES) {
+        clusterService.clusterSettings.addSettingsUpdateConsumer(FILTER_BY_BACKEND_ROLES) {
             filterByEnabled = it
         }
     }

--- a/src/main/kotlin/org/opensearch/indexmanagement/snapshotmanagement/engine/SMStateMachine.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/snapshotmanagement/engine/SMStateMachine.kt
@@ -8,6 +8,10 @@ package org.opensearch.indexmanagement.snapshotmanagement.engine
 import org.apache.logging.log4j.LogManager
 import org.apache.logging.log4j.Logger
 import org.opensearch.client.Client
+import org.opensearch.common.settings.Settings
+import org.opensearch.commons.ConfigConstants
+import org.opensearch.indexmanagement.opensearchapi.IndexManagementSecurityContext
+import org.opensearch.indexmanagement.opensearchapi.withClosableContext
 import org.opensearch.indexmanagement.snapshotmanagement.SnapshotManagementException
 import org.opensearch.indexmanagement.snapshotmanagement.SnapshotManagementException.ExceptionKey
 import org.opensearch.indexmanagement.snapshotmanagement.engine.states.SMResult
@@ -18,6 +22,7 @@ import org.opensearch.indexmanagement.snapshotmanagement.model.SMPolicy
 import org.opensearch.indexmanagement.snapshotmanagement.model.SMMetadata
 import org.opensearch.indexmanagement.snapshotmanagement.smDocIdToPolicyName
 import org.opensearch.indexmanagement.util.OpenForTesting
+import org.opensearch.threadpool.ThreadPool
 import java.time.Instant.now
 
 @OpenForTesting
@@ -25,6 +30,8 @@ class SMStateMachine(
     val client: Client,
     val job: SMPolicy,
     var metadata: SMMetadata,
+    val settings: Settings,
+    val threadPool: ThreadPool
 ) {
 
     val log: Logger = LogManager.getLogger("$javaClass [${smDocIdToPolicyName(job.id)}]")
@@ -51,7 +58,24 @@ class SMStateMachine(
                 for (nextState in nextStates) {
                     currentState = nextState
                     log.info("sm dev: Start executing $currentState.")
-                    result = currentState.instance.execute(this) as SMResult
+                    log.info(
+                        "SM dev: User and roles string from thread context: ${threadPool.threadContext.getTransient<String>(
+                            ConfigConstants.OPENSEARCH_SECURITY_USER_INFO_THREAD_CONTEXT
+                        )}"
+                    )
+                    result = withClosableContext(
+                        IndexManagementSecurityContext(
+                            job.id, settings, threadPool.threadContext, job.user
+                        )
+                    ) {
+                        log.info(
+                            "SM dev: User and roles string from thread context: ${threadPool.threadContext.getTransient<String>(
+                                ConfigConstants.OPENSEARCH_SECURITY_USER_INFO_THREAD_CONTEXT
+                            )}"
+                        )
+                        currentState.instance.execute(this@SMStateMachine) as SMResult
+                    }
+
                     when (result) {
                         is SMResult.Next -> {
                             log.info("State [$currentState] has finished.")

--- a/src/main/kotlin/org/opensearch/indexmanagement/snapshotmanagement/model/SMPolicy.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/snapshotmanagement/model/SMPolicy.kt
@@ -15,15 +15,20 @@ import org.opensearch.common.xcontent.XContentBuilder
 import org.opensearch.common.xcontent.XContentParser
 import org.opensearch.common.xcontent.XContentParser.Token
 import org.opensearch.common.xcontent.XContentParserUtils.ensureExpectedToken
+import org.opensearch.commons.authuser.User
 import org.opensearch.index.seqno.SequenceNumbers
 import org.opensearch.indexmanagement.indexstatemanagement.util.WITH_TYPE
+import org.opensearch.indexmanagement.indexstatemanagement.util.WITH_USER
 import org.opensearch.indexmanagement.opensearchapi.instant
 import org.opensearch.indexmanagement.opensearchapi.nullValueHandler
 import org.opensearch.indexmanagement.opensearchapi.optionalField
 import org.opensearch.indexmanagement.opensearchapi.optionalTimeField
+import org.opensearch.indexmanagement.opensearchapi.optionalUserField
 import org.opensearch.indexmanagement.snapshotmanagement.smPolicyNameToMetadataId
 import org.opensearch.indexmanagement.snapshotmanagement.model.SMPolicy.DeleteCondition.Companion.DEFAULT_DELETE_CONDITION
 import org.opensearch.indexmanagement.snapshotmanagement.smDocIdToPolicyName
+import org.opensearch.indexmanagement.spi.indexstatemanagement.model.ActionTimeout
+import org.opensearch.indexmanagement.util.IndexUtils
 import org.opensearch.jobscheduler.spi.ScheduledJobParameter
 import org.opensearch.jobscheduler.spi.schedule.CronSchedule
 import org.opensearch.jobscheduler.spi.schedule.IntervalSchedule
@@ -38,6 +43,7 @@ private val log = LogManager.getLogger(SMPolicy::class.java)
 data class SMPolicy(
     val id: String,
     val description: String? = null,
+    val schemaVersion: Long,
     val creation: Creation,
     val deletion: Deletion?,
     val snapshotConfig: Map<String, Any>,
@@ -47,6 +53,7 @@ data class SMPolicy(
     val jobSchedule: Schedule,
     val seqNo: Long = SequenceNumbers.UNASSIGNED_SEQ_NO,
     val primaryTerm: Long = SequenceNumbers.UNASSIGNED_PRIMARY_TERM,
+    val user: User? = null
 ) : ScheduledJobParameter, Writeable {
 
     init {
@@ -76,6 +83,7 @@ data class SMPolicy(
         if (params.paramAsBoolean(WITH_TYPE, true)) builder.startObject(SM_TYPE)
         builder.field(NAME_FIELD, smDocIdToPolicyName(id)) // for searching policy by name
             .optionalField(DESCRIPTION_FIELD, description)
+            .field(SCHEMA_VERSION_FIELD, schemaVersion)
             .field(CREATION_FIELD, creation)
             .optionalField(DELETION_FIELD, deletion)
             .field(SNAPSHOT_CONFIG_FIELD, snapshotConfig)
@@ -83,6 +91,7 @@ data class SMPolicy(
             .field(ENABLED_FIELD, jobEnabled)
             .optionalTimeField(LAST_UPDATED_TIME_FIELD, jobLastUpdateTime)
             .optionalTimeField(ENABLED_TIME_FIELD, jobEnabledTime)
+        if (params.paramAsBoolean(WITH_USER, true)) builder.optionalUserField(USER_FIELD, user)
         if (params.paramAsBoolean(WITH_TYPE, true)) builder.endObject()
         return builder.endObject()
     }
@@ -93,6 +102,7 @@ data class SMPolicy(
         const val SM_METADATA_ID_SUFFIX = "-sm-metadata"
         const val NAME_FIELD = "name"
         const val DESCRIPTION_FIELD = "description"
+        const val SCHEMA_VERSION_FIELD = "schema_version"
         const val CREATION_FIELD = "creation"
         const val DELETION_FIELD = "deletion"
         const val SNAPSHOT_CONFIG_FIELD = "snapshot_config"
@@ -101,10 +111,12 @@ data class SMPolicy(
         const val LAST_UPDATED_TIME_FIELD = "last_updated_time"
         const val ENABLED_TIME_FIELD = "enabled_time"
         const val SCHEDULE_FIELD = "schedule"
+        const val USER_FIELD = "user"
 
         // Used by sub models Creation and Deletion
         const val TIME_LIMIT_FIELD = "time_limit"
 
+        @Suppress("ComplexMethod")
         fun parse(
             xcp: XContentParser,
             id: String,
@@ -116,9 +128,11 @@ data class SMPolicy(
             var deletion: Deletion? = null
             var snapshotConfig: Map<String, Any>? = null
             var lastUpdatedTime: Instant? = null
+            var schemaVersion: Long = IndexUtils.DEFAULT_SCHEMA_VERSION
             var enabledTime: Instant? = null
             var schedule: Schedule? = null
             var enabled = true
+            var user: User? = null
 
             if (xcp.currentToken() == null) xcp.nextToken()
             ensureExpectedToken(Token.START_OBJECT, xcp.currentToken(), xcp)
@@ -129,6 +143,7 @@ data class SMPolicy(
                 when (fieldName) {
                     NAME_FIELD -> requireNotNull(xcp.text()) { "The name field of SMPolicy must not be null." }
                     DESCRIPTION_FIELD -> description = xcp.nullValueHandler { text() }
+                    SCHEMA_VERSION_FIELD -> schemaVersion = xcp.longValue()
                     CREATION_FIELD -> creation = Creation.parse(xcp)
                     DELETION_FIELD -> deletion = Deletion.parse(xcp)
                     SNAPSHOT_CONFIG_FIELD -> snapshotConfig = xcp.map()
@@ -136,6 +151,7 @@ data class SMPolicy(
                     ENABLED_TIME_FIELD -> enabledTime = xcp.instant()
                     SCHEDULE_FIELD -> schedule = ScheduleParser.parse(xcp)
                     ENABLED_FIELD -> enabled = xcp.booleanValue()
+                    USER_FIELD -> user = if (xcp.currentToken() == Token.VALUE_NULL) null else User.parse(xcp)
                 }
             }
 
@@ -164,6 +180,7 @@ data class SMPolicy(
 
             return SMPolicy(
                 description = description,
+                schemaVersion = schemaVersion,
                 creation = creation,
                 deletion = deletion,
                 snapshotConfig = requireNotNull(snapshotConfig) { "snapshot_config field must not be null" },
@@ -174,12 +191,14 @@ data class SMPolicy(
                 id = id,
                 seqNo = seqNo,
                 primaryTerm = primaryTerm,
+                user = user
             )
         }
     }
 
     constructor(sin: StreamInput) : this(
         description = sin.readOptionalString(),
+        schemaVersion = sin.readLong(),
         creation = Creation(sin),
         deletion = sin.readOptionalWriteable { Deletion(it) },
         snapshotConfig = sin.readMap() as Map<String, Any>,
@@ -190,10 +209,12 @@ data class SMPolicy(
         id = sin.readString(),
         seqNo = sin.readLong(),
         primaryTerm = sin.readLong(),
+        user = sin.readOptionalWriteable(::User)
     )
 
     override fun writeTo(out: StreamOutput) {
         out.writeOptionalString(description)
+        out.writeLong(schemaVersion)
         creation.writeTo(out)
         out.writeOptionalWriteable(deletion)
         out.writeMap(snapshotConfig)
@@ -204,6 +225,7 @@ data class SMPolicy(
         out.writeString(id)
         out.writeLong(seqNo)
         out.writeLong(primaryTerm)
+        out.writeOptionalWriteable(user)
     }
 
     data class Creation(

--- a/src/main/kotlin/org/opensearch/indexmanagement/snapshotmanagement/model/SMPolicy.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/snapshotmanagement/model/SMPolicy.kt
@@ -27,7 +27,6 @@ import org.opensearch.indexmanagement.opensearchapi.optionalUserField
 import org.opensearch.indexmanagement.snapshotmanagement.smPolicyNameToMetadataId
 import org.opensearch.indexmanagement.snapshotmanagement.model.SMPolicy.DeleteCondition.Companion.DEFAULT_DELETE_CONDITION
 import org.opensearch.indexmanagement.snapshotmanagement.smDocIdToPolicyName
-import org.opensearch.indexmanagement.spi.indexstatemanagement.model.ActionTimeout
 import org.opensearch.indexmanagement.util.IndexUtils
 import org.opensearch.jobscheduler.spi.ScheduledJobParameter
 import org.opensearch.jobscheduler.spi.schedule.CronSchedule

--- a/src/main/kotlin/org/opensearch/indexmanagement/snapshotmanagement/settings/SnapshotManagementSettings.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/snapshotmanagement/settings/SnapshotManagementSettings.kt
@@ -1,0 +1,20 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.indexmanagement.snapshotmanagement.settings
+
+import org.opensearch.common.settings.Setting
+
+@Suppress("UtilityClassWithPublicConstructor")
+class SnapshotManagementSettings {
+
+    companion object {
+        val FILTER_BY_BACKEND_ROLES: Setting<Boolean> = Setting.boolSetting(
+            "plugins.snapshot_management.filter_by_backend_roles",
+            false,
+            Setting.Property.NodeScope,
+            Setting.Property.Dynamic
+        )
+    }
+}

--- a/src/main/kotlin/org/opensearch/indexmanagement/util/SecurityUtils.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/util/SecurityUtils.kt
@@ -127,6 +127,7 @@ class SecurityUtils {
         /**
          * Check if the requested user has permission on the resource
          */
+        @Suppress("ComplexCondition")
         fun userHasPermissionForResource(
             requestedUser: User?,
             resourceUser: User?,

--- a/src/main/kotlin/org/opensearch/indexmanagement/util/SecurityUtils.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/util/SecurityUtils.kt
@@ -38,6 +38,23 @@ class SecurityUtils {
             }
         }
 
+        fun validateUserConfiguration(user: User?, filterEnabled: Boolean) {
+            if (filterEnabled) {
+                if (user == null) {
+                    throw IndexManagementException.wrap(
+                        OpenSearchStatusException(
+                            "Filter by user backend roles in IndexManagement is not supported with security disabled",
+                            RestStatus.FORBIDDEN
+                        )
+                    )
+                } else if (user.backendRoles.isEmpty()) {
+                    throw IndexManagementException.wrap(
+                        OpenSearchStatusException("User doesn't have backend roles configured. Contact administrator", RestStatus.FORBIDDEN)
+                    )
+                }
+            }
+        }
+
         /**
          * If filterBy is enabled and security is disabled or if filter by is enabled and backend role are empty
          * we should prevent users from scheduling new jobs
@@ -88,6 +105,23 @@ class SecurityUtils {
             }
 
             return true
+        }
+
+        /**
+         * Check if the requested user has permission on the resource, throwing an exception if the user does not.
+         */
+        fun verifyUserHasPermissionForResource(
+            requestedUser: User?,
+            resourceUser: User?,
+            filterEnabled: Boolean = false,
+            resourceName: String,
+            resourceId: String
+        ) {
+            if (!userHasPermissionForResource(requestedUser, resourceUser, filterEnabled)) {
+                throw IndexManagementException.wrap(
+                    OpenSearchStatusException("Do not have permission for $resourceName [$resourceId]", RestStatus.FORBIDDEN)
+                )
+            }
         }
 
         /**

--- a/src/main/resources/mappings/opendistro-ism-config.json
+++ b/src/main/resources/mappings/opendistro-ism-config.json
@@ -1314,6 +1314,9 @@
         "description": {
           "type": "text"
         },
+        "schema_version": {
+          "type": "long"
+        },
         "creation": {
           "properties": {
             "schedule": {

--- a/src/test/kotlin/org/opensearch/indexmanagement/IndexManagementSettingsTests.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/IndexManagementSettingsTests.kt
@@ -12,6 +12,7 @@ import org.opensearch.indexmanagement.indexstatemanagement.settings.LegacyOpenDi
 import org.opensearch.indexmanagement.indexstatemanagement.settings.ManagedIndexSettings
 import org.opensearch.indexmanagement.rollup.settings.LegacyOpenDistroRollupSettings
 import org.opensearch.indexmanagement.rollup.settings.RollupSettings
+import org.opensearch.indexmanagement.snapshotmanagement.settings.SnapshotManagementSettings
 import org.opensearch.test.OpenSearchTestCase
 
 class IndexManagementSettingsTests : OpenSearchTestCase() {
@@ -91,7 +92,8 @@ class IndexManagementSettingsTests : OpenSearchTestCase() {
                     RollupSettings.ROLLUP_ENABLED,
                     RollupSettings.ROLLUP_SEARCH_ENABLED,
                     RollupSettings.ROLLUP_SEARCH_ALL_JOBS,
-                    RollupSettings.ROLLUP_DASHBOARDS
+                    RollupSettings.ROLLUP_DASHBOARDS,
+                    SnapshotManagementSettings.FILTER_BY_BACKEND_ROLES
                 )
             )
         )

--- a/src/test/kotlin/org/opensearch/indexmanagement/snapshotmanagement/TestUtils.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/snapshotmanagement/TestUtils.kt
@@ -87,6 +87,7 @@ fun randomLatestExecution(
 
 fun randomSMPolicy(
     policyName: String = randomAlphaOfLength(10).lowercase(),
+    schemaVersion: Long = OpenSearchRestTestCase.randomLong(),
     jobEnabled: Boolean = OpenSearchRestTestCase.randomBoolean(),
     jobLastUpdateTime: Instant = randomInstant(),
     creationSchedule: CronSchedule = randomCronSchedule(),
@@ -108,6 +109,7 @@ fun randomSMPolicy(
 ): SMPolicy {
     return SMPolicy(
         id = smPolicyNameToDocId(policyName),
+        schemaVersion = schemaVersion,
         jobEnabled = jobEnabled,
         jobLastUpdateTime = jobLastUpdateTime,
         creation = SMPolicy.Creation(

--- a/src/test/kotlin/org/opensearch/indexmanagement/snapshotmanagement/action/ResponseTests.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/snapshotmanagement/action/ResponseTests.kt
@@ -7,7 +7,7 @@ package org.opensearch.indexmanagement.snapshotmanagement.action
 
 import org.opensearch.common.io.stream.BytesStreamOutput
 import org.opensearch.common.io.stream.StreamInput
-import org.opensearch.indexmanagement.indexstatemanagement.util.XCONTENT_WITHOUT_TYPE
+import org.opensearch.indexmanagement.indexstatemanagement.util.XCONTENT_WITHOUT_TYPE_AND_USER
 import org.opensearch.indexmanagement.snapshotmanagement.api.transport.explain.ExplainSMPolicyResponse
 import org.opensearch.indexmanagement.snapshotmanagement.api.transport.get.GetSMPoliciesResponse
 import org.opensearch.indexmanagement.snapshotmanagement.api.transport.get.GetSMPolicyResponse
@@ -40,7 +40,7 @@ class ResponseTests : OpenSearchTestCase() {
         val smPolicy = randomSMPolicy()
         val res = IndexSMPolicyResponse("someid", 1L, 2L, 3L, smPolicy, RestStatus.OK)
         val resMap = res.toMap()
-        assertEquals(resMap["sm_policy"], smPolicy.toMap(XCONTENT_WITHOUT_TYPE))
+        assertEquals(resMap["sm_policy"], smPolicy.toMap(XCONTENT_WITHOUT_TYPE_AND_USER))
     }
 
     fun `test get sm policy response`() {
@@ -83,6 +83,6 @@ class ResponseTests : OpenSearchTestCase() {
         val smPolicy = randomSMPolicy()
         val res = GetSMPolicyResponse("someid", 1L, 2L, 3L, smPolicy)
         val resMap = res.toMap()
-        assertEquals(resMap["sm_policy"], smPolicy.toMap(XCONTENT_WITHOUT_TYPE))
+        assertEquals(resMap["sm_policy"], smPolicy.toMap(XCONTENT_WITHOUT_TYPE_AND_USER))
     }
 }

--- a/src/test/kotlin/org/opensearch/indexmanagement/snapshotmanagement/engine/states/creation/CreatingStateTests.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/snapshotmanagement/engine/states/creation/CreatingStateTests.kt
@@ -6,8 +6,8 @@
 package org.opensearch.indexmanagement.snapshotmanagement.engine.states.creation
 
 import kotlinx.coroutines.runBlocking
-import org.opensearch.indexmanagement.ClientMockTestCase
 import org.opensearch.indexmanagement.snapshotmanagement.engine.SMStateMachine
+import org.opensearch.indexmanagement.snapshotmanagement.engine.SMStateMachineTests
 import org.opensearch.indexmanagement.snapshotmanagement.engine.states.SMResult
 import org.opensearch.indexmanagement.snapshotmanagement.engine.states.SMState
 import org.opensearch.indexmanagement.snapshotmanagement.randomSMMetadata
@@ -19,7 +19,7 @@ import org.opensearch.indexmanagement.snapshotmanagement.model.SMMetadata
 import java.time.Instant.now
 import java.time.temporal.ChronoUnit
 
-class CreatingStateTests : ClientMockTestCase() {
+class CreatingStateTests : SMStateMachineTests() {
 
     fun `test create snapshot succeed`() = runBlocking {
         mockGetSnapshotsCall(response = mockGetSnapshotResponse(0))
@@ -29,7 +29,7 @@ class CreatingStateTests : ClientMockTestCase() {
             creationCurrentState = SMState.CREATION_CONDITION_MET,
         )
         val job = randomSMPolicy()
-        val context = SMStateMachine(client, job, metadata)
+        val context = SMStateMachine(client, job, metadata, settings, threadPool)
 
         val result = SMState.CREATING.instance.execute(context)
         assertTrue("Execution result should be Next.", result is SMResult.Next)
@@ -47,7 +47,7 @@ class CreatingStateTests : ClientMockTestCase() {
             creationCurrentState = SMState.CREATION_CONDITION_MET,
         )
         val job = randomSMPolicy()
-        val context = SMStateMachine(client, job, metadata)
+        val context = SMStateMachine(client, job, metadata, settings, threadPool)
 
         val result = SMState.CREATING.instance.execute(context)
         assertTrue("Execution result should be Failure.", result is SMResult.Fail)
@@ -67,7 +67,7 @@ class CreatingStateTests : ClientMockTestCase() {
             creationCurrentState = SMState.CREATION_CONDITION_MET,
         )
         val job = randomSMPolicy(policyName = "daily-snapshot")
-        val context = SMStateMachine(client, job, metadata)
+        val context = SMStateMachine(client, job, metadata, settings, threadPool)
 
         val result = SMState.CREATING.instance.execute(context)
         assertTrue("Execution result should be Next.", result is SMResult.Next)
@@ -87,7 +87,7 @@ class CreatingStateTests : ClientMockTestCase() {
             creationCurrentState = SMState.CREATION_CONDITION_MET,
         )
         val job = randomSMPolicy(policyName = "daily-snapshot")
-        val context = SMStateMachine(client, job, metadata)
+        val context = SMStateMachine(client, job, metadata, settings, threadPool)
 
         val result = SMState.CREATING.instance.execute(context)
         assertTrue("Execution result should be Next.", result is SMResult.Next)
@@ -103,7 +103,7 @@ class CreatingStateTests : ClientMockTestCase() {
             creationCurrentState = SMState.CREATION_CONDITION_MET,
         )
         val job = randomSMPolicy()
-        val context = SMStateMachine(client, job, metadata)
+        val context = SMStateMachine(client, job, metadata, settings, threadPool)
 
         val result = SMState.CREATING.instance.execute(context)
         assertTrue("Execution result should be Failure.", result is SMResult.Fail)

--- a/src/test/kotlin/org/opensearch/indexmanagement/snapshotmanagement/engine/states/creation/CreationConditionMetStateTests.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/snapshotmanagement/engine/states/creation/CreationConditionMetStateTests.kt
@@ -6,15 +6,15 @@
 package org.opensearch.indexmanagement.snapshotmanagement.engine.states.creation
 
 import kotlinx.coroutines.runBlocking
-import org.opensearch.indexmanagement.ClientMockTestCase
 import org.opensearch.indexmanagement.snapshotmanagement.engine.SMStateMachine
+import org.opensearch.indexmanagement.snapshotmanagement.engine.SMStateMachineTests
 import org.opensearch.indexmanagement.snapshotmanagement.engine.states.SMResult
 import org.opensearch.indexmanagement.snapshotmanagement.engine.states.SMState
 import org.opensearch.indexmanagement.snapshotmanagement.randomSMMetadata
 import org.opensearch.indexmanagement.snapshotmanagement.randomSMPolicy
 import java.time.Instant.now
 
-class CreationConditionMetStateTests : ClientMockTestCase() {
+class CreationConditionMetStateTests : SMStateMachineTests() {
 
     fun `test next creation time met`() = runBlocking {
         val metadata = randomSMMetadata(
@@ -22,7 +22,7 @@ class CreationConditionMetStateTests : ClientMockTestCase() {
             nextCreationTime = now().minusSeconds(60),
         )
         val job = randomSMPolicy()
-        val context = SMStateMachine(client, job, metadata)
+        val context = SMStateMachine(client, job, metadata, settings, threadPool)
 
         val result = SMState.CREATION_CONDITION_MET.instance.execute(context)
         assertTrue("Execution result should be Next.", result is SMResult.Next)
@@ -36,7 +36,7 @@ class CreationConditionMetStateTests : ClientMockTestCase() {
             nextCreationTime = now().plusSeconds(60),
         )
         val job = randomSMPolicy()
-        val context = SMStateMachine(client, job, metadata)
+        val context = SMStateMachine(client, job, metadata, settings, threadPool)
 
         val result = SMState.CREATION_CONDITION_MET.instance.execute(context)
         assertTrue("Execution result should be Stay.", result is SMResult.Stay)

--- a/src/test/kotlin/org/opensearch/indexmanagement/snapshotmanagement/engine/states/creation/CreationFinishedStateTests.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/snapshotmanagement/engine/states/creation/CreationFinishedStateTests.kt
@@ -7,8 +7,8 @@ package org.opensearch.indexmanagement.snapshotmanagement.engine.states.creation
 
 import kotlinx.coroutines.runBlocking
 import org.opensearch.common.unit.TimeValue
-import org.opensearch.indexmanagement.ClientMockTestCase
 import org.opensearch.indexmanagement.snapshotmanagement.engine.SMStateMachine
+import org.opensearch.indexmanagement.snapshotmanagement.engine.SMStateMachineTests
 import org.opensearch.indexmanagement.snapshotmanagement.engine.states.SMResult
 import org.opensearch.indexmanagement.snapshotmanagement.engine.states.SMState
 import org.opensearch.indexmanagement.snapshotmanagement.mockGetSnapshotResponse
@@ -20,7 +20,7 @@ import org.opensearch.indexmanagement.snapshotmanagement.randomSMMetadata
 import org.opensearch.indexmanagement.snapshotmanagement.randomSMPolicy
 import java.time.Instant
 
-class CreationFinishedStateTests : ClientMockTestCase() {
+class CreationFinishedStateTests : SMStateMachineTests() {
     fun `test creation end successful`() = runBlocking {
         val snapshotName = "test_creation_succeed"
         val snapshotInfo = mockSnapshotInfo(name = snapshotName)
@@ -34,7 +34,7 @@ class CreationFinishedStateTests : ClientMockTestCase() {
             ),
         )
         val job = randomSMPolicy(policyName = "daily-snapshot")
-        val context = SMStateMachine(client, job, metadata)
+        val context = SMStateMachine(client, job, metadata, settings, threadPool)
 
         val result = SMState.CREATION_FINISHED.instance.execute(context)
         assertTrue("Execution results should be Next.", result is SMResult.Next)
@@ -59,7 +59,7 @@ class CreationFinishedStateTests : ClientMockTestCase() {
             ),
         )
         val job = randomSMPolicy(policyName = "daily-snapshot")
-        val context = SMStateMachine(client, job, metadata)
+        val context = SMStateMachine(client, job, metadata, settings, threadPool)
 
         val result = SMState.CREATION_FINISHED.instance.execute(context)
         assertTrue("Execution results should be Stay.", result is SMResult.Stay)
@@ -81,7 +81,7 @@ class CreationFinishedStateTests : ClientMockTestCase() {
             ),
         )
         val job = randomSMPolicy(policyName = "daily-snapshot")
-        val context = SMStateMachine(client, job, metadata)
+        val context = SMStateMachine(client, job, metadata, settings, threadPool)
 
         val result = SMState.CREATION_FINISHED.instance.execute(context)
         assertTrue("Execution results should be Next.", result is SMResult.Next)
@@ -105,7 +105,7 @@ class CreationFinishedStateTests : ClientMockTestCase() {
             ),
         )
         val job = randomSMPolicy(policyName = "daily-snapshot")
-        val context = SMStateMachine(client, job, metadata)
+        val context = SMStateMachine(client, job, metadata, settings, threadPool)
 
         val result = SMState.CREATION_FINISHED.instance.execute(context)
         assertTrue("Execution results should be Failure.", result is SMResult.Fail)
@@ -128,7 +128,7 @@ class CreationFinishedStateTests : ClientMockTestCase() {
             ),
         )
         val job = randomSMPolicy(policyName = "daily-snapshot")
-        val context = SMStateMachine(client, job, metadata)
+        val context = SMStateMachine(client, job, metadata, settings, threadPool)
 
         val result = SMState.CREATION_FINISHED.instance.execute(context)
         assertTrue("Execution results should be Next.", result is SMResult.Next)
@@ -155,7 +155,7 @@ class CreationFinishedStateTests : ClientMockTestCase() {
             policyName = "daily-snapshot",
             creationTimeLimit = TimeValue.timeValueSeconds(5)
         )
-        val context = SMStateMachine(client, job, metadata)
+        val context = SMStateMachine(client, job, metadata, settings, threadPool)
 
         val result = SMState.CREATION_FINISHED.instance.execute(context)
         assertTrue("Execution results should be Failure.", result is SMResult.Fail)

--- a/src/test/kotlin/org/opensearch/indexmanagement/snapshotmanagement/engine/states/creation/CreationStartStateTests.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/snapshotmanagement/engine/states/creation/CreationStartStateTests.kt
@@ -6,21 +6,21 @@
 package org.opensearch.indexmanagement.snapshotmanagement.engine.states.creation
 
 import kotlinx.coroutines.runBlocking
-import org.opensearch.indexmanagement.ClientMockTestCase
 import org.opensearch.indexmanagement.snapshotmanagement.engine.SMStateMachine
+import org.opensearch.indexmanagement.snapshotmanagement.engine.SMStateMachineTests
 import org.opensearch.indexmanagement.snapshotmanagement.engine.states.SMResult
 import org.opensearch.indexmanagement.snapshotmanagement.engine.states.SMState
 import org.opensearch.indexmanagement.snapshotmanagement.randomSMMetadata
 import org.opensearch.indexmanagement.snapshotmanagement.randomSMPolicy
 
-class CreationStartStateTests : ClientMockTestCase() {
+class CreationStartStateTests : SMStateMachineTests() {
 
     fun `test start state execution`() = runBlocking {
         val metadata = randomSMMetadata(
             creationCurrentState = SMState.CREATION_FINISHED
         )
         val job = randomSMPolicy()
-        val context = SMStateMachine(client, job, metadata)
+        val context = SMStateMachine(client, job, metadata, settings, threadPool)
 
         val result = SMState.CREATION_START.instance.execute(context)
         assertTrue("Execution result should be Next.", result is SMResult.Next)

--- a/src/test/kotlin/org/opensearch/indexmanagement/snapshotmanagement/engine/states/deletion/DeletingStateTests.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/snapshotmanagement/engine/states/deletion/DeletingStateTests.kt
@@ -8,8 +8,8 @@ package org.opensearch.indexmanagement.snapshotmanagement.engine.states.deletion
 import kotlinx.coroutines.runBlocking
 import org.opensearch.action.support.master.AcknowledgedResponse
 import org.opensearch.common.unit.TimeValue
-import org.opensearch.indexmanagement.ClientMockTestCase
 import org.opensearch.indexmanagement.snapshotmanagement.engine.SMStateMachine
+import org.opensearch.indexmanagement.snapshotmanagement.engine.SMStateMachineTests
 import org.opensearch.indexmanagement.snapshotmanagement.engine.states.SMResult
 import org.opensearch.indexmanagement.snapshotmanagement.engine.states.SMState
 import org.opensearch.indexmanagement.snapshotmanagement.mockGetSnapshotResponse
@@ -22,7 +22,7 @@ import org.opensearch.indexmanagement.snapshotmanagement.randomSMPolicy
 import org.opensearch.indexmanagement.snapshotmanagement.randomSnapshotName
 import java.time.Instant.now
 
-class DeletingStateTests : ClientMockTestCase() {
+class DeletingStateTests : SMStateMachineTests() {
 
     fun `test snapshots exceed max count`() = runBlocking {
         mockGetSnapshotsCall(response = mockGetSnapshotResponse(11))
@@ -35,7 +35,7 @@ class DeletingStateTests : ClientMockTestCase() {
             policyName = "daily-snapshot",
             deletionMaxCount = 10,
         )
-        val context = SMStateMachine(client, job, metadata)
+        val context = SMStateMachine(client, job, metadata, settings, threadPool)
 
         val result = SMState.DELETING.instance.execute(context)
         assertTrue("Execution result should be Next.", result is SMResult.Next)
@@ -60,7 +60,7 @@ class DeletingStateTests : ClientMockTestCase() {
             deletionMaxAge = TimeValue.timeValueMinutes(1),
             deletionMinCount = 2,
         )
-        val context = SMStateMachine(client, job, metadata)
+        val context = SMStateMachine(client, job, metadata, settings, threadPool)
 
         val result = SMState.DELETING.instance.execute(context)
         assertTrue("Execution result should be Next.", result is SMResult.Next)
@@ -85,7 +85,7 @@ class DeletingStateTests : ClientMockTestCase() {
             deletionMaxAge = TimeValue.timeValueMinutes(1),
             deletionMinCount = 2,
         )
-        val context = SMStateMachine(client, job, metadata)
+        val context = SMStateMachine(client, job, metadata, settings, threadPool)
 
         val result = SMState.DELETING.instance.execute(context)
         assertTrue("Execution result should be Next.", result is SMResult.Next)
@@ -104,7 +104,7 @@ class DeletingStateTests : ClientMockTestCase() {
             deletionCurrentState = SMState.DELETION_CONDITION_MET,
         )
         val job = randomSMPolicy(policyName = "daily-snapshot")
-        val context = SMStateMachine(client, job, metadata)
+        val context = SMStateMachine(client, job, metadata, settings, threadPool)
 
         val result = SMState.DELETING.instance.execute(context)
         assertTrue("Execution result should be Failure.", result is SMResult.Fail)
@@ -126,7 +126,7 @@ class DeletingStateTests : ClientMockTestCase() {
             )
         )
         val job = randomSMPolicy(policyName = "daily-snapshot")
-        val context = SMStateMachine(client, job, metadata)
+        val context = SMStateMachine(client, job, metadata, settings, threadPool)
 
         val result = SMState.DELETING.instance.execute(context)
         assertTrue("Execution result should be Fail.", result is SMResult.Fail)
@@ -145,7 +145,7 @@ class DeletingStateTests : ClientMockTestCase() {
         val job = randomSMPolicy(
             deletionNull = true
         )
-        val context = SMStateMachine(client, job, metadata)
+        val context = SMStateMachine(client, job, metadata, settings, threadPool)
 
         val result = SMState.DELETING.instance.execute(context)
         assertTrue("Execution result should be Fail.", result is SMResult.Fail)

--- a/src/test/kotlin/org/opensearch/indexmanagement/snapshotmanagement/engine/states/deletion/DeletionConditionMetStateTests.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/snapshotmanagement/engine/states/deletion/DeletionConditionMetStateTests.kt
@@ -6,8 +6,8 @@
 package org.opensearch.indexmanagement.snapshotmanagement.engine.states.deletion
 
 import kotlinx.coroutines.runBlocking
-import org.opensearch.indexmanagement.ClientMockTestCase
 import org.opensearch.indexmanagement.snapshotmanagement.engine.SMStateMachine
+import org.opensearch.indexmanagement.snapshotmanagement.engine.SMStateMachineTests
 import org.opensearch.indexmanagement.snapshotmanagement.engine.states.SMResult
 import org.opensearch.indexmanagement.snapshotmanagement.engine.states.SMState
 import org.opensearch.indexmanagement.snapshotmanagement.randomSMMetadata
@@ -15,7 +15,7 @@ import org.opensearch.indexmanagement.snapshotmanagement.randomSMPolicy
 import org.opensearch.indexmanagement.snapshotmanagement.randomSnapshotName
 import java.time.Instant
 
-class DeletionConditionMetStateTests : ClientMockTestCase() {
+class DeletionConditionMetStateTests : SMStateMachineTests() {
 
     fun `test next deletion time met`() = runBlocking {
         val metadata = randomSMMetadata(
@@ -23,7 +23,7 @@ class DeletionConditionMetStateTests : ClientMockTestCase() {
             nextDeletionTime = Instant.now().minusSeconds(60),
         )
         val job = randomSMPolicy()
-        val context = SMStateMachine(client, job, metadata)
+        val context = SMStateMachine(client, job, metadata, settings, threadPool)
 
         val result = SMState.DELETION_CONDITION_MET.instance.execute(context)
         assertTrue("Execution result should be Next.", result is SMResult.Next)
@@ -37,7 +37,7 @@ class DeletionConditionMetStateTests : ClientMockTestCase() {
             nextDeletionTime = Instant.now().plusSeconds(60),
         )
         val job = randomSMPolicy()
-        val context = SMStateMachine(client, job, metadata)
+        val context = SMStateMachine(client, job, metadata, settings, threadPool)
 
         val result = SMState.DELETION_CONDITION_MET.instance.execute(context)
         assertTrue("Execution result should be Stay.", result is SMResult.Stay)
@@ -53,7 +53,7 @@ class DeletionConditionMetStateTests : ClientMockTestCase() {
         val job = randomSMPolicy(
             deletionNull = true
         )
-        val context = SMStateMachine(client, job, metadata)
+        val context = SMStateMachine(client, job, metadata, settings, threadPool)
 
         val result = SMState.DELETION_CONDITION_MET.instance.execute(context)
         assertTrue("Execution result should be Fail.", result is SMResult.Fail)

--- a/src/test/kotlin/org/opensearch/indexmanagement/snapshotmanagement/engine/states/deletion/DeletionFinishedStateTests.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/snapshotmanagement/engine/states/deletion/DeletionFinishedStateTests.kt
@@ -7,8 +7,8 @@ package org.opensearch.indexmanagement.snapshotmanagement.engine.states.deletion
 
 import kotlinx.coroutines.runBlocking
 import org.opensearch.common.unit.TimeValue
-import org.opensearch.indexmanagement.ClientMockTestCase
 import org.opensearch.indexmanagement.snapshotmanagement.engine.SMStateMachine
+import org.opensearch.indexmanagement.snapshotmanagement.engine.SMStateMachineTests
 import org.opensearch.indexmanagement.snapshotmanagement.engine.states.SMResult
 import org.opensearch.indexmanagement.snapshotmanagement.engine.states.SMState
 import org.opensearch.indexmanagement.snapshotmanagement.mockGetSnapshotResponse
@@ -19,7 +19,7 @@ import org.opensearch.indexmanagement.snapshotmanagement.randomSMMetadata
 import org.opensearch.indexmanagement.snapshotmanagement.randomSMPolicy
 import java.time.Instant
 
-class DeletionFinishedStateTests : ClientMockTestCase() {
+class DeletionFinishedStateTests : SMStateMachineTests() {
     fun `test deletion succeed`() = runBlocking {
         val snapshotName = "test_deletion_success"
         mockGetSnapshotsCall(response = mockGetSnapshotResponse(0))
@@ -32,7 +32,7 @@ class DeletionFinishedStateTests : ClientMockTestCase() {
             ),
         )
         val job = randomSMPolicy(policyName = "daily-snapshot")
-        val context = SMStateMachine(client, job, metadata)
+        val context = SMStateMachine(client, job, metadata, settings, threadPool)
 
         val result = SMState.DELETION_FINISHED.instance.execute(context)
         assertTrue("Execution results should be Next.", result is SMResult.Next)
@@ -57,7 +57,7 @@ class DeletionFinishedStateTests : ClientMockTestCase() {
             ),
         )
         val job = randomSMPolicy(policyName = "daily-snapshot")
-        val context = SMStateMachine(client, job, metadata)
+        val context = SMStateMachine(client, job, metadata, settings, threadPool)
 
         val result = SMState.DELETION_FINISHED.instance.execute(context)
         assertTrue("Execution results should be Stay.", result is SMResult.Stay)
@@ -80,7 +80,7 @@ class DeletionFinishedStateTests : ClientMockTestCase() {
             ),
         )
         val job = randomSMPolicy(policyName = "daily-snapshot")
-        val context = SMStateMachine(client, job, metadata)
+        val context = SMStateMachine(client, job, metadata, settings, threadPool)
 
         val result = SMState.DELETION_FINISHED.instance.execute(context)
         assertTrue("Execution results should be Failure.", result is SMResult.Fail)
@@ -104,7 +104,7 @@ class DeletionFinishedStateTests : ClientMockTestCase() {
             ),
         )
         val job = randomSMPolicy(policyName = "daily-snapshot", deletionTimeLimit = TimeValue.timeValueSeconds(5))
-        val context = SMStateMachine(client, job, metadata)
+        val context = SMStateMachine(client, job, metadata, settings, threadPool)
 
         val result = SMState.DELETION_FINISHED.instance.execute(context)
         assertTrue("Execution results should be Failure.", result is SMResult.Fail)

--- a/src/test/kotlin/org/opensearch/indexmanagement/snapshotmanagement/engine/states/deletion/DeletionStartStateTests.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/snapshotmanagement/engine/states/deletion/DeletionStartStateTests.kt
@@ -6,21 +6,21 @@
 package org.opensearch.indexmanagement.snapshotmanagement.engine.states.deletion
 
 import kotlinx.coroutines.runBlocking
-import org.opensearch.indexmanagement.ClientMockTestCase
 import org.opensearch.indexmanagement.snapshotmanagement.engine.SMStateMachine
+import org.opensearch.indexmanagement.snapshotmanagement.engine.SMStateMachineTests
 import org.opensearch.indexmanagement.snapshotmanagement.engine.states.SMResult
 import org.opensearch.indexmanagement.snapshotmanagement.engine.states.SMState
 import org.opensearch.indexmanagement.snapshotmanagement.randomSMMetadata
 import org.opensearch.indexmanagement.snapshotmanagement.randomSMPolicy
 
-class DeletionStartStateTests : ClientMockTestCase() {
+class DeletionStartStateTests : SMStateMachineTests() {
 
     fun `test start state execution`() = runBlocking {
         val metadata = randomSMMetadata(
             deletionCurrentState = SMState.DELETION_FINISHED
         )
         val job = randomSMPolicy()
-        val context = SMStateMachine(client, job, metadata)
+        val context = SMStateMachine(client, job, metadata, settings, threadPool)
 
         val result = SMState.DELETION_START.instance.execute(context)
         assertTrue("Execution result should be Next.", result is SMResult.Next)

--- a/src/test/kotlin/org/opensearch/indexmanagement/snapshotmanagement/resthandler/RestGetSnapshotManagementIT.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/snapshotmanagement/resthandler/RestGetSnapshotManagementIT.kt
@@ -12,6 +12,7 @@ import org.opensearch.indexmanagement.IndexManagementPlugin
 import org.opensearch.indexmanagement.makeRequest
 import org.opensearch.indexmanagement.opensearchapi.convertToMap
 import org.opensearch.indexmanagement.snapshotmanagement.SnapshotManagementRestTestCase
+import org.opensearch.indexmanagement.snapshotmanagement.model.SMPolicy
 import org.opensearch.indexmanagement.snapshotmanagement.model.SMPolicy.Companion.ENABLED_TIME_FIELD
 import org.opensearch.indexmanagement.snapshotmanagement.model.SMPolicy.Companion.SM_TYPE
 import org.opensearch.indexmanagement.snapshotmanagement.randomSMPolicy
@@ -73,7 +74,9 @@ class RestGetSnapshotManagementIT : SnapshotManagementRestTestCase() {
             assertNotNull("Did not find matching SM Policy that should exist", foundPolicy)
             assertNotNull("Matching response did not have policy", foundPolicy?.get(SM_TYPE))
             val policyInResponse = foundPolicy!![SM_TYPE]
-            assertEquals("Policy in get all response differed from actual", testSMPolicy.convertToMap()[SM_TYPE], policyInResponse)
+            val actualPolicyMap = testSMPolicy.convertToMap()[SM_TYPE] as MutableMap<String, Any>
+            actualPolicyMap.remove(SMPolicy.USER_FIELD)
+            assertEquals("Policy in get all response differed from actual", actualPolicyMap, policyInResponse)
         }
     }
 
@@ -96,7 +99,9 @@ class RestGetSnapshotManagementIT : SnapshotManagementRestTestCase() {
             assertNotNull("Did not find matching SM Policy that should exist", foundPolicy)
             assertNotNull("Matching response did not have policy", foundPolicy?.get(SM_TYPE))
             val policyInResponse = foundPolicy!![SM_TYPE]
-            assertEquals("Policy in get all response differed from actual", testSMPolicy.convertToMap()[SM_TYPE], policyInResponse)
+            val actualPolicyMap = testSMPolicy.convertToMap()[SM_TYPE] as MutableMap<String, Any>
+            actualPolicyMap.remove(SMPolicy.USER_FIELD)
+            assertEquals("Policy in get all response differed from actual", actualPolicyMap, policyInResponse)
         }
         // Add the 'from' param
         searchParamQuery["from"] = searchParamSize.toString()
@@ -112,7 +117,9 @@ class RestGetSnapshotManagementIT : SnapshotManagementRestTestCase() {
             assertNotNull("Did not find matching SM Policy that should exist", foundPolicy)
             assertNotNull("Matching response did not have policy", foundPolicy?.get(SM_TYPE))
             val policyInResponse = foundPolicy!![SM_TYPE]
-            assertEquals("Policy in get all response differed from actual", testSMPolicy.convertToMap()[SM_TYPE], policyInResponse)
+            val actualPolicyMap = testSMPolicy.convertToMap()[SM_TYPE] as MutableMap<String, Any>
+            actualPolicyMap.remove(SMPolicy.USER_FIELD)
+            assertEquals("Policy in get all response differed from actual", actualPolicyMap, policyInResponse)
         }
     }
 
@@ -132,7 +139,9 @@ class RestGetSnapshotManagementIT : SnapshotManagementRestTestCase() {
             val actualPolicy = sortedPolicies[policyNumber]
             val foundPolicy = responsePolicies[policyNumber]
             val policyInResponse = foundPolicy[SM_TYPE]
-            assertEquals("Policy in get all response differed from actual", actualPolicy.convertToMap()[SM_TYPE], policyInResponse)
+            val actualPolicyMap = actualPolicy.convertToMap()[SM_TYPE] as MutableMap<String, Any>
+            actualPolicyMap.remove(SMPolicy.USER_FIELD)
+            assertEquals("Policy in get all response differed from actual", actualPolicyMap, policyInResponse)
         }
     }
 }

--- a/src/test/kotlin/org/opensearch/indexmanagement/snapshotmanagement/resthandler/RestIndexSnapshotManagementIT.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/snapshotmanagement/resthandler/RestIndexSnapshotManagementIT.kt
@@ -9,7 +9,6 @@ import org.opensearch.client.ResponseException
 import org.opensearch.common.xcontent.XContentType
 import org.opensearch.indexmanagement.IndexManagementPlugin.Companion.INDEX_MANAGEMENT_INDEX
 import org.opensearch.indexmanagement.IndexManagementPlugin.Companion.SM_POLICIES_URI
-import org.opensearch.indexmanagement.indexstatemanagement.util.XCONTENT_WITHOUT_TYPE
 import org.opensearch.indexmanagement.indexstatemanagement.util.XCONTENT_WITHOUT_TYPE_AND_USER
 import org.opensearch.indexmanagement.makeRequest
 import org.opensearch.indexmanagement.snapshotmanagement.SnapshotManagementRestTestCase

--- a/src/test/resources/mappings/cached-opendistro-ism-config.json
+++ b/src/test/resources/mappings/cached-opendistro-ism-config.json
@@ -1314,6 +1314,9 @@
         "description": {
           "type": "text"
         },
+        "schema_version": {
+          "type": "long"
+        },
         "creation": {
           "properties": {
             "schedule": {


### PR DESCRIPTION
*Issue #, if available:*
NA

*Description of changes:*
Adds security integration for snapshot management. Adds config schema version and user to SMPolicy model. Tested manually by updating the index management zip on the 2.0 OpenSearch tar.
APIs:
- Index/update: throws an exception if FILTER_BY_BACKEND_ROLES is enabled and security is disabled
- Get policy: throws an exception if the user does not have permission for the policy
- Start/stop/delete: throws an exception if the user does not have permission for the policy
- Get all policies: Adds user filter to query for policies
- Explain: Adds user filter to query for policies

Core:
- Wraps the state running logic in a thread injected with the user noted in the snapshot management policy, restricting snapshot management to accessing the user's resources.

Following a core security failure, the explain response would contain the following information, or something similar:
```
info=Info(message=Caught exception while creating snapshot test-policy-cz2ph18f., cause=no permissions for [cluster:admin/snapshot/create] and associated roles [own_index, indices_all_role, slm_all_role]))
```

*CheckList:*
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/index-management/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
