### PR TITLE
added support for searching multiple rollup indices with same mapping

### DIFF
--- a/src/main/kotlin/org/opensearch/indexmanagement/rollup/interceptor/RollupInterceptor.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/rollup/interceptor/RollupInterceptor.kt
@@ -113,7 +113,7 @@ class RollupInterceptor(
             for (rollupJob in rollupJobs) {
                 val (matchingRollupJobs, issues) = findMatchingRollupJobs(fieldMappings, listOf(rollupJob))
                 if (issues.isNotEmpty() || matchingRollupJobs.isEmpty()) {
-                    throw IllegalArgumentException("Not all indices have matching rollup job")
+                    throw IllegalArgumentException("Could not find a rollup job that can answer this query because $issues")
                 }
                 allMatchingRollupJobs += matchingRollupJobs
             }

--- a/src/main/kotlin/org/opensearch/indexmanagement/rollup/interceptor/RollupInterceptor.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/rollup/interceptor/RollupInterceptor.kt
@@ -264,10 +264,10 @@ class RollupInterceptor(
             return rollups.first()
         }
         // Make selection deterministic
-        rollups.sortedBy { it.id }
+        val sortedRollups = rollups.sortedBy { it.id }
 
         // Picking the job with largest rollup window for now
-        return rollups.reduce { matched, new ->
+        return sortedRollups.reduce { matched, new ->
             if (getEstimateRollupInterval(matched) > getEstimateRollupInterval(new)) matched
             else new
         }

--- a/src/main/kotlin/org/opensearch/indexmanagement/rollup/interceptor/RollupInterceptor.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/rollup/interceptor/RollupInterceptor.kt
@@ -5,7 +5,6 @@
 
 package org.opensearch.indexmanagement.rollup.interceptor
 
-import org.apache.logging.log4j.LogManager
 import org.opensearch.cluster.metadata.IndexNameExpressionResolver
 import org.opensearch.cluster.service.ClusterService
 import org.opensearch.common.settings.Settings
@@ -53,8 +52,6 @@ class RollupInterceptor(
     val indexNameExpressionResolver: IndexNameExpressionResolver
 ) : TransportInterceptor {
 
-    private val logger = LogManager.getLogger(javaClass)
-
     @Volatile private var searchEnabled = RollupSettings.ROLLUP_SEARCH_ENABLED.get(settings)
     @Volatile private var searchAllJobs = RollupSettings.ROLLUP_SEARCH_ALL_JOBS.get(settings)
 
@@ -88,36 +85,40 @@ class RollupInterceptor(
                         val concreteIndices = indexNameExpressionResolver
                             .concreteIndexNames(clusterService.state(), request.indicesOptions(), *indices)
 
-                        if (concreteIndices.size > 1) {
-                            logger.warn(
-                                "There can be only one index in search request if its a rollup search - requested to search [${concreteIndices
-                                    .size}] indices including rollup index [$index]"
-                            )
-                            throw IllegalArgumentException("Searching rollup index with other indices is not supported currently")
-                        }
-
-                        val rollupJobs = clusterService.state().metadata.index(index).getRollupJobs()
-                            ?: throw IllegalArgumentException("Could not find any valid rollup job on the index")
-
                         val queryFieldMappings = getQueryMetadata(request.source().query())
                         val aggregationFieldMappings = getAggregationMetadata(request.source().aggregations()?.aggregatorFactories)
                         val fieldMappings = queryFieldMappings + aggregationFieldMappings
 
-                        val (matchingRollupJobs, issues) = findMatchingRollupJobs(fieldMappings, rollupJobs)
-
-                        if (matchingRollupJobs.isEmpty()) {
-                            throw IllegalArgumentException("Could not find a rollup job that can answer this query because $issues")
-                        }
+                        val allMatchingRollupJobs = validateIndicies(concreteIndices, fieldMappings)
 
                         // only rebuild if there is necessity to rebuild
                         if (fieldMappings.isNotEmpty()) {
-                            rewriteShardSearchForRollupJobs(request, matchingRollupJobs)
+                            rewriteShardSearchForRollupJobs(request, allMatchingRollupJobs)
                         }
                     }
                 }
                 actualHandler.messageReceived(request, channel, task)
             }
         }
+    }
+    /*
+    * Validate that all indices have rollup job which matches field mappings from request
+    * TODO return compiled list of issues here instead of just throwing exception
+    * */
+    private fun validateIndicies(concreteIndices: Array<String>, fieldMappings: Set<RollupFieldMapping>): Map<Rollup, Set<RollupFieldMapping>> {
+        var allMatchingRollupJobs: Map<Rollup, Set<RollupFieldMapping>> = mapOf()
+        for (concreteIndex in concreteIndices) {
+            val rollupJobs = clusterService.state().metadata.index(concreteIndex).getRollupJobs()
+                ?: throw IllegalArgumentException("Not all indices have rollup job")
+            for (rollupJob in rollupJobs) {
+                val (matchingRollupJobs, issues) = findMatchingRollupJobs(fieldMappings, listOf(rollupJob))
+                if (issues.isNotEmpty() || matchingRollupJobs.isEmpty()) {
+                    throw IllegalArgumentException("Not all indices have matching rollup job")
+                }
+                allMatchingRollupJobs += matchingRollupJobs
+            }
+        }
+        return allMatchingRollupJobs
     }
 
     @Suppress("ComplexMethod")

--- a/src/test/kotlin/org/opensearch/indexmanagement/rollup/interceptor/RollupInterceptorIT.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/rollup/interceptor/RollupInterceptorIT.kt
@@ -379,8 +379,7 @@ class RollupInterceptorIT : RollupRestTestCase() {
         } catch (e: ResponseException) {
             assertEquals(
                 "Wrong error message",
-                "Could not find a rollup job that can answer this query because [missing field RateCodeID, missing field timestamp, " +
-                    "missing sum aggregation on total_amount]",
+                "Not all indices have matching rollup job",
                 (e.response.asMap() as Map<String, Map<String, Map<String, String>>>)["error"]!!["caused_by"]!!["reason"]
             )
             assertEquals("Unexpected status", RestStatus.BAD_REQUEST, e.response.restStatus())

--- a/src/test/kotlin/org/opensearch/indexmanagement/rollup/interceptor/RollupInterceptorIT.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/rollup/interceptor/RollupInterceptorIT.kt
@@ -379,7 +379,8 @@ class RollupInterceptorIT : RollupRestTestCase() {
         } catch (e: ResponseException) {
             assertEquals(
                 "Wrong error message",
-                "Not all indices have matching rollup job",
+                "Could not find a rollup job that can answer this query because [missing field RateCodeID, missing field timestamp, " +
+                    "missing sum aggregation on total_amount]",
                 (e.response.asMap() as Map<String, Map<String, Map<String, String>>>)["error"]!!["caused_by"]!!["reason"]
             )
             assertEquals("Unexpected status", RestStatus.BAD_REQUEST, e.response.restStatus())


### PR DESCRIPTION
Signed-off-by: Petar Dzepina <petar.dzepina@gmail.com>

*Issue #, if available:* [321](https://github.com/opensearch-project/index-management/issues/321)

*Description of changes:*

Allowed searching multiple rollup indices with matching field mappings from query

*CheckList:*
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/index-management/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
