### PR TITLE
[FIX] Failed concurrent creates of ISM policies should return http 409

### DIFF
--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/transport/action/indexpolicy/TransportIndexPolicyAction.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/transport/action/indexpolicy/TransportIndexPolicyAction.kt
@@ -8,6 +8,7 @@ package org.opensearch.indexmanagement.indexstatemanagement.transport.action.ind
 import org.apache.logging.log4j.LogManager
 import org.opensearch.ExceptionsHelper
 import org.opensearch.OpenSearchStatusException
+import org.opensearch.ResourceAlreadyExistsException
 import org.opensearch.action.ActionListener
 import org.opensearch.action.DocWriteRequest
 import org.opensearch.action.index.IndexRequest
@@ -97,7 +98,11 @@ class TransportIndexPolicyAction @Inject constructor(
                     }
 
                     override fun onFailure(t: Exception) {
-                        actionListener.onFailure(ExceptionsHelper.unwrapCause(t) as Exception)
+                        if (t is ResourceAlreadyExistsException) {
+                            actionListener.onFailure(OpenSearchStatusException(t.localizedMessage, RestStatus.CONFLICT))
+                        } else {
+                            actionListener.onFailure(ExceptionsHelper.unwrapCause(t) as Exception)
+                        }
                     }
                 })
             }


### PR DESCRIPTION
*Issue #, if available:* [260](https://github.com/opensearch-project/index-management/issues/260)

*Description of changes:* When multiple Policy creation requests are issued in parallel right after the cluster startup, some requests run into `resource_already_exists_exception`. Currently, the REST status code is 400, BAD_REQUEST but the ideal response should be 409, CONFLICT(resource_already_exists_exception). 

This code change fixed this behavior.

*Testing*: Verified we get `409` status code.
```
% curl -X PUT -H 'Content-type: application/json' -d '{"policy": {"description": "Example rollover policy.","default_state": "rollover","states": [{"name": "rollover","actions": [{"rollover": {"min_doc_count": 1}}],"transitions": []}],"ism_template": {"index_patterns": ["log*"],"priority": 100}}}' localhost:9200/_plugins/_ism/policies/rollover_policy &
curl -X PUT -H 'Content-type: application/json' -d '{"policy": {"description": "hot warm delete workflow","default_state": "hot","schema_version": 1,"states": [{"name": "hot","actions": [{"rollover": {"min_index_age": "1d","min_primary_shard_size": "30gb"}}],"transitions": [{"state_name": "warm"}]},{"name": "warm","actions": [{"replica_count": {"number_of_replicas": 5}}],"transitions": [{"state_name": "delete","conditions": {"min_index_age": "30d"}}]},{"name": "delete","actions": [{"notification": {"destination": {"chime": {"url": "<URL>"}},"message_template": {"source": "The index {{ctx.index}} is being deleted"}}},{"delete": {}}]}],"ism_template": {"index_patterns": ["log*"],"priority": 100}}}' localhost:9200/_plugins/_ism/policies/hot_warm_workflow &
[1] 12420
[2] 12421
% {"error":{"root_cause":[{"type":"status_exception","reason":"index [.opendistro-ism-config/JxlezzmDREmS0WHyYHOvWw] already exists"}],"type":"status_exception","reason":"index [.opendistro-ism-config/JxlezzmDREmS0WHyYHOvWw] already exists"},"status":409}
[2]  + done       curl -X PUT -H 'Content-type: application/json' -d
% {"_id":"rollover_policy","_version":1,"_primary_term":1,"_seq_no":0,"policy":{"policy":{"policy_id":"rollover_policy","description":"Example rollover policy.","last_updated_time":1660182585613,"schema_version":1,"error_notification":null,"default_state":"rollover","states":[{"name":"rollover","actions":[{"retry":{"count":3,"backoff":"exponential","delay":"1m"},"rollover":{"min_doc_count":1}}],"transitions":[]}],"ism_template":[{"index_patterns":["log*"],"priority":100,"last_updated_time":1660182585613}]}}}
[1]  + done       curl -X PUT -H 'Content-type: application/json' -d
```

*CheckList:*
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/index-management/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
