### PR TITLE
Snapshot management default date format in snapshot name

### DIFF
--- a/src/main/kotlin/org/opensearch/indexmanagement/snapshotmanagement/SMUtils.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/snapshotmanagement/SMUtils.kt
@@ -51,6 +51,7 @@ import java.time.ZoneId
 import java.time.format.DateTimeFormatter
 import java.time.temporal.ChronoUnit
 import java.util.Locale
+import org.opensearch.common.time.DateFormatters
 
 private val log = LogManager.getLogger("o.i.s.SnapshotManagementHelper")
 
@@ -161,10 +162,12 @@ fun getRandomString(length: Int): String {
         .joinToString("")
 }
 
+/**
+ * For supporting formats, refer to [DateFormatters]
+ */
 fun generateFormatTime(dateFormat: String, timezone: ZoneId = ZoneId.of("UTC")): String {
     val dateFormatter = DateFormatter.forPattern(dateFormat).withZone(timezone)
-    val instant = dateFormatter.toDateMathParser().parse("now/s", System::currentTimeMillis, false, timezone)
-    return dateFormatter.format(instant)
+    return dateFormatter.format(now())
 }
 
 fun validateDateFormat(dateFormat: String): String? {

--- a/src/main/kotlin/org/opensearch/indexmanagement/snapshotmanagement/SMUtils.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/snapshotmanagement/SMUtils.kt
@@ -145,13 +145,13 @@ fun generateSnapshotName(policy: SMPolicy): String {
         dateFormat = "yyyy-MM-dd'T'HH:mm:ss"
     }
     val dateValue = if (policy.snapshotConfig[DATE_FORMAT_TIMEZONE_FIELD] != null) {
-        generateFormatTime(
+        generateFormatDate(
             dateFormat,
             ZoneId.of(policy.snapshotConfig[DATE_FORMAT_TIMEZONE_FIELD] as String),
         )
     } else {
-        generateFormatTime(dateFormat)
-    }
+        generateFormatDate(dateFormat)
+    }.lowercase()
     result += "-$dateValue"
     return result + "-${getRandomString(RANDOM_STRING_LENGTH)}"
 }
@@ -167,7 +167,7 @@ fun getRandomString(length: Int): String {
 /**
  * For the supporting formats, refer to [DateFormatters]
  */
-fun generateFormatTime(dateFormat: String, timezone: ZoneId = ZoneId.of("UTC")): String {
+fun generateFormatDate(dateFormat: String, timezone: ZoneId = ZoneId.of("UTC")): String {
     val dateFormatter = DateFormatter.forPattern(dateFormat).withZone(timezone)
     return dateFormatter.format(now())
 }

--- a/src/main/kotlin/org/opensearch/indexmanagement/snapshotmanagement/SMUtils.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/snapshotmanagement/SMUtils.kt
@@ -140,17 +140,19 @@ suspend fun Client.indexMetadata(
 
 fun generateSnapshotName(policy: SMPolicy): String {
     var result: String = policy.policyName
-    if (policy.snapshotConfig[DATE_FORMAT_FIELD] != null) {
-        val dateFormat = if (policy.snapshotConfig[DATE_FORMAT_TIMEZONE_FIELD] != null) {
-            generateFormatTime(
-                policy.snapshotConfig[DATE_FORMAT_FIELD] as String,
-                ZoneId.of(policy.snapshotConfig[DATE_FORMAT_TIMEZONE_FIELD] as String),
-            )
-        } else {
-            generateFormatTime(policy.snapshotConfig[DATE_FORMAT_FIELD] as String)
-        }
-        result += "-$dateFormat"
+    var dateFormat = policy.snapshotConfig[DATE_FORMAT_FIELD] as String?
+    if (dateFormat == null) {
+        dateFormat = "yyyy-MM-dd'T'HH:mm:ss"
     }
+    val dateValue = if (policy.snapshotConfig[DATE_FORMAT_TIMEZONE_FIELD] != null) {
+        generateFormatTime(
+            dateFormat,
+            ZoneId.of(policy.snapshotConfig[DATE_FORMAT_TIMEZONE_FIELD] as String),
+        )
+    } else {
+        generateFormatTime(dateFormat)
+    }
+    result += "-$dateValue"
     return result + "-${getRandomString(RANDOM_STRING_LENGTH)}"
 }
 
@@ -163,7 +165,7 @@ fun getRandomString(length: Int): String {
 }
 
 /**
- * For supporting formats, refer to [DateFormatters]
+ * For the supporting formats, refer to [DateFormatters]
  */
 fun generateFormatTime(dateFormat: String, timezone: ZoneId = ZoneId.of("UTC")): String {
     val dateFormatter = DateFormatter.forPattern(dateFormat).withZone(timezone)

--- a/src/test/kotlin/org/opensearch/indexmanagement/snapshotmanagement/SMUtilsTests.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/snapshotmanagement/SMUtilsTests.kt
@@ -25,7 +25,7 @@ class SMUtilsTests : OpenSearchTestCase() {
 
     fun `test snapshot name date_format`() {
         assertFailsWith<IllegalArgumentException> {
-            val smPolicy = randomSMPolicy(dateFormat = "")
+            val smPolicy = randomSMPolicy(dateFormat = " ")
             val smPolicyString = smPolicy.toJsonString()
             smPolicyString.parser().parseWithType(smPolicy.id, smPolicy.seqNo, smPolicy.primaryTerm, SMPolicy.Companion::parse)
         }

--- a/src/test/kotlin/org/opensearch/indexmanagement/snapshotmanagement/SnapshotManagementRestTestCase.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/snapshotmanagement/SnapshotManagementRestTestCase.kt
@@ -10,6 +10,7 @@ import org.apache.http.HttpHeaders
 import org.apache.http.entity.ContentType.APPLICATION_JSON
 import org.apache.http.entity.StringEntity
 import org.apache.http.message.BasicHeader
+import org.junit.Before
 import org.opensearch.client.Response
 import org.opensearch.client.ResponseException
 import org.opensearch.common.xcontent.XContentParser
@@ -30,9 +31,23 @@ import org.opensearch.jobscheduler.spi.schedule.IntervalSchedule
 import org.opensearch.rest.RestStatus
 import java.io.InputStream
 import java.time.Duration
+import java.time.Instant
 import java.time.Instant.now
 
 abstract class SnapshotManagementRestTestCase : IndexManagementRestTestCase() {
+
+    var timeout: Instant = Instant.ofEpochSecond(20)
+
+    /**
+     * For multi node test, if the shard of config index is moving, then the job scheduler
+     * could miss the execution after [updateSMPolicyStartTime]
+     * Extending this to be more than 1 minute, so even missed at first place, it could still be
+     * picked up to run in the next scheduled job.
+     */
+    @Before
+    fun timeoutForMultiNode() {
+        if (isMultiNode) timeout = Instant.ofEpochSecond(70)
+    }
 
     protected fun createSMPolicy(
         smPolicy: SMPolicy,

--- a/src/test/kotlin/org/opensearch/indexmanagement/snapshotmanagement/resthandler/RestExplainSnapshotManagementIT.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/snapshotmanagement/resthandler/RestExplainSnapshotManagementIT.kt
@@ -32,7 +32,7 @@ class RestExplainSnapshotManagementIT : SnapshotManagementRestTestCase() {
             )
         )
         updateSMPolicyStartTime(smPolicy)
-        waitFor {
+        waitFor(timeout = timeout) {
             val explainResponse = explainSMPolicy(smPolicy.policyName)
             val responseMap = createParser(XContentType.JSON.xContent(), explainResponse.entity.content).map() as Map<String, Any>
             assertTrue(responseMap.containsKey(ExplainSMPolicyResponse.SM_POLICIES_FIELD))
@@ -76,7 +76,7 @@ class RestExplainSnapshotManagementIT : SnapshotManagementRestTestCase() {
         }
         // if this proves to be flaky, just index the metadata directly instead of executing to generate metadata
         smPolicies.forEach { updateSMPolicyStartTime(it) }
-        waitFor {
+        waitFor(timeout = timeout) {
             val explainResponse = explainSMPolicy(smPolicies.joinToString(",") { it.policyName })
             val responseMap = createParser(XContentType.JSON.xContent(), explainResponse.entity.content).map() as Map<String, Any>
             assertTrue(responseMap.containsKey(ExplainSMPolicyResponse.SM_POLICIES_FIELD))
@@ -104,7 +104,7 @@ class RestExplainSnapshotManagementIT : SnapshotManagementRestTestCase() {
         }
         // if this proves to be flaky, just index the metadata directly instead of executing to generate metadata
         smPolicies.forEach { updateSMPolicyStartTime(it) }
-        waitFor {
+        waitFor(timeout = timeout) {
             val explainResponse = explainSMPolicy("")
             val responseMap = createParser(XContentType.JSON.xContent(), explainResponse.entity.content).map() as Map<String, Any>
             assertTrue(responseMap.containsKey(ExplainSMPolicyResponse.SM_POLICIES_FIELD))


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- Default date format to `yyyy-MM-dd'T'HH:mm:ss`. If user doesn't provide date_format in snapshot_config, the date format is the default. Snapshot name created from SM policy is like <policy name>-<date format>-<random string suffix>

*CheckList:*
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/index-management/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
