### PR TITLE
Disable detekt because of the CVE issues

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -59,7 +59,8 @@ buildscript {
         classpath "org.opensearch.gradle:build-tools:${opensearch_version}"
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:${kotlin_version}"
         classpath "org.jetbrains.kotlin:kotlin-allopen:${kotlin_version}"
-        classpath "io.gitlab.arturbosch.detekt:detekt-gradle-plugin:1.21.0"
+        // TODO because snakeyaml CVE issue is on the latest version, have to disable detekt for now
+//        classpath "io.gitlab.arturbosch.detekt:detekt-gradle-plugin:1.21.0"
         classpath "org.jacoco:org.jacoco.agent:0.8.7"
     }
 }
@@ -75,7 +76,7 @@ apply plugin: 'idea'
 apply plugin: 'opensearch.opensearchplugin'
 apply plugin: 'opensearch.testclusters'
 apply plugin: 'opensearch.rest-test'
-apply plugin: 'io.gitlab.arturbosch.detekt'
+//apply plugin: 'io.gitlab.arturbosch.detekt'
 apply plugin: 'org.jetbrains.kotlin.jvm'
 apply plugin: 'org.jetbrains.kotlin.plugin.allopen'
 apply plugin: 'opensearch.pluginzip'
@@ -147,10 +148,10 @@ task ktlintFormat(type: JavaExec, group: "formatting") {
     args "-F", "src/**/*.kt", "spi/src/main/**/*.kt"
 }
 
-detekt {
-    config = files("detekt.yml")
-    buildUponDefaultConfig = true
-}
+//detekt {
+//    config = files("detekt.yml")
+//    buildUponDefaultConfig = true
+//}
 
 configurations.testImplementation {
     exclude module: "securemock"


### PR DESCRIPTION
Signed-off-by: bowenlan-amzn <bowenlan23@gmail.com>

*Issue #, if available:*
#491 
#492 
#493 
#494 

*Description of changes:*

Similar to the changes in common-util and notification repo
https://github.com/opensearch-project/common-utils/pull/237
https://github.com/opensearch-project/notifications/pull/528

*CheckList:*
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/index-management/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
