### PR TITLE
556: Moved _doc_count from transform._doc_count to root of document

### DIFF
--- a/src/main/kotlin/org/opensearch/indexmanagement/transform/model/Transform.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/transform/model/Transform.kt
@@ -170,10 +170,12 @@ data class Transform(
         return if (includeId) {
             mutableMapOf(
                 TRANSFORM_DOC_ID_FIELD to this.id,
+                _DOC_COUNT to docCount,
                 TRANSFORM_DOC_COUNT_FIELD to docCount
             )
         } else {
             mutableMapOf(
+                _DOC_COUNT to docCount,
                 TRANSFORM_DOC_COUNT_FIELD to docCount
             )
         }
@@ -286,6 +288,8 @@ data class Transform(
         const val MAXIMUM_PAGE_SIZE_CONTINUOUS = 1_000
         const val MINIMUM_JOB_INTERVAL = 1
         const val TRANSFORM_DOC_ID_FIELD = "$TRANSFORM_TYPE._id"
+        const val _DOC_COUNT = "_doc_count"
+        // Keeping the field in order to be backward compatible
         const val TRANSFORM_DOC_COUNT_FIELD = "$TRANSFORM_TYPE._doc_count"
         const val CONTINUOUS_FIELD = "continuous"
         const val USER_FIELD = "user"

--- a/src/test/kotlin/org/opensearch/indexmanagement/transform/resthandler/RestPreviewTransformActionIT.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/transform/resthandler/RestPreviewTransformActionIT.kt
@@ -62,7 +62,7 @@ class RestPreviewTransformActionIT : TransformRestTestCase() {
             emptyMap(),
             transform.toHttpEntity()
         )
-        val expectedKeys = setOf("revenue", "passengerCount", "flag", "transform._doc_count")
+        val expectedKeys = setOf("revenue", "passengerCount", "flag", "transform._doc_count", "_doc_count")
         assertEquals("Preview transform failed", RestStatus.OK, response.restStatus())
         val transformedDocs = response.asMap()["documents"] as List<Map<String, Any>>
         assertEquals("Transformed docs have unexpected schema", expectedKeys, transformedDocs.first().keys)


### PR DESCRIPTION
Signed-off-by: Stevan Buzejic <buzejic.stevan@gmail.com>

*Issue #, if available:* https://github.com/opensearch-project/index-management/issues/556

*Description of changes:*
Moved _doc_values from transform.doc_values to root of document

*CheckList:*
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/index-management/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
