### PR TITLE
64: Added rounding when using aggreagate script for avg metric. Added…

### DIFF
--- a/src/main/kotlin/org/opensearch/indexmanagement/rollup/util/RollupUtils.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/rollup/util/RollupUtils.kt
@@ -214,7 +214,7 @@ fun Rollup.rewriteAggregationBuilder(aggregationBuilder: AggregationBuilder): Ag
         }
         is AvgAggregationBuilder -> {
             ScriptedMetricAggregationBuilder(aggregationBuilder.name)
-                .initScript(Script(ScriptType.INLINE, Script.DEFAULT_SCRIPT_LANG, "state.sums = 0; state.counts = 0;", emptyMap()))
+                .initScript(Script(ScriptType.INLINE, Script.DEFAULT_SCRIPT_LANG, "state.sums = 0D; state.counts = 0L;", emptyMap()))
                 .mapScript(
                     Script(
                         ScriptType.INLINE, Script.DEFAULT_SCRIPT_LANG,
@@ -227,7 +227,7 @@ fun Rollup.rewriteAggregationBuilder(aggregationBuilder: AggregationBuilder): Ag
                 .combineScript(
                     Script(
                         ScriptType.INLINE, Script.DEFAULT_SCRIPT_LANG,
-                        "def d = new long[2]; d[0] = state.sums; d[1] = state.counts; return d", emptyMap()
+                        "def d = new double[2]; d[0] = state.sums; d[1] = state.counts; return d", emptyMap()
                     )
                 )
                 .reduceScript(

--- a/src/test/kotlin/org/opensearch/indexmanagement/rollup/runner/RollupRunnerIT.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/rollup/runner/RollupRunnerIT.kt
@@ -77,7 +77,7 @@ class RollupRunnerIT : RollupRestTestCase() {
         generateNYCTaxiData(sourceIdxTestName)
 
         val rollup = Rollup(
-            id = "basic_stats_check_runner_fifth",
+            id = "rollup_test",
             schemaVersion = 1L,
             enabled = true,
             jobSchedule = IntervalSchedule(Instant.now(), 1, ChronoUnit.MINUTES),

--- a/src/test/kotlin/org/opensearch/indexmanagement/rollup/runner/RollupRunnerIT.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/rollup/runner/RollupRunnerIT.kt
@@ -93,7 +93,7 @@ class RollupRunnerIT : RollupRestTestCase() {
             continuous = false,
             dimensions = listOf(DateHistogram(sourceField = "tpep_pickup_datetime", fixedInterval = "1h")),
             metrics = listOf(
-                RollupMetrics(sourceField = propertyName, targetField = propertyName, metrics = listOf(Sum(), Min(), Max(), ValueCount(), Average()))
+                RollupMetrics(sourceField = propertyName, targetField = propertyName, metrics = listOf(Average()))
             )
         ).let { createRollup(it, it.id) }
 


### PR DESCRIPTION
… unit tests for checking average aggregations against the target rollup index

Signed-off-by: Stevan Buzejic <buzejic.stevan@gmail.com>
[
*Issue #, if available:*](https://github.com/opensearch-project/index-management/issues/64)

Added double summing the avg values when using avg metric

*CheckList:*
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/index-management/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
