### PR TITLE
Adds plugin version sweep background job

### DIFF
--- a/src/main/kotlin/org/opensearch/indexmanagement/IndexManagementPlugin.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/IndexManagementPlugin.kt
@@ -370,7 +370,7 @@ class IndexManagementPlugin : JobSchedulerExtension, NetworkPlugin, ActionPlugin
         fieldCapsFilter = FieldCapsFilter(clusterService, settings, indexNameExpressionResolver)
         this.indexNameExpressionResolver = indexNameExpressionResolver
 
-        val skipFlag = SkipExecution(client, clusterService)
+        val skipFlag = SkipExecution(settings, threadPool, client, clusterService)
         RollupFieldValueExpressionResolver.registerScriptService(scriptService)
         val rollupRunner = RollupRunner
             .registerClient(client)
@@ -496,6 +496,7 @@ class IndexManagementPlugin : JobSchedulerExtension, NetworkPlugin, ActionPlugin
             LegacyOpenDistroManagedIndexSettings.METADATA_SERVICE_ENABLED,
             LegacyOpenDistroManagedIndexSettings.JOB_INTERVAL,
             LegacyOpenDistroManagedIndexSettings.SWEEP_PERIOD,
+            LegacyOpenDistroManagedIndexSettings.SWEEP_SKIP_PERIOD,
             LegacyOpenDistroManagedIndexSettings.COORDINATOR_BACKOFF_COUNT,
             LegacyOpenDistroManagedIndexSettings.COORDINATOR_BACKOFF_MILLIS,
             LegacyOpenDistroManagedIndexSettings.ALLOW_LIST,

--- a/src/main/kotlin/org/opensearch/indexmanagement/IndexManagementPlugin.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/IndexManagementPlugin.kt
@@ -371,7 +371,7 @@ class IndexManagementPlugin : JobSchedulerExtension, NetworkPlugin, ActionPlugin
         fieldCapsFilter = FieldCapsFilter(clusterService, settings, indexNameExpressionResolver)
         this.indexNameExpressionResolver = indexNameExpressionResolver
 
-        val skipFlag = SkipExecution(client, clusterService)
+        val skipFlag = SkipExecution(client)
         RollupFieldValueExpressionResolver.registerScriptService(scriptService)
         val rollupRunner = RollupRunner
             .registerClient(client)
@@ -501,7 +501,6 @@ class IndexManagementPlugin : JobSchedulerExtension, NetworkPlugin, ActionPlugin
             LegacyOpenDistroManagedIndexSettings.METADATA_SERVICE_ENABLED,
             LegacyOpenDistroManagedIndexSettings.JOB_INTERVAL,
             LegacyOpenDistroManagedIndexSettings.SWEEP_PERIOD,
-            LegacyOpenDistroManagedIndexSettings.SWEEP_SKIP_PERIOD,
             LegacyOpenDistroManagedIndexSettings.COORDINATOR_BACKOFF_COUNT,
             LegacyOpenDistroManagedIndexSettings.COORDINATOR_BACKOFF_MILLIS,
             LegacyOpenDistroManagedIndexSettings.ALLOW_LIST,

--- a/src/main/kotlin/org/opensearch/indexmanagement/IndexManagementPlugin.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/IndexManagementPlugin.kt
@@ -37,6 +37,7 @@ import org.opensearch.indexmanagement.indexstatemanagement.IndexStateManagementH
 import org.opensearch.indexmanagement.indexstatemanagement.ManagedIndexCoordinator
 import org.opensearch.indexmanagement.indexstatemanagement.ManagedIndexRunner
 import org.opensearch.indexmanagement.indexstatemanagement.MetadataService
+import org.opensearch.indexmanagement.indexstatemanagement.PluginVersionSweepCoordinator
 import org.opensearch.indexmanagement.indexstatemanagement.SkipExecution
 import org.opensearch.indexmanagement.indexstatemanagement.model.ManagedIndexConfig
 import org.opensearch.indexmanagement.indexstatemanagement.model.Policy
@@ -370,7 +371,7 @@ class IndexManagementPlugin : JobSchedulerExtension, NetworkPlugin, ActionPlugin
         fieldCapsFilter = FieldCapsFilter(clusterService, settings, indexNameExpressionResolver)
         this.indexNameExpressionResolver = indexNameExpressionResolver
 
-        val skipFlag = SkipExecution(settings, threadPool, client, clusterService)
+        val skipFlag = SkipExecution(client, clusterService)
         RollupFieldValueExpressionResolver.registerScriptService(scriptService)
         val rollupRunner = RollupRunner
             .registerClient(client)
@@ -428,6 +429,8 @@ class IndexManagementPlugin : JobSchedulerExtension, NetworkPlugin, ActionPlugin
 
         val smRunner = SMRunner.init(client, threadPool, settings, indexManagementIndices, clusterService)
 
+        val pluginVersionSweepCoordinator = PluginVersionSweepCoordinator(skipFlag, settings, threadPool, clusterService)
+
         return listOf(
             managedIndexRunner,
             rollupRunner,
@@ -436,7 +439,8 @@ class IndexManagementPlugin : JobSchedulerExtension, NetworkPlugin, ActionPlugin
             managedIndexCoordinator,
             indexStateManagementHistory,
             indexMetadataProvider,
-            smRunner
+            smRunner,
+            pluginVersionSweepCoordinator
         )
     }
 
@@ -461,6 +465,7 @@ class IndexManagementPlugin : JobSchedulerExtension, NetworkPlugin, ActionPlugin
             ManagedIndexSettings.JITTER,
             ManagedIndexSettings.JOB_INTERVAL,
             ManagedIndexSettings.SWEEP_PERIOD,
+            ManagedIndexSettings.SWEEP_SKIP_PERIOD,
             ManagedIndexSettings.COORDINATOR_BACKOFF_COUNT,
             ManagedIndexSettings.COORDINATOR_BACKOFF_MILLIS,
             ManagedIndexSettings.ALLOW_LIST,

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/PluginVersionSweepCoordinator.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/PluginVersionSweepCoordinator.kt
@@ -1,0 +1,85 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.indexmanagement.indexstatemanagement
+
+import kotlinx.coroutines.CoroutineName
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import org.apache.logging.log4j.LogManager
+import org.opensearch.cluster.service.ClusterService
+import org.opensearch.common.component.LifecycleListener
+import org.opensearch.common.settings.Settings
+import org.opensearch.common.unit.TimeValue
+import org.opensearch.indexmanagement.indexstatemanagement.settings.ManagedIndexSettings
+import org.opensearch.indexmanagement.util.OpenForTesting
+import org.opensearch.threadpool.Scheduler
+import org.opensearch.threadpool.ThreadPool
+
+class PluginVersionSweepCoordinator(
+    private val skipExecution: SkipExecution,
+    settings: Settings,
+    private val threadPool: ThreadPool,
+    private val clusterService: ClusterService,
+) : CoroutineScope by CoroutineScope(SupervisorJob() + Dispatchers.Default + CoroutineName("ISMPluginSweepCoordinator")),
+    LifecycleListener() {
+    private val logger = LogManager.getLogger(javaClass)
+
+    private var scheduledSkipExecution: Scheduler.Cancellable? = null
+
+    @Volatile
+    private var sweepSkipPeriod = ManagedIndexSettings.SWEEP_SKIP_PERIOD.get(settings)
+
+    @Volatile
+    private var indexStateManagementEnabled = ManagedIndexSettings.INDEX_STATE_MANAGEMENT_ENABLED.get(settings)
+
+    init {
+        clusterService.addLifecycleListener(this)
+        clusterService.clusterSettings.addSettingsUpdateConsumer(ManagedIndexSettings.SWEEP_SKIP_PERIOD) {
+            sweepSkipPeriod = it
+            initBackgroundSweepISMPluginVersionExecution()
+        }
+    }
+
+    override fun afterStart() {
+        initBackgroundSweepISMPluginVersionExecution()
+    }
+
+    override fun beforeStop() {
+        scheduledSkipExecution?.cancel()
+    }
+
+    @OpenForTesting
+    fun initBackgroundSweepISMPluginVersionExecution() {
+        // If ISM is disabled return early
+        if (!isIndexStateManagementEnabled()) return
+        // Cancel existing background sweep
+        scheduledSkipExecution?.cancel()
+        val scheduledJob = Runnable {
+            // Starting job without coroutine - in order to avoid thread leak error
+            try {
+                if (!skipExecution.flag) {
+                    logger.info("Canceling sweep ism plugin version job")
+                    scheduledSkipExecution?.cancel()
+                } else {
+                    skipExecution.sweepISMPluginVersion()
+                }
+            } catch (e: Exception) {
+                logger.error("Failed to sweep ism plugin version", e)
+            }
+        }
+        scheduledSkipExecution =
+            threadPool.scheduleWithFixedDelay(scheduledJob,
+                TimeValue.timeValueMinutes(RETRY_PERIOD_IN_MINUTES),
+                ThreadPool.Names.MANAGEMENT)
+    }
+
+    private fun isIndexStateManagementEnabled(): Boolean = indexStateManagementEnabled == true
+
+    companion object {
+        private const val RETRY_PERIOD_IN_MINUTES = 5L
+    }
+}

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/SkipExecution.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/SkipExecution.kt
@@ -12,18 +12,14 @@ import org.opensearch.action.admin.cluster.node.info.NodesInfoRequest
 import org.opensearch.action.admin.cluster.node.info.NodesInfoResponse
 import org.opensearch.action.admin.cluster.node.info.PluginsAndModules
 import org.opensearch.client.Client
-import org.opensearch.cluster.ClusterChangedEvent
-import org.opensearch.cluster.ClusterStateListener
-import org.opensearch.cluster.service.ClusterService
 import org.opensearch.indexmanagement.util.OpenForTesting
 
 // TODO this can be moved to job scheduler, so that all extended plugin
 //  can avoid running jobs in an upgrading cluster
 @OpenForTesting
 class SkipExecution(
-    private val client: Client,
-    private val clusterService: ClusterService,
-) : ClusterStateListener {
+    private val client: Client
+) {
     private val logger = LogManager.getLogger(javaClass)
 
     @Volatile
@@ -34,16 +30,6 @@ class SkipExecution(
     @Volatile
     final var hasLegacyPlugin: Boolean = false
         private set
-
-    init {
-        clusterService.addListener(this)
-    }
-
-    override fun clusterChanged(event: ClusterChangedEvent) {
-        if (event.nodesChanged() || event.isNewCluster) {
-            sweepISMPluginVersion()
-        }
-    }
 
     fun sweepISMPluginVersion() {
         // if old version ISM plugin exists (2 versions ISM in one cluster), set skip flag to true

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/SkipExecution.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/SkipExecution.kt
@@ -5,11 +5,6 @@
 
 package org.opensearch.indexmanagement.indexstatemanagement
 
-import kotlinx.coroutines.CoroutineName
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.SupervisorJob
-import kotlinx.coroutines.launch
 import org.apache.logging.log4j.LogManager
 import org.opensearch.action.ActionListener
 import org.opensearch.action.admin.cluster.node.info.NodesInfoAction
@@ -20,34 +15,16 @@ import org.opensearch.client.Client
 import org.opensearch.cluster.ClusterChangedEvent
 import org.opensearch.cluster.ClusterStateListener
 import org.opensearch.cluster.service.ClusterService
-import org.opensearch.common.component.LifecycleListener
-import org.opensearch.common.settings.Settings
-import org.opensearch.common.unit.TimeValue
-import org.opensearch.indexmanagement.indexstatemanagement.settings.ManagedIndexSettings
 import org.opensearch.indexmanagement.util.OpenForTesting
-import org.opensearch.threadpool.Scheduler
-import org.opensearch.threadpool.ThreadPool
 
 // TODO this can be moved to job scheduler, so that all extended plugin
 //  can avoid running jobs in an upgrading cluster
 @OpenForTesting
 class SkipExecution(
-    private val settings: Settings,
-    private val threadPool: ThreadPool,
     private val client: Client,
     private val clusterService: ClusterService,
-) : ClusterStateListener,
-    CoroutineScope by CoroutineScope(SupervisorJob() + Dispatchers.Default + CoroutineName("ISMPluginSweepCoordinator")),
-    LifecycleListener() {
+) : ClusterStateListener {
     private val logger = LogManager.getLogger(javaClass)
-
-    private var scheduledSkipExecution: Scheduler.Cancellable? = null
-
-    @Volatile
-    private var sweepSkipPeriod = ManagedIndexSettings.SWEEP_SKIP_PERIOD.get(settings)
-
-    @Volatile
-    private var indexStateManagementEnabled = ManagedIndexSettings.INDEX_STATE_MANAGEMENT_ENABLED.get(settings)
 
     @Volatile
     final var flag: Boolean = false
@@ -60,46 +37,12 @@ class SkipExecution(
 
     init {
         clusterService.addListener(this)
-        clusterService.addLifecycleListener(this)
-        clusterService.clusterSettings.addSettingsUpdateConsumer(ManagedIndexSettings.SWEEP_SKIP_PERIOD) {
-            sweepSkipPeriod = it
-            initBackgroundSweepISMPluginVersionExecution()
-        }
     }
 
     override fun clusterChanged(event: ClusterChangedEvent) {
         if (event.nodesChanged() || event.isNewCluster) {
             sweepISMPluginVersion()
         }
-    }
-
-    override fun beforeStop() {
-        scheduledSkipExecution?.cancel()
-    }
-
-    @OpenForTesting
-    fun initBackgroundSweepISMPluginVersionExecution() {
-        logger.info("initing sweep skip execution")
-        // If ISM is disabled return early
-        if (!isIndexStateManagementEnabled()) return
-        // Cancel existing background sweep
-        scheduledSkipExecution?.cancel()
-        val scheduledJob = Runnable {
-            launch {
-                try {
-                    if (!flag) {
-                        logger.info("Canceling sweep ism plugin version")
-                        scheduledSkipExecution?.cancel()
-                        return@launch
-                    }
-                    sweepISMPluginVersion()
-                } catch (e: Exception) {
-                    logger.error("Failed to sweep managed indices", e)
-                }
-            }
-        }
-        scheduledSkipExecution =
-            threadPool.scheduleWithFixedDelay(scheduledJob, TimeValue.timeValueMinutes(5), ThreadPool.Names.MANAGEMENT)
     }
 
     fun sweepISMPluginVersion() {
@@ -147,6 +90,4 @@ class SkipExecution(
             }
         )
     }
-
-    private fun isIndexStateManagementEnabled(): Boolean = indexStateManagementEnabled == true
 }

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/settings/LegacyOpenDistroManagedIndexSettings.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/settings/LegacyOpenDistroManagedIndexSettings.kt
@@ -107,6 +107,15 @@ class LegacyOpenDistroManagedIndexSettings {
             Setting.Property.Deprecated
         )
 
+        val SWEEP_SKIP_PERIOD: Setting<TimeValue> = Setting.timeSetting(
+            "opendistro.index_state_management.coordinator.sweep_skip_period",
+            TimeValue.timeValueMinutes(10),
+            TimeValue.timeValueMinutes(5),
+            Setting.Property.NodeScope,
+            Setting.Property.Dynamic,
+            Setting.Property.Deprecated
+        )
+
         val COORDINATOR_BACKOFF_MILLIS: Setting<TimeValue> = Setting.positiveTimeSetting(
             "opendistro.index_state_management.coordinator.backoff_millis",
             TimeValue.timeValueMillis(50),

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/settings/LegacyOpenDistroManagedIndexSettings.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/settings/LegacyOpenDistroManagedIndexSettings.kt
@@ -107,15 +107,6 @@ class LegacyOpenDistroManagedIndexSettings {
             Setting.Property.Deprecated
         )
 
-        val SWEEP_SKIP_PERIOD: Setting<TimeValue> = Setting.timeSetting(
-            "opendistro.index_state_management.coordinator.sweep_skip_period",
-            TimeValue.timeValueMinutes(10),
-            TimeValue.timeValueMinutes(5),
-            Setting.Property.NodeScope,
-            Setting.Property.Dynamic,
-            Setting.Property.Deprecated
-        )
-
         val COORDINATOR_BACKOFF_MILLIS: Setting<TimeValue> = Setting.positiveTimeSetting(
             "opendistro.index_state_management.coordinator.backoff_millis",
             TimeValue.timeValueMillis(50),

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/settings/ManagedIndexSettings.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/settings/ManagedIndexSettings.kt
@@ -101,6 +101,13 @@ class ManagedIndexSettings {
             Setting.Property.Dynamic
         )
 
+        val SWEEP_SKIP_PERIOD: Setting<TimeValue> = Setting.timeSetting(
+            "plugins.index_state_management.coordinator.sweep_skip_period",
+            LegacyOpenDistroManagedIndexSettings.SWEEP_SKIP_PERIOD,
+            Setting.Property.NodeScope,
+            Setting.Property.Dynamic
+        )
+
         val COORDINATOR_BACKOFF_MILLIS: Setting<TimeValue> = Setting.positiveTimeSetting(
             "plugins.index_state_management.coordinator.backoff_millis",
             LegacyOpenDistroManagedIndexSettings.COORDINATOR_BACKOFF_MILLIS,

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/settings/ManagedIndexSettings.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/settings/ManagedIndexSettings.kt
@@ -103,7 +103,7 @@ class ManagedIndexSettings {
 
         val SWEEP_SKIP_PERIOD: Setting<TimeValue> = Setting.timeSetting(
             "plugins.index_state_management.coordinator.sweep_skip_period",
-            LegacyOpenDistroManagedIndexSettings.SWEEP_SKIP_PERIOD,
+            TimeValue.timeValueMinutes(5),
             Setting.Property.NodeScope,
             Setting.Property.Dynamic
         )

--- a/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/MetadataServiceTests.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/MetadataServiceTests.kt
@@ -54,7 +54,7 @@ class MetadataServiceTests : OpenSearchTestCase() {
                 )
             )
         )
-        val skipFlag = SkipExecution(client, clusterService)
+        val skipFlag = SkipExecution(client)
         val metadataService = MetadataService(client, clusterService, skipFlag, imIndices)
         metadataService.moveMetadata()
 
@@ -75,7 +75,7 @@ class MetadataServiceTests : OpenSearchTestCase() {
             )
         )
 
-        val skipFlag = SkipExecution(client, clusterService)
+        val skipFlag = SkipExecution(client)
         val metadataService = MetadataService(client, clusterService, skipFlag, imIndices)
         metadataService.moveMetadata()
         assertEquals(metadataService.runTimeCounter, 2)

--- a/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/MetadataServiceTests.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/MetadataServiceTests.kt
@@ -23,13 +23,17 @@ import org.opensearch.cluster.ClusterState
 import org.opensearch.cluster.metadata.Metadata
 import org.opensearch.cluster.service.ClusterService
 import org.opensearch.common.collect.ImmutableOpenMap
+import org.opensearch.common.settings.Settings
 import org.opensearch.indexmanagement.IndexManagementIndices
 import org.opensearch.test.OpenSearchTestCase
+import org.opensearch.threadpool.ThreadPool
 import kotlin.test.assertFailsWith
 
 class MetadataServiceTests : OpenSearchTestCase() {
 
     private val clusterService: ClusterService = mock()
+    private var settings: Settings = mock()
+    private var threadPool: ThreadPool = mock()
     private val clusterState: ClusterState = mock()
     private val metadata: Metadata = mock()
     private val imIndices: IndexManagementIndices = mock()
@@ -54,7 +58,7 @@ class MetadataServiceTests : OpenSearchTestCase() {
                 )
             )
         )
-        val skipFlag = SkipExecution(client, clusterService)
+        val skipFlag = SkipExecution(settings, threadPool, client, clusterService)
         val metadataService = MetadataService(client, clusterService, skipFlag, imIndices)
         metadataService.moveMetadata()
 
@@ -75,7 +79,7 @@ class MetadataServiceTests : OpenSearchTestCase() {
             )
         )
 
-        val skipFlag = SkipExecution(client, clusterService)
+        val skipFlag = SkipExecution(settings, threadPool, client, clusterService)
         val metadataService = MetadataService(client, clusterService, skipFlag, imIndices)
         metadataService.moveMetadata()
         assertEquals(metadataService.runTimeCounter, 2)

--- a/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/MetadataServiceTests.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/MetadataServiceTests.kt
@@ -23,17 +23,13 @@ import org.opensearch.cluster.ClusterState
 import org.opensearch.cluster.metadata.Metadata
 import org.opensearch.cluster.service.ClusterService
 import org.opensearch.common.collect.ImmutableOpenMap
-import org.opensearch.common.settings.Settings
 import org.opensearch.indexmanagement.IndexManagementIndices
 import org.opensearch.test.OpenSearchTestCase
-import org.opensearch.threadpool.ThreadPool
 import kotlin.test.assertFailsWith
 
 class MetadataServiceTests : OpenSearchTestCase() {
 
     private val clusterService: ClusterService = mock()
-    private var settings: Settings = mock()
-    private var threadPool: ThreadPool = mock()
     private val clusterState: ClusterState = mock()
     private val metadata: Metadata = mock()
     private val imIndices: IndexManagementIndices = mock()
@@ -58,7 +54,7 @@ class MetadataServiceTests : OpenSearchTestCase() {
                 )
             )
         )
-        val skipFlag = SkipExecution(settings, threadPool, client, clusterService)
+        val skipFlag = SkipExecution(client, clusterService)
         val metadataService = MetadataService(client, clusterService, skipFlag, imIndices)
         metadataService.moveMetadata()
 
@@ -79,7 +75,7 @@ class MetadataServiceTests : OpenSearchTestCase() {
             )
         )
 
-        val skipFlag = SkipExecution(settings, threadPool, client, clusterService)
+        val skipFlag = SkipExecution(client, clusterService)
         val metadataService = MetadataService(client, clusterService, skipFlag, imIndices)
         metadataService.moveMetadata()
         assertEquals(metadataService.runTimeCounter, 2)

--- a/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/coordinator/SkipExecutionTests.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/coordinator/SkipExecutionTests.kt
@@ -11,27 +11,24 @@ import org.opensearch.action.admin.cluster.node.info.NodesInfoAction
 import org.opensearch.client.Client
 import org.opensearch.cluster.ClusterChangedEvent
 import org.opensearch.cluster.OpenSearchAllocationTestCase
-import org.opensearch.cluster.service.ClusterService
 import org.opensearch.indexmanagement.indexstatemanagement.SkipExecution
 
 class SkipExecutionTests : OpenSearchAllocationTestCase() {
 
     private lateinit var client: Client
-    private lateinit var clusterService: ClusterService
     private lateinit var skip: SkipExecution
 
     @Before
     @Throws(Exception::class)
     fun setup() {
         client = Mockito.mock(Client::class.java)
-        clusterService = Mockito.mock(ClusterService::class.java)
-        skip = SkipExecution(client, clusterService)
+        skip = SkipExecution(client)
     }
 
     fun `test cluster change event`() {
         val event = Mockito.mock(ClusterChangedEvent::class.java)
         Mockito.`when`(event.nodesChanged()).thenReturn(true)
-        skip.clusterChanged(event)
+        skip.sweepISMPluginVersion()
         Mockito.verify(client).execute(Mockito.eq(NodesInfoAction.INSTANCE), Mockito.any(), Mockito.any())
     }
 }

--- a/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/coordinator/SkipExecutionTests.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/coordinator/SkipExecutionTests.kt
@@ -12,12 +12,16 @@ import org.opensearch.client.Client
 import org.opensearch.cluster.ClusterChangedEvent
 import org.opensearch.cluster.OpenSearchAllocationTestCase
 import org.opensearch.cluster.service.ClusterService
+import org.opensearch.common.settings.Settings
 import org.opensearch.indexmanagement.indexstatemanagement.SkipExecution
+import org.opensearch.threadpool.ThreadPool
 
 class SkipExecutionTests : OpenSearchAllocationTestCase() {
 
     private lateinit var client: Client
     private lateinit var clusterService: ClusterService
+    private lateinit var settings: Settings
+    private lateinit var threadPool: ThreadPool
     private lateinit var skip: SkipExecution
 
     @Before
@@ -25,7 +29,9 @@ class SkipExecutionTests : OpenSearchAllocationTestCase() {
     fun setup() {
         client = Mockito.mock(Client::class.java)
         clusterService = Mockito.mock(ClusterService::class.java)
-        skip = SkipExecution(client, clusterService)
+        settings = Mockito.mock(Settings::class.java)
+        threadPool = Mockito.mock(ThreadPool::class.java)
+        skip = SkipExecution(settings, threadPool, client, clusterService)
     }
 
     fun `test cluster change event`() {

--- a/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/coordinator/SkipExecutionTests.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/coordinator/SkipExecutionTests.kt
@@ -12,16 +12,12 @@ import org.opensearch.client.Client
 import org.opensearch.cluster.ClusterChangedEvent
 import org.opensearch.cluster.OpenSearchAllocationTestCase
 import org.opensearch.cluster.service.ClusterService
-import org.opensearch.common.settings.Settings
 import org.opensearch.indexmanagement.indexstatemanagement.SkipExecution
-import org.opensearch.threadpool.ThreadPool
 
 class SkipExecutionTests : OpenSearchAllocationTestCase() {
 
     private lateinit var client: Client
     private lateinit var clusterService: ClusterService
-    private lateinit var settings: Settings
-    private lateinit var threadPool: ThreadPool
     private lateinit var skip: SkipExecution
 
     @Before
@@ -29,9 +25,7 @@ class SkipExecutionTests : OpenSearchAllocationTestCase() {
     fun setup() {
         client = Mockito.mock(Client::class.java)
         clusterService = Mockito.mock(ClusterService::class.java)
-        settings = Mockito.mock(Settings::class.java)
-        threadPool = Mockito.mock(ThreadPool::class.java)
-        skip = SkipExecution(settings, threadPool, client, clusterService)
+        skip = SkipExecution(client, clusterService)
     }
 
     fun `test cluster change event`() {


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/opensearch-project/index-management/issues/207

*Description of changes:*
Index Management currently skips all job executions when there are two differing versions of Index Management on the cluster. The plugin currently does this by performing a NodesInfoRequest to get and compare plugin versions whenever there is a node added or a new cluster, and set a flag, SkipExecution, to true when there are multiple plugin versions. We have seen cases where the SkipExecution flag is still set to true even though the upgrade process (early ES 7.x to later ES 7.x) has finished and the cluster is on the latest version w/ all nodes containing the same version of IM plugin.

From analyzing the code, we can see race conditions that would allow multiple requests to overwrite each other in the wrong order. Though the cluster changed events would come in order, the NodesInfoRequests may actually overwrite the flag out of order. 

To resolve this race condition, this PR adds a background job which will run every five minutes to poll the plugin versions if the flag is currently set to true.

This is an alternative strategy to https://github.com/opensearch-project/index-management/pull/423 and is also entirely by Stevan Buzejic, @stevanbz, I am just raising the PR for an early review.

*CheckList:*
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/index-management/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
