### PR TITLE
Clean the mapping update log in SMStateMachine

### DIFF
--- a/src/main/kotlin/org/opensearch/indexmanagement/IndexManagementIndices.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/IndexManagementIndices.kt
@@ -77,7 +77,7 @@ class IndexManagementIndices(
         }
     }
 
-    suspend fun checkAndUpdateIMConfigIndex(logger: Logger) {
+    suspend fun checkAndUpdateIMConfigIndex(logger: Logger): Boolean {
         val response: AcknowledgedResponse = suspendCoroutine { cont ->
             checkAndUpdateIMConfigIndex(
                 object : ActionListener<AcknowledgedResponse> {
@@ -87,7 +87,7 @@ class IndexManagementIndices(
             )
         }
         if (response.isAcknowledged) {
-            logger.info("Successfully created or updated $INDEX_MANAGEMENT_INDEX with newest mappings.")
+            return true
         } else {
             logger.error("Unable to create or update $INDEX_MANAGEMENT_INDEX with newest mapping.")
             throw OpenSearchStatusException(

--- a/src/main/kotlin/org/opensearch/indexmanagement/snapshotmanagement/api/transport/index/TransportIndexSMPolicyAction.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/snapshotmanagement/api/transport/index/TransportIndexSMPolicyAction.kt
@@ -55,7 +55,9 @@ class TransportIndexSMPolicyAction @Inject constructor(
         // If filterBy is enabled and security is disabled or if filter by is enabled and backend role are empty an exception will be thrown
         SecurityUtils.validateUserConfiguration(user, filterByEnabled)
 
-        indexManagementIndices.checkAndUpdateIMConfigIndex(log)
+        if (indexManagementIndices.checkAndUpdateIMConfigIndex(log)) {
+            log.info("Successfully created or updated $INDEX_MANAGEMENT_INDEX with newest mappings.")
+        }
         return indexSMPolicy(request, user)
     }
 

--- a/src/test/kotlin/org/opensearch/indexmanagement/snapshotmanagement/TestUtils.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/snapshotmanagement/TestUtils.kt
@@ -28,7 +28,6 @@ import org.opensearch.indexmanagement.indexstatemanagement.randomChannel
 import org.opensearch.indexmanagement.opensearchapi.toMap
 import org.opensearch.indexmanagement.randomCronSchedule
 import org.opensearch.indexmanagement.randomInstant
-import org.opensearch.indexmanagement.randomIntervalSchedule
 import org.opensearch.indexmanagement.snapshotmanagement.engine.states.SMState
 import org.opensearch.indexmanagement.snapshotmanagement.model.NotificationConfig
 import org.opensearch.indexmanagement.snapshotmanagement.model.SMMetadata
@@ -45,6 +44,7 @@ import org.opensearch.test.OpenSearchTestCase.randomIntBetween
 import org.opensearch.test.OpenSearchTestCase.randomNonNegativeLong
 import org.opensearch.test.rest.OpenSearchRestTestCase
 import java.time.Instant
+import java.time.temporal.ChronoUnit
 
 fun randomSMMetadata(
     creationCurrentState: SMState = SMState.CREATION_START,
@@ -110,7 +110,7 @@ fun randomSMPolicy(
     ),
     dateFormat: String? = null,
     jobEnabledTime: Instant? = randomInstant(),
-    jobSchedule: IntervalSchedule = randomIntervalSchedule(),
+    jobSchedule: IntervalSchedule = IntervalSchedule(randomInstant(), 1, ChronoUnit.MINUTES),
     seqNo: Long = SequenceNumbers.UNASSIGNED_SEQ_NO,
     primaryTerm: Long = SequenceNumbers.UNASSIGNED_PRIMARY_TERM,
     notificationConfig: NotificationConfig? = null


### PR DESCRIPTION
Signed-off-by: bowenlan-amzn <bowenlan23@gmail.com>

*Issue #, if available:*

*Description of changes:*

This log `Successfully created or updated` is shown every time even the mapping is not updated when SM jobs are running. This PR stops it from showing in SM state machine update metadata.

*CheckList:*
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/index-management/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
