### PR TITLE
added support for mustache scripting of rollup.target_index field

### DIFF
--- a/src/main/kotlin/org/opensearch/indexmanagement/IndexManagementPlugin.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/IndexManagementPlugin.kt
@@ -110,6 +110,7 @@ import org.opensearch.indexmanagement.rollup.resthandler.RestStartRollupAction
 import org.opensearch.indexmanagement.rollup.resthandler.RestStopRollupAction
 import org.opensearch.indexmanagement.rollup.settings.LegacyOpenDistroRollupSettings
 import org.opensearch.indexmanagement.rollup.settings.RollupSettings
+import org.opensearch.indexmanagement.rollup.util.RollupFieldValueExpressionResolver
 import org.opensearch.indexmanagement.settings.IndexManagementSettings
 import org.opensearch.indexmanagement.snapshotmanagement.api.resthandler.RestCreateSMPolicyHandler
 import org.opensearch.indexmanagement.snapshotmanagement.api.resthandler.RestDeleteSMPolicyHandler
@@ -370,6 +371,7 @@ class IndexManagementPlugin : JobSchedulerExtension, NetworkPlugin, ActionPlugin
         this.indexNameExpressionResolver = indexNameExpressionResolver
 
         val skipFlag = SkipExecution(client, clusterService)
+        RollupFieldValueExpressionResolver.registerScriptService(scriptService)
         val rollupRunner = RollupRunner
             .registerClient(client)
             .registerClusterService(clusterService)

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/rollup/AttemptCreateRollupJobStep.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/rollup/AttemptCreateRollupJobStep.kt
@@ -7,6 +7,7 @@ package org.opensearch.indexmanagement.indexstatemanagement.step.rollup
 
 import org.apache.logging.log4j.LogManager
 import org.opensearch.ExceptionsHelper
+import org.opensearch.OpenSearchStatusException
 import org.opensearch.action.support.WriteRequest
 import org.opensearch.action.support.master.AcknowledgedResponse
 import org.opensearch.index.engine.VersionConflictEngineException
@@ -63,6 +64,8 @@ class AttemptCreateRollupJobStep(private val action: RollupAction) : Step(name) 
         } catch (e: RemoteTransportException) {
             processFailure(rollup.id, indexName, ExceptionsHelper.unwrapCause(e) as Exception)
         } catch (e: RemoteTransportException) {
+            processFailure(rollup.id, indexName, e)
+        } catch (e: OpenSearchStatusException) {
             processFailure(rollup.id, indexName, e)
         }
 

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/rollup/AttemptCreateRollupJobStep.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/rollup/AttemptCreateRollupJobStep.kt
@@ -7,7 +7,6 @@ package org.opensearch.indexmanagement.indexstatemanagement.step.rollup
 
 import org.apache.logging.log4j.LogManager
 import org.opensearch.ExceptionsHelper
-import org.opensearch.OpenSearchStatusException
 import org.opensearch.action.support.WriteRequest
 import org.opensearch.action.support.master.AcknowledgedResponse
 import org.opensearch.index.engine.VersionConflictEngineException

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/rollup/AttemptCreateRollupJobStep.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/rollup/AttemptCreateRollupJobStep.kt
@@ -65,6 +65,8 @@ class AttemptCreateRollupJobStep(private val action: RollupAction) : Step(name) 
             processFailure(rollup.id, indexName, ExceptionsHelper.unwrapCause(e) as Exception)
         } catch (e: OpenSearchException) {
             processFailure(rollup.id, indexName, e)
+        } catch (e: Exception) {
+            processFailure(rollup.id, indexName, e)
         }
 
         return this

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/rollup/AttemptCreateRollupJobStep.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/rollup/AttemptCreateRollupJobStep.kt
@@ -63,8 +63,6 @@ class AttemptCreateRollupJobStep(private val action: RollupAction) : Step(name) 
             }
         } catch (e: RemoteTransportException) {
             processFailure(rollup.id, indexName, ExceptionsHelper.unwrapCause(e) as Exception)
-        } catch (e: RemoteTransportException) {
-            processFailure(rollup.id, indexName, e)
         } catch (e: OpenSearchStatusException) {
             processFailure(rollup.id, indexName, e)
         }

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/rollup/AttemptCreateRollupJobStep.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/rollup/AttemptCreateRollupJobStep.kt
@@ -7,6 +7,7 @@ package org.opensearch.indexmanagement.indexstatemanagement.step.rollup
 
 import org.apache.logging.log4j.LogManager
 import org.opensearch.ExceptionsHelper
+import org.opensearch.OpenSearchException
 import org.opensearch.action.support.WriteRequest
 import org.opensearch.action.support.master.AcknowledgedResponse
 import org.opensearch.index.engine.VersionConflictEngineException
@@ -62,7 +63,7 @@ class AttemptCreateRollupJobStep(private val action: RollupAction) : Step(name) 
             }
         } catch (e: RemoteTransportException) {
             processFailure(rollup.id, indexName, ExceptionsHelper.unwrapCause(e) as Exception)
-        } catch (e: Exception) {
+        } catch (e: OpenSearchException) {
             processFailure(rollup.id, indexName, e)
         }
 

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/rollup/AttemptCreateRollupJobStep.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/rollup/AttemptCreateRollupJobStep.kt
@@ -63,7 +63,7 @@ class AttemptCreateRollupJobStep(private val action: RollupAction) : Step(name) 
             }
         } catch (e: RemoteTransportException) {
             processFailure(rollup.id, indexName, ExceptionsHelper.unwrapCause(e) as Exception)
-        } catch (e: OpenSearchStatusException) {
+        } catch (e: Exception) {
             processFailure(rollup.id, indexName, e)
         }
 

--- a/src/main/kotlin/org/opensearch/indexmanagement/rollup/RollupIndexer.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/rollup/RollupIndexer.kt
@@ -124,7 +124,7 @@ class RollupIndexer(
                 }
             }
             mapOfKeyValues.putAll(aggResults)
-            var targetIndexResolvedName = RollupFieldValueExpressionResolver.resolve(job, job.targetIndex)
+            val targetIndexResolvedName = RollupFieldValueExpressionResolver.resolve(job, job.targetIndex)
             val indexRequest = IndexRequest(targetIndexResolvedName)
                 .id(documentId)
                 .source(mapOfKeyValues, XContentType.JSON)

--- a/src/main/kotlin/org/opensearch/indexmanagement/rollup/RollupIndexer.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/rollup/RollupIndexer.kt
@@ -23,6 +23,7 @@ import org.opensearch.indexmanagement.rollup.model.Rollup
 import org.opensearch.indexmanagement.rollup.model.RollupStats
 import org.opensearch.indexmanagement.rollup.settings.RollupSettings.Companion.ROLLUP_INGEST_BACKOFF_COUNT
 import org.opensearch.indexmanagement.rollup.settings.RollupSettings.Companion.ROLLUP_INGEST_BACKOFF_MILLIS
+import org.opensearch.indexmanagement.rollup.util.RollupFieldValueExpressionResolver
 import org.opensearch.indexmanagement.rollup.util.getInitialDocValues
 import org.opensearch.indexmanagement.util.IndexUtils.Companion.ODFE_MAGIC_NULL
 import org.opensearch.indexmanagement.util.IndexUtils.Companion.hashToFixedSize
@@ -123,7 +124,8 @@ class RollupIndexer(
                 }
             }
             mapOfKeyValues.putAll(aggResults)
-            val indexRequest = IndexRequest(job.targetIndex)
+            var targetIndexResolvedName = RollupFieldValueExpressionResolver.resolve(job, job.targetIndex)
+            val indexRequest = IndexRequest(targetIndexResolvedName)
                 .id(documentId)
                 .source(mapOfKeyValues, XContentType.JSON)
             requests.add(indexRequest)

--- a/src/main/kotlin/org/opensearch/indexmanagement/rollup/RollupMapperService.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/rollup/RollupMapperService.kt
@@ -70,7 +70,7 @@ class RollupMapperService(
     // TODO: error handling
     @Suppress("ReturnCount")
     suspend fun attemptCreateRollupTargetIndex(job: Rollup, hasLegacyPlugin: Boolean): RollupJobValidationResult {
-        var targetIndexResolvedName = RollupFieldValueExpressionResolver.resolve(job, job.targetIndex)
+        val targetIndexResolvedName = RollupFieldValueExpressionResolver.resolve(job, job.targetIndex)
         if (indexExists(targetIndexResolvedName)) {
             return validateAndAttemptToUpdateTargetIndex(job, targetIndexResolvedName)
         } else {

--- a/src/main/kotlin/org/opensearch/indexmanagement/rollup/action/index/TransportIndexRollupAction.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/rollup/action/index/TransportIndexRollupAction.kt
@@ -92,6 +92,14 @@ class TransportIndexRollupAction @Inject constructor(
             if (response.isAcknowledged) {
                 log.info("Successfully created or updated $INDEX_MANAGEMENT_INDEX with newest mappings.")
                 if (request.opType() == DocWriteRequest.OpType.CREATE) {
+                    if (!validateTargetIndexName()) {
+                        return actionListener.onFailure(
+                            OpenSearchStatusException(
+                                "target_index value is invalid: ${request.rollup.targetIndex}",
+                                RestStatus.BAD_REQUEST
+                            )
+                        )
+                    }
                     putRollup()
                 } else {
                     getRollup()

--- a/src/main/kotlin/org/opensearch/indexmanagement/rollup/action/index/TransportIndexRollupAction.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/rollup/action/index/TransportIndexRollupAction.kt
@@ -129,6 +129,14 @@ class TransportIndexRollupAction @Inject constructor(
             if (modified.isNotEmpty()) {
                 return actionListener.onFailure(OpenSearchStatusException("Not allowed to modify $modified", RestStatus.BAD_REQUEST))
             }
+            if (!validateTargetIndexName()) {
+                return actionListener.onFailure(
+                    OpenSearchStatusException(
+                        "target_index value is invalid: ${request.rollup.targetIndex}",
+                        RestStatus.BAD_REQUEST
+                    )
+                )
+            }
             putRollup()
         }
 
@@ -144,14 +152,6 @@ class TransportIndexRollupAction @Inject constructor(
         }
 
         private fun putRollup() {
-            if (!validateTargetIndexName()) {
-                return actionListener.onFailure(
-                    OpenSearchStatusException(
-                        "target_index value is invalid: ${request.rollup.targetIndex}",
-                        RestStatus.BAD_REQUEST
-                    )
-                )
-            }
             val rollup = request.rollup.copy(schemaVersion = IndexUtils.indexManagementConfigSchemaVersion, user = this.user)
             request.index(INDEX_MANAGEMENT_INDEX)
                 .id(request.rollup.id)

--- a/src/main/kotlin/org/opensearch/indexmanagement/rollup/action/index/TransportIndexRollupAction.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/rollup/action/index/TransportIndexRollupAction.kt
@@ -145,9 +145,11 @@ class TransportIndexRollupAction @Inject constructor(
 
         private fun putRollup() {
             if (!validateTargetIndexName()) {
-                return actionListener.onFailure(OpenSearchStatusException(
-                    "target_index value is invalid: ${request.rollup.targetIndex}",
-                    RestStatus.BAD_REQUEST)
+                return actionListener.onFailure(
+                    OpenSearchStatusException(
+                        "target_index value is invalid: ${request.rollup.targetIndex}",
+                        RestStatus.BAD_REQUEST
+                    )
                 )
             }
             val rollup = request.rollup.copy(schemaVersion = IndexUtils.indexManagementConfigSchemaVersion, user = this.user)

--- a/src/main/kotlin/org/opensearch/indexmanagement/rollup/action/mapping/TransportUpdateRollupMappingAction.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/rollup/action/mapping/TransportUpdateRollupMappingAction.kt
@@ -25,6 +25,7 @@ import org.opensearch.common.xcontent.XContentFactory
 import org.opensearch.common.xcontent.XContentHelper
 import org.opensearch.common.xcontent.XContentType
 import org.opensearch.indexmanagement.indexstatemanagement.util.XCONTENT_WITHOUT_TYPE
+import org.opensearch.indexmanagement.rollup.util.RollupFieldValueExpressionResolver
 import org.opensearch.indexmanagement.util.IndexUtils.Companion._META
 import org.opensearch.threadpool.ThreadPool
 import org.opensearch.transport.TransportService
@@ -59,7 +60,8 @@ class TransportUpdateRollupMappingAction @Inject constructor(
         state: ClusterState,
         listener: ActionListener<AcknowledgedResponse>
     ) {
-        val index = state.metadata.index(request.rollup.targetIndex)
+        var targetIndexResolvedName = RollupFieldValueExpressionResolver.resolve(request.rollup, request.rollup.targetIndex)
+        val index = state.metadata.index(targetIndexResolvedName)
         if (index == null) {
             log.debug("Could not find index [$index]")
             return listener.onFailure(IllegalStateException("Could not find index [$index]"))
@@ -113,7 +115,8 @@ class TransportUpdateRollupMappingAction @Inject constructor(
         }
 
         // TODO: Does schema_version get overwritten?
-        val putMappingRequest = PutMappingRequest(request.rollup.targetIndex).source(metaMappings)
+        var targetIndexResovledName = RollupFieldValueExpressionResolver.resolve(request.rollup, request.rollup.targetIndex)
+        val putMappingRequest = PutMappingRequest(targetIndexResovledName).source(metaMappings)
         client.admin().indices().putMapping(
             putMappingRequest,
             object : ActionListener<AcknowledgedResponse> {

--- a/src/main/kotlin/org/opensearch/indexmanagement/rollup/action/mapping/TransportUpdateRollupMappingAction.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/rollup/action/mapping/TransportUpdateRollupMappingAction.kt
@@ -60,7 +60,7 @@ class TransportUpdateRollupMappingAction @Inject constructor(
         state: ClusterState,
         listener: ActionListener<AcknowledgedResponse>
     ) {
-        var targetIndexResolvedName = RollupFieldValueExpressionResolver.resolve(request.rollup, request.rollup.targetIndex)
+        val targetIndexResolvedName = RollupFieldValueExpressionResolver.resolve(request.rollup, request.rollup.targetIndex)
         val index = state.metadata.index(targetIndexResolvedName)
         if (index == null) {
             log.debug("Could not find index [$index]")
@@ -115,7 +115,7 @@ class TransportUpdateRollupMappingAction @Inject constructor(
         }
 
         // TODO: Does schema_version get overwritten?
-        var targetIndexResovledName = RollupFieldValueExpressionResolver.resolve(request.rollup, request.rollup.targetIndex)
+        val targetIndexResovledName = RollupFieldValueExpressionResolver.resolve(request.rollup, request.rollup.targetIndex)
         val putMappingRequest = PutMappingRequest(targetIndexResovledName).source(metaMappings)
         client.admin().indices().putMapping(
             putMappingRequest,

--- a/src/main/kotlin/org/opensearch/indexmanagement/rollup/action/mapping/TransportUpdateRollupMappingAction.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/rollup/action/mapping/TransportUpdateRollupMappingAction.kt
@@ -51,7 +51,8 @@ class TransportUpdateRollupMappingAction @Inject constructor(
     private val log = LogManager.getLogger(javaClass)
 
     override fun checkBlock(request: UpdateRollupMappingRequest, state: ClusterState): ClusterBlockException? {
-        return state.blocks.indicesBlockedException(ClusterBlockLevel.METADATA_WRITE, arrayOf(request.rollup.targetIndex))
+        val targetIndexResolvedName = RollupFieldValueExpressionResolver.resolve(request.rollup, request.rollup.targetIndex)
+        return state.blocks.indicesBlockedException(ClusterBlockLevel.METADATA_WRITE, arrayOf(targetIndexResolvedName))
     }
 
     @Suppress("ReturnCount", "LongMethod")
@@ -115,8 +116,7 @@ class TransportUpdateRollupMappingAction @Inject constructor(
         }
 
         // TODO: Does schema_version get overwritten?
-        val targetIndexResovledName = RollupFieldValueExpressionResolver.resolve(request.rollup, request.rollup.targetIndex)
-        val putMappingRequest = PutMappingRequest(targetIndexResovledName).source(metaMappings)
+        val putMappingRequest = PutMappingRequest(targetIndexResolvedName).source(metaMappings)
         client.admin().indices().putMapping(
             putMappingRequest,
             object : ActionListener<AcknowledgedResponse> {

--- a/src/main/kotlin/org/opensearch/indexmanagement/rollup/model/Rollup.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/rollup/model/Rollup.kt
@@ -24,6 +24,7 @@ import org.opensearch.indexmanagement.indexstatemanagement.util.WITH_USER
 import org.opensearch.indexmanagement.opensearchapi.instant
 import org.opensearch.indexmanagement.opensearchapi.optionalTimeField
 import org.opensearch.indexmanagement.opensearchapi.optionalUserField
+import org.opensearch.indexmanagement.rollup.util.RollupFieldValueExpressionResolver
 import org.opensearch.indexmanagement.util.IndexUtils
 import org.opensearch.indexmanagement.util.NO_ID
 import org.opensearch.indexmanagement.util._ID
@@ -95,6 +96,9 @@ data class Rollup(
             require(delay >= MINIMUM_DELAY) { "Delay must be non-negative if set" }
             require(delay <= Instant.now().toEpochMilli()) { "Delay must be less than the current unix time" }
         }
+
+        val targetIndexResolvedName = RollupFieldValueExpressionResolver.resolve(this, targetIndex)
+        require(targetIndexResolvedName.contains("*") == false)
     }
 
     override fun isEnabled() = enabled

--- a/src/main/kotlin/org/opensearch/indexmanagement/rollup/model/Rollup.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/rollup/model/Rollup.kt
@@ -24,7 +24,6 @@ import org.opensearch.indexmanagement.indexstatemanagement.util.WITH_USER
 import org.opensearch.indexmanagement.opensearchapi.instant
 import org.opensearch.indexmanagement.opensearchapi.optionalTimeField
 import org.opensearch.indexmanagement.opensearchapi.optionalUserField
-import org.opensearch.indexmanagement.rollup.util.RollupFieldValueExpressionResolver
 import org.opensearch.indexmanagement.util.IndexUtils
 import org.opensearch.indexmanagement.util.NO_ID
 import org.opensearch.indexmanagement.util._ID
@@ -96,9 +95,6 @@ data class Rollup(
             require(delay >= MINIMUM_DELAY) { "Delay must be non-negative if set" }
             require(delay <= Instant.now().toEpochMilli()) { "Delay must be less than the current unix time" }
         }
-
-        val targetIndexResolvedName = RollupFieldValueExpressionResolver.resolve(this, targetIndex)
-        require(targetIndexResolvedName.contains("*") == false)
     }
 
     override fun isEnabled() = enabled

--- a/src/main/kotlin/org/opensearch/indexmanagement/rollup/util/RollupFieldValueExpressionResolver.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/rollup/util/RollupFieldValueExpressionResolver.kt
@@ -18,7 +18,7 @@ import org.opensearch.script.TemplateScript
 
 object RollupFieldValueExpressionResolver {
 
-    private val validTopContextFields = setOf("source_index")
+    private val validTopContextFields = setOf(Rollup.SOURCE_INDEX_FIELD)
 
     private lateinit var scriptService: ScriptService
 

--- a/src/main/kotlin/org/opensearch/indexmanagement/rollup/util/RollupFieldValueExpressionResolver.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/rollup/util/RollupFieldValueExpressionResolver.kt
@@ -1,0 +1,46 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.indexmanagement.rollup.util
+
+import org.opensearch.common.bytes.BytesReference
+import org.opensearch.common.xcontent.XContentFactory
+import org.opensearch.common.xcontent.XContentHelper
+import org.opensearch.common.xcontent.XContentType
+import org.opensearch.indexmanagement.indexstatemanagement.util.XCONTENT_WITHOUT_TYPE
+import org.opensearch.indexmanagement.rollup.model.Rollup
+import org.opensearch.script.Script
+import org.opensearch.script.ScriptService
+import org.opensearch.script.ScriptType
+import org.opensearch.script.TemplateScript
+
+object RollupFieldValueExpressionResolver {
+
+    private val validTopContextFields = setOf("source_index")
+
+    private lateinit var scriptService: ScriptService
+
+    fun resolve(rollup: Rollup, fieldValue: String): String {
+        val script = Script(ScriptType.INLINE, Script.DEFAULT_TEMPLATE_LANG, fieldValue, mapOf())
+
+        val contextMap = XContentHelper.convertToMap(
+            BytesReference.bytes(rollup.toXContent(XContentFactory.jsonBuilder(), XCONTENT_WITHOUT_TYPE)),
+            false,
+            XContentType.JSON
+        ).v2().filterKeys { key ->
+            key in validTopContextFields
+        }
+
+        val compiledValue = scriptService.compile(script, TemplateScript.CONTEXT)
+            .newInstance(script.params + mapOf("ctx" to contextMap))
+            .execute()
+
+        return if (compiledValue.isBlank()) fieldValue else compiledValue
+    }
+
+    fun registerScriptService(scriptService: ScriptService) {
+        this.scriptService = scriptService
+    }
+}

--- a/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/action/RollupActionIT.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/action/RollupActionIT.kt
@@ -209,11 +209,7 @@ class RollupActionIT : IndexStateManagementRestTestCase() {
         // Ensure rollup works on backing indices of a data stream.
         val indexName = DataStream.getDefaultBackingIndexName(dataStreamName, 1L)
         assertIndexRolledUp(indexName, policyID, rollup)
-
-        val catIndex = (cat("indices/rollup_$indexName?format=json&bytes=b") as List<Map<String, Any>>)
-            .find { it["index"] == "rollup_$indexName" }
-
-        assertNotNull(catIndex)
+        assertIndexExists("rollup_$indexName")
     }
 
     fun `test rollup action failure`() {

--- a/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/action/RollupActionIT.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/action/RollupActionIT.kt
@@ -146,6 +146,76 @@ class RollupActionIT : IndexStateManagementRestTestCase() {
         assertIndexRolledUp(indexName, policyID, rollup)
     }
 
+    fun `test data stream rollup action with scripted targetIndex`() {
+        val dataStreamName = "${testIndexName}_data_stream"
+        val policyID = "${testIndexName}_rollup_policy"
+
+        val rollup = ISMRollup(
+            description = "data stream rollup",
+            targetIndex = "rollup_{{ctx.source_index}}",
+            pageSize = 100,
+            dimensions = listOf(
+                DateHistogram(sourceField = "tpep_pickup_datetime", fixedInterval = "1h"),
+                Terms("RatecodeID", "RatecodeID"),
+                Terms("PULocationID", "PULocationID")
+            ),
+            metrics = listOf(
+                RollupMetrics(
+                    sourceField = "passenger_count",
+                    targetField = "passenger_count",
+                    metrics = listOf(Sum(), Min(), Max(), ValueCount(), Average())
+                ),
+                RollupMetrics(
+                    sourceField = "total_amount",
+                    targetField = "total_amount",
+                    metrics = listOf(Max(), Min())
+                )
+            )
+        )
+
+        // Create an ISM policy to rollup backing indices of a data stream.
+        val actionConfig = RollupAction(rollup, 0)
+        val states = listOf(State("rollup", listOf(actionConfig), listOf()))
+        val policy = Policy(
+            id = policyID,
+            description = "data stream rollup policy",
+            schemaVersion = 1L,
+            lastUpdatedTime = Instant.now().truncatedTo(ChronoUnit.MILLIS),
+            errorNotification = randomErrorNotification(),
+            defaultState = states[0].name,
+            states = states,
+            ismTemplate = listOf(ISMTemplate(listOf(dataStreamName), 100, Instant.now().truncatedTo(ChronoUnit.MILLIS)))
+        )
+        createPolicy(policy, policyID)
+
+        val sourceIndexMappingString = "\"properties\": {\"tpep_pickup_datetime\": { \"type\": \"date\" }, \"RatecodeID\": { \"type\": " +
+            "\"keyword\" }, \"PULocationID\": { \"type\": \"keyword\" }, \"passenger_count\": { \"type\": \"integer\" }, \"total_amount\": " +
+            "{ \"type\": \"double\" }}"
+
+        // Create an index template for a data stream with the given source index mapping.
+        client().makeRequest(
+            "PUT",
+            "/_index_template/rollup-data-stream-template",
+            StringEntity(
+                "{ " +
+                    "\"index_patterns\": [ \"$dataStreamName\" ], " +
+                    "\"data_stream\": { \"timestamp_field\": { \"name\": \"tpep_pickup_datetime\" } }, " +
+                    "\"template\": { \"mappings\": { $sourceIndexMappingString } } }",
+                ContentType.APPLICATION_JSON
+            )
+        )
+        client().makeRequest("PUT", "/_data_stream/$dataStreamName")
+
+        // Ensure rollup works on backing indices of a data stream.
+        val indexName = DataStream.getDefaultBackingIndexName(dataStreamName, 1L)
+        assertIndexRolledUp(indexName, policyID, rollup)
+
+        val catIndex = (cat("indices/rollup_$indexName?format=json&bytes=b") as List<Map<String, Any>>)
+            .find { it["index"] == "rollup_$indexName" }
+
+        assertNotNull(catIndex)
+    }
+
     fun `test rollup action failure`() {
         val indexName = "${testIndexName}_index_failure"
         val policyID = "${testIndexName}_policy_failure"

--- a/src/test/kotlin/org/opensearch/indexmanagement/rollup/util/RollupFieldValueExpressionResolverTests.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/rollup/util/RollupFieldValueExpressionResolverTests.kt
@@ -1,0 +1,42 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.indexmanagement.rollup.util
+
+import com.nhaarman.mockitokotlin2.any
+import com.nhaarman.mockitokotlin2.eq
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.whenever
+import com.nhaarman.mockitokotlin2.doReturn
+import org.junit.Before
+import org.opensearch.indexmanagement.rollup.randomRollup
+import org.opensearch.ingest.TestTemplateService
+import org.opensearch.script.ScriptService
+import org.opensearch.script.TemplateScript
+import org.opensearch.test.OpenSearchTestCase
+
+class RollupFieldValueExpressionResolverTests : OpenSearchTestCase() {
+
+    private val scriptService: ScriptService = mock()
+
+    @Before
+    fun settings() {
+        RollupFieldValueExpressionResolver.registerScriptService(scriptService)
+    }
+
+    fun `test resolving successfully`() {
+        whenever(scriptService.compile(any(), eq(TemplateScript.CONTEXT))).doReturn(TestTemplateService.MockTemplateScript.Factory("test_index_123"))
+        val rollup = randomRollup().copy(sourceIndex = "test_index_123", targetIndex = "{{ctx.source_index}}")
+        val targetIndexResolvedName = RollupFieldValueExpressionResolver.resolve(rollup, rollup.targetIndex)
+        assertEquals("test_index_123", targetIndexResolvedName)
+    }
+
+    fun `test resolving failed returned passed value`() {
+        whenever(scriptService.compile(any(), eq(TemplateScript.CONTEXT))).doReturn(TestTemplateService.MockTemplateScript.Factory(""))
+        val rollup = randomRollup().copy(sourceIndex = "test_index_123", targetIndex = "{{ctx.source_index}}")
+        val targetIndexResolvedName = RollupFieldValueExpressionResolver.resolve(rollup, rollup.targetIndex)
+        assertEquals("{{ctx.source_index}}", targetIndexResolvedName)
+    }
+}


### PR DESCRIPTION
*Issue #, if available:* [61](https://github.com/opensearch-project/index-management/issues/61)

*Description of changes:*

Added capability to use mustache scripting as target_index field value. Only supported param right now is source_index: target_index: rollup_{{ctx.source_index}}

*CheckList:*
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/index-management/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
