### PR TITLE
moved _doc_count field from rollup._doc_count to root of document

### DIFF
--- a/src/main/kotlin/org/opensearch/indexmanagement/rollup/model/Rollup.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/rollup/model/Rollup.kt
@@ -241,7 +241,10 @@ data class Rollup(
         const val MINIMUM_PAGE_SIZE = 1
         const val MAXIMUM_PAGE_SIZE = 10_000
         const val ROLLUP_DOC_ID_FIELD = "$ROLLUP_TYPE.$_ID"
-        const val ROLLUP_DOC_COUNT_FIELD = "$ROLLUP_TYPE._doc_count"
+        /*
+        *  _doc_count has to be in root of document so that core's aggregator would pick it up and use it
+        * */
+        const val ROLLUP_DOC_COUNT_FIELD = "_doc_count"
         const val ROLLUP_DOC_SCHEMA_VERSION_FIELD = "$ROLLUP_TYPE._$SCHEMA_VERSION_FIELD"
         const val USER_FIELD = "user"
 


### PR DESCRIPTION
Signed-off-by: Petar Dzepina <petar.dzepina@gmail.com>

*Issue #, if available:* [57](https://github.com/opensearch-project/index-management/issues/57)

*Description of changes:*

After merging [this ](https://github.com/opensearch-project/OpenSearch/pull/3985/files)_doc_count elasticsearch PR, now we have to move _doc_count to root of rollup doc, so that core picks it up and calculate doc_count correctly

*CheckList:*
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/index-management/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
