### PR TITLE
flaky transform test fix attempt

### DIFF
--- a/src/test/kotlin/org/opensearch/indexmanagement/transform/TransformRunnerIT.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/transform/TransformRunnerIT.kt
@@ -738,15 +738,14 @@ class TransformRunnerIT : TransformRestTestCase() {
             assertEquals("Transform did not complete iteration", null, transformMetadata.afterKey)
             assertNotNull("Continuous stats were not updated", transformMetadata.continuousStats)
             assertNotNull("Continuous stats were set, but lastTimestamp was not", transformMetadata.continuousStats!!.lastTimestamp)
+            assertEquals("Not the expected transform status", TransformMetadata.Status.STARTED, transformMetadata.status)
+            assertEquals("Not the expected pages processed", 6L, transformMetadata.stats.pagesProcessed)
+            assertEquals("Not the expected documents indexed", 2L, transformMetadata.stats.documentsIndexed)
+            assertEquals("Not the expected documents processed", 15000L, transformMetadata.stats.documentsProcessed)
+            assertTrue("Doesn't capture indexed time", transformMetadata.stats.indexTimeInMillis > 0)
+            assertTrue("Didn't capture search time", transformMetadata.stats.searchTimeInMillis > 0)
             transformMetadata
         }
-
-        assertEquals("Not the expected transform status", TransformMetadata.Status.STARTED, firstIterationMetadata.status)
-        assertEquals("Not the expected pages processed", 6L, firstIterationMetadata.stats.pagesProcessed)
-        assertEquals("Not the expected documents indexed", 2L, firstIterationMetadata.stats.documentsIndexed)
-        assertEquals("Not the expected documents processed", 15000L, firstIterationMetadata.stats.documentsProcessed)
-        assertTrue("Doesn't capture indexed time", firstIterationMetadata.stats.indexTimeInMillis > 0)
-        assertTrue("Didn't capture search time", firstIterationMetadata.stats.searchTimeInMillis > 0)
 
         waitFor {
             val documentsBehind = getTransformDocumentsBehind(transform.id)
@@ -759,22 +758,20 @@ class TransformRunnerIT : TransformRestTestCase() {
 
         Thread.sleep(5000)
 
-        val secondIterationMetadata = waitFor {
+        waitFor {
             val job = getTransform(transformId = transform.id)
             assertNotNull("Transform job doesn't have metadata set", job.metadataId)
             val transformMetadata = getTransformMetadata(job.metadataId!!)
             assertEquals("Transform did not complete iteration or had incorrect number of documents processed", 15000, transformMetadata.stats.documentsProcessed)
             assertEquals("Transform did not have null afterKey after iteration", null, transformMetadata.afterKey)
             assertTrue("Timestamp was not updated", transformMetadata.continuousStats!!.lastTimestamp!!.isAfter(firstIterationMetadata.continuousStats!!.lastTimestamp))
-            transformMetadata
+            assertEquals("Not the expected transform status", TransformMetadata.Status.STARTED, transformMetadata.status)
+            assertEquals("More than expected pages processed", 6, transformMetadata.stats.pagesProcessed)
+            assertEquals("More than expected documents indexed", 2L, transformMetadata.stats.documentsIndexed)
+            assertEquals("Not the expected documents processed", 15000L, transformMetadata.stats.documentsProcessed)
+            assertEquals("Not the expected indexed time", transformMetadata.stats.indexTimeInMillis, firstIterationMetadata.stats.indexTimeInMillis)
+            assertEquals("Not the expected search time", transformMetadata.stats.searchTimeInMillis, firstIterationMetadata.stats.searchTimeInMillis)
         }
-
-        assertEquals("Not the expected transform status", TransformMetadata.Status.STARTED, secondIterationMetadata.status)
-        assertEquals("More than expected pages processed", 6, secondIterationMetadata.stats.pagesProcessed)
-        assertEquals("More than expected documents indexed", 2L, secondIterationMetadata.stats.documentsIndexed)
-        assertEquals("Not the expected documents processed", 15000L, secondIterationMetadata.stats.documentsProcessed)
-        assertEquals("Not the expected indexed time", secondIterationMetadata.stats.indexTimeInMillis, firstIterationMetadata.stats.indexTimeInMillis)
-        assertEquals("Not the expected search time", secondIterationMetadata.stats.searchTimeInMillis, firstIterationMetadata.stats.searchTimeInMillis)
 
         disableTransform(transform.id)
     }
@@ -1003,6 +1000,12 @@ class TransformRunnerIT : TransformRestTestCase() {
             assertEquals("Transform did not complete iteration", null, transformMetadata.afterKey)
             assertNotNull("Continuous stats were not updated", transformMetadata.continuousStats)
             assertNotNull("Continuous stats were set, but lastTimestamp was not", transformMetadata.continuousStats!!.lastTimestamp)
+            assertEquals("Not the expected transform status", TransformMetadata.Status.STARTED, transformMetadata.status)
+            assertEquals("Not the expected pages processed", 6L, transformMetadata.stats.pagesProcessed)
+            assertEquals("Not the expected documents indexed", 2L, transformMetadata.stats.documentsIndexed)
+            assertEquals("Not the expected documents processed", 15000L, transformMetadata.stats.documentsProcessed)
+            assertTrue("Doesn't capture indexed time", transformMetadata.stats.indexTimeInMillis > 0)
+            assertTrue("Didn't capture search time", transformMetadata.stats.searchTimeInMillis > 0)
             transformMetadata
         }
 

--- a/src/test/kotlin/org/opensearch/indexmanagement/transform/TransformRunnerIT.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/transform/TransformRunnerIT.kt
@@ -1000,12 +1000,6 @@ class TransformRunnerIT : TransformRestTestCase() {
             assertEquals("Transform did not complete iteration", null, transformMetadata.afterKey)
             assertNotNull("Continuous stats were not updated", transformMetadata.continuousStats)
             assertNotNull("Continuous stats were set, but lastTimestamp was not", transformMetadata.continuousStats!!.lastTimestamp)
-            assertEquals("Not the expected transform status", TransformMetadata.Status.STARTED, transformMetadata.status)
-            assertEquals("Not the expected pages processed", 6L, transformMetadata.stats.pagesProcessed)
-            assertEquals("Not the expected documents indexed", 2L, transformMetadata.stats.documentsIndexed)
-            assertEquals("Not the expected documents processed", 15000L, transformMetadata.stats.documentsProcessed)
-            assertTrue("Doesn't capture indexed time", transformMetadata.stats.indexTimeInMillis > 0)
-            assertTrue("Didn't capture search time", transformMetadata.stats.searchTimeInMillis > 0)
             transformMetadata
         }
 


### PR DESCRIPTION
Signed-off-by: Petar Dzepina <petar.dzepina@vroom.com>

*Issue #, if available:*

*Description of changes:*

Moved asserts inside waitFor block

TransformRunnerIT Integ test success run:
```
index-management % ./gradlew integTest -Dtests.class="*TransformRunnerIT"                              

> Configure project :
mixed cluster flag: false
=======================================
OpenSearch Build Hamster says Hello!
  Gradle Version        : 7.4.2
  OS Info               : Mac OS X 12.6 (x86_64)
  JDK Version           : 17 (Zulu JDK)
  JAVA_HOME             : /Library/Java/JavaVirtualMachines/zulu-17.jdk/Contents/Home
  Random Testing Seed   : D705BCEBC3477413
  In FIPS 140 mode      : false
=======================================

> Task :integTest
OpenJDK 64-Bit Server VM warning: Ignoring option --illegal-access=warn; support was removed in 17.0

Deprecated Gradle features were used in this build, making it incompatible with Gradle 8.0.

You can use '--warning-mode all' to show the individual deprecation warnings and determine if they come from your own scripts or plugins.

See https://docs.gradle.org/7.4.2/userguide/command_line_interface.html#sec:command_line_warnings

BUILD SUCCESSFUL in 2m 37s
13 actionable tasks: 3 executed, 10 up-to-date

```

*CheckList:*
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/index-management/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
