### PR TITLE
Adds an alias action (#35)

### DIFF
--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/ISMActionsParser.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/ISMActionsParser.kt
@@ -8,6 +8,7 @@ package org.opensearch.indexmanagement.indexstatemanagement
 import org.opensearch.common.io.stream.StreamInput
 import org.opensearch.common.xcontent.XContentParser
 import org.opensearch.common.xcontent.XContentParserUtils
+import org.opensearch.indexmanagement.indexstatemanagement.action.AliasActionParser
 import org.opensearch.indexmanagement.indexstatemanagement.action.AllocationActionParser
 import org.opensearch.indexmanagement.indexstatemanagement.action.CloseActionParser
 import org.opensearch.indexmanagement.indexstatemanagement.action.DeleteActionParser
@@ -34,6 +35,7 @@ class ISMActionsParser private constructor() {
     }
 
     val parsers = mutableListOf(
+        AliasActionParser(),
         AllocationActionParser(),
         CloseActionParser(),
         DeleteActionParser(),

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/action/AliasAction.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/action/AliasAction.kt
@@ -1,0 +1,51 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.indexmanagement.indexstatemanagement.action
+
+import org.opensearch.action.admin.indices.alias.IndicesAliasesRequest
+import org.opensearch.common.io.stream.StreamOutput
+import org.opensearch.common.xcontent.ToXContent
+import org.opensearch.common.xcontent.XContentBuilder
+import org.opensearch.indexmanagement.indexstatemanagement.step.alias.AttemptAliasStep
+import org.opensearch.indexmanagement.spi.indexstatemanagement.Action
+import org.opensearch.indexmanagement.spi.indexstatemanagement.Step
+import org.opensearch.indexmanagement.spi.indexstatemanagement.model.StepContext
+
+class AliasAction(
+    val actions: List<IndicesAliasesRequest.AliasActions>,
+    index: Int
+) : Action(name, index) {
+
+    init {
+        require(actions.isNotEmpty()) { "At least one alias action needs to be specified." }
+    }
+
+    private val attemptAliasStep = AttemptAliasStep(this)
+
+    private val steps = listOf(attemptAliasStep)
+
+    override fun getStepToExecute(context: StepContext): Step {
+        return attemptAliasStep
+    }
+
+    override fun getSteps(): List<Step> = steps
+
+    override fun populateAction(builder: XContentBuilder, params: ToXContent.Params) {
+        builder.startObject(type)
+        builder.field(ACTIONS, actions)
+        builder.endObject()
+    }
+
+    override fun populateAction(out: StreamOutput) {
+        out.writeList(actions)
+        out.writeInt(actionIndex)
+    }
+
+    companion object {
+        const val name = "alias"
+        const val ACTIONS = "actions"
+    }
+}

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/action/AliasAction.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/action/AliasAction.kt
@@ -21,6 +21,8 @@ class AliasAction(
 
     init {
         require(actions.isNotEmpty()) { "At least one alias action needs to be specified." }
+        require(!actions.any { it.actionType() == IndicesAliasesRequest.AliasActions.Type.REMOVE_INDEX }) { "Remove_index is not allowed here." }
+        require(actions.all { it.indices().isNullOrEmpty() }) { "Alias actions are only allowed on managed indices." }
     }
 
     private val attemptAliasStep = AttemptAliasStep(this)

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/action/AliasActionParser.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/action/AliasActionParser.kt
@@ -1,0 +1,45 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.indexmanagement.indexstatemanagement.action
+
+import org.opensearch.action.admin.indices.alias.IndicesAliasesRequest
+import org.opensearch.common.io.stream.StreamInput
+import org.opensearch.common.xcontent.XContentParser
+import org.opensearch.common.xcontent.XContentParser.Token
+import org.opensearch.common.xcontent.XContentParserUtils.ensureExpectedToken
+import org.opensearch.indexmanagement.indexstatemanagement.action.AliasAction.Companion.ACTIONS
+import org.opensearch.indexmanagement.spi.indexstatemanagement.Action
+import org.opensearch.indexmanagement.spi.indexstatemanagement.ActionParser
+
+class AliasActionParser : ActionParser() {
+    override fun fromStreamInput(sin: StreamInput): Action {
+        val actions = sin.readList(IndicesAliasesRequest::AliasActions)
+        val index = sin.readInt()
+        return AliasAction(actions, index)
+    }
+
+    override fun fromXContent(xcp: XContentParser, index: Int): Action {
+        val actions: MutableList<IndicesAliasesRequest.AliasActions> = mutableListOf()
+
+        ensureExpectedToken(Token.START_OBJECT, xcp.currentToken(), xcp)
+        while (xcp.nextToken() != Token.END_OBJECT) {
+            val fieldName = xcp.currentName()
+            xcp.nextToken()
+            when (fieldName) {
+                ACTIONS -> {
+                    ensureExpectedToken(Token.START_ARRAY, xcp.currentToken(), xcp)
+                    while (xcp.nextToken() != Token.END_ARRAY) {
+                        actions.add(IndicesAliasesRequest.AliasActions.fromXContent(xcp))
+                    }
+                }
+                else -> throw IllegalArgumentException("Invalid field: [$fieldName] found in AliasAction.")
+            }
+        }
+        return AliasAction(actions, index)
+    }
+
+    override fun getActionType(): String = AliasAction.name
+}

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/action/AliasActionParser.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/action/AliasActionParser.kt
@@ -5,6 +5,7 @@
 
 package org.opensearch.indexmanagement.indexstatemanagement.action
 
+import org.apache.logging.log4j.LogManager
 import org.opensearch.action.admin.indices.alias.IndicesAliasesRequest
 import org.opensearch.common.io.stream.StreamInput
 import org.opensearch.common.xcontent.XContentParser
@@ -15,6 +16,8 @@ import org.opensearch.indexmanagement.spi.indexstatemanagement.Action
 import org.opensearch.indexmanagement.spi.indexstatemanagement.ActionParser
 
 class AliasActionParser : ActionParser() {
+
+    private val logger = LogManager.getLogger(javaClass)
     override fun fromStreamInput(sin: StreamInput): Action {
         val actions = sin.readList(IndicesAliasesRequest::AliasActions)
         val index = sin.readInt()
@@ -35,7 +38,10 @@ class AliasActionParser : ActionParser() {
                         actions.add(IndicesAliasesRequest.AliasActions.fromXContent(xcp))
                     }
                 }
-                else -> throw IllegalArgumentException("Invalid field: [$fieldName] found in AliasAction.")
+                else -> {
+                    logger.error("Invalid field: [$fieldName] found in AliasAction.")
+                    throw IllegalArgumentException("Invalid field: [$fieldName] found in AliasAction.")
+                }
             }
         }
         return AliasAction(actions, index)

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/alias/AttemptAliasStep.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/alias/AttemptAliasStep.kt
@@ -8,17 +8,11 @@ package org.opensearch.indexmanagement.indexstatemanagement.step.alias
 import org.apache.logging.log4j.LogManager
 import org.opensearch.action.admin.indices.alias.IndicesAliasesRequest
 import org.opensearch.action.support.master.AcknowledgedResponse
-import org.opensearch.common.Strings
 import org.opensearch.indexmanagement.indexstatemanagement.action.AliasAction
-import org.opensearch.indexmanagement.opensearchapi.convertToMap
 import org.opensearch.indexmanagement.opensearchapi.suspendUntil
 import org.opensearch.indexmanagement.spi.indexstatemanagement.Step
 import org.opensearch.indexmanagement.spi.indexstatemanagement.model.ManagedIndexMetaData
 import org.opensearch.indexmanagement.spi.indexstatemanagement.model.StepMetaData
-import org.opensearch.script.Script
-import org.opensearch.script.ScriptService
-import org.opensearch.script.ScriptType
-import org.opensearch.script.TemplateScript
 
 class AttemptAliasStep(private val action: AliasAction) : Step(name) {
 
@@ -32,15 +26,8 @@ class AttemptAliasStep(private val action: AliasAction) : Step(name) {
         try {
             val request = IndicesAliasesRequest()
             action.actions.forEach {
-                // Take the indices that were set to be updated on the alias action and join them into a single string
-                // So we don't have to pass each one individually into the script service to be compiled
-                val indices = it.indices().joinToString(",")
-                // Compile them so the user can use the current dynamic index name in the name such as "{{ctx.index}}" in the static policy
-                val indicesScript = Script(ScriptType.INLINE, Script.DEFAULT_TEMPLATE_LANG, indices, mapOf())
-                val compiledIndices = compileTemplate(indicesScript, context.metadata, indices, context.scriptService)
-                // Split them back into individual index names and set back on the AliasActions request
-                val splitIndices = Strings.splitStringByCommaToArray(compiledIndices)
-                it.indices(*splitIndices)
+                // Applying the actions on the managed index.
+                it.indices(indexName)
                 request.addAliasAction(it)
             }
             val response: AcknowledgedResponse = context.client.admin().indices().suspendUntil { aliases(request, it) }
@@ -77,19 +64,6 @@ class AttemptAliasStep(private val action: AliasAction) : Step(name) {
             transitionTo = null,
             info = info
         )
-    }
-
-    private fun compileTemplate(
-        template: Script,
-        managedIndexMetaData: ManagedIndexMetaData,
-        defaultValue: String,
-        scriptService: ScriptService
-    ): String {
-        val contextMap = managedIndexMetaData.convertToMap().filterKeys { key -> key in validTopContextFields }
-        val compiledValue = scriptService.compile(template, TemplateScript.CONTEXT)
-            .newInstance(template.params + mapOf("ctx" to contextMap))
-            .execute()
-        return compiledValue.ifBlank { defaultValue }
     }
 
     override fun isIdempotent() = true

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/alias/AttemptAliasStep.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/alias/AttemptAliasStep.kt
@@ -1,0 +1,103 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.indexmanagement.indexstatemanagement.step.alias
+
+import org.apache.logging.log4j.LogManager
+import org.opensearch.action.admin.indices.alias.IndicesAliasesRequest
+import org.opensearch.action.support.master.AcknowledgedResponse
+import org.opensearch.common.Strings
+import org.opensearch.indexmanagement.indexstatemanagement.action.AliasAction
+import org.opensearch.indexmanagement.opensearchapi.convertToMap
+import org.opensearch.indexmanagement.opensearchapi.suspendUntil
+import org.opensearch.indexmanagement.spi.indexstatemanagement.Step
+import org.opensearch.indexmanagement.spi.indexstatemanagement.model.ManagedIndexMetaData
+import org.opensearch.indexmanagement.spi.indexstatemanagement.model.StepMetaData
+import org.opensearch.script.Script
+import org.opensearch.script.ScriptService
+import org.opensearch.script.ScriptType
+import org.opensearch.script.TemplateScript
+
+class AttemptAliasStep(private val action: AliasAction) : Step(name) {
+
+    private val logger = LogManager.getLogger(javaClass)
+    private var stepStatus = StepStatus.STARTING
+    private var info: Map<String, Any>? = null
+
+    override suspend fun execute(): Step {
+        val context = this.context ?: return this
+        val indexName = context.metadata.index
+        try {
+            val request = IndicesAliasesRequest()
+            action.actions.forEach {
+                // Take the indices that were set to be updated on the alias action and join them into a single string
+                // So we don't have to pass each one individually into the script service to be compiled
+                val indices = it.indices().joinToString(",")
+                // Compile them so the user can use the current dynamic index name in the name such as "{{ctx.index}}" in the static policy
+                val indicesScript = Script(ScriptType.INLINE, Script.DEFAULT_TEMPLATE_LANG, indices, mapOf())
+                val compiledIndices = compileTemplate(indicesScript, context.metadata, indices, context.scriptService)
+                // Split them back into individual index names and set back on the AliasActions request
+                val splitIndices = Strings.splitStringByCommaToArray(compiledIndices)
+                it.indices(*splitIndices)
+                request.addAliasAction(it)
+            }
+            val response: AcknowledgedResponse = context.client.admin().indices().suspendUntil { aliases(request, it) }
+            handleResponse(response, indexName)
+        } catch (e: Exception) {
+            handleException(e, indexName)
+        }
+        return this
+    }
+
+    private fun handleException(e: Exception, indexName: String) {
+        val message = getFailedMessage(indexName)
+        logger.error(message, e)
+        stepStatus = StepStatus.FAILED
+        val mutableInfo = mutableMapOf("message" to message)
+        val errorMessage = e.message
+        if (errorMessage != null) mutableInfo["cause"] = errorMessage
+        info = mutableInfo.toMap()
+    }
+
+    private fun handleResponse(response: AcknowledgedResponse, indexName: String) {
+        if (response.isAcknowledged) {
+            stepStatus = StepStatus.COMPLETED
+            info = mapOf("message" to getSuccessMessage(indexName))
+        } else {
+            stepStatus = StepStatus.FAILED
+            info = mapOf("message" to getFailedMessage(indexName))
+        }
+    }
+
+    override fun getUpdatedManagedIndexMetadata(currentMetadata: ManagedIndexMetaData): ManagedIndexMetaData {
+        return currentMetadata.copy(
+            stepMetaData = StepMetaData(name, getStepStartTime(currentMetadata).toEpochMilli(), stepStatus),
+            transitionTo = null,
+            info = info
+        )
+    }
+
+    private fun compileTemplate(
+        template: Script,
+        managedIndexMetaData: ManagedIndexMetaData,
+        defaultValue: String,
+        scriptService: ScriptService
+    ): String {
+        val contextMap = managedIndexMetaData.convertToMap().filterKeys { key -> key in validTopContextFields }
+        val compiledValue = scriptService.compile(template, TemplateScript.CONTEXT)
+            .newInstance(template.params + mapOf("ctx" to contextMap))
+            .execute()
+        return compiledValue.ifBlank { defaultValue }
+    }
+
+    override fun isIdempotent() = true
+
+    companion object {
+        val validTopContextFields = setOf("index")
+        const val name = "attempt_alias"
+        fun getFailedMessage(index: String) = "Failed to update alias [index=$index]"
+        fun getSuccessMessage(index: String) = "Successfully updated alias [index=$index]"
+    }
+}

--- a/src/main/resources/mappings/opendistro-ism-config.json
+++ b/src/main/resources/mappings/opendistro-ism-config.json
@@ -1,6 +1,6 @@
 {
   "_meta" : {
-    "schema_version": 16
+    "schema_version": 17
   },
   "dynamic": "strict",
   "properties": {
@@ -156,6 +156,14 @@
                     },
                     "delay": {
                       "type": "keyword"
+                    }
+                  }
+                },
+                "alias": {
+                  "properties": {
+                    "actions": {
+                      "type": "object",
+                      "enabled": false
                     }
                   }
                 },

--- a/src/test/kotlin/org/opensearch/indexmanagement/IndexManagementRestTestCase.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/IndexManagementRestTestCase.kt
@@ -27,7 +27,7 @@ import javax.management.remote.JMXServiceURL
 
 abstract class IndexManagementRestTestCase : ODFERestTestCase() {
 
-    val configSchemaVersion = 16
+    val configSchemaVersion = 17
     val historySchemaVersion = 5
 
     // Having issues with tests leaking into other tests and mappings being incorrect and they are not caught by any pending task wait check as

--- a/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/TestHelpers.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/TestHelpers.kt
@@ -208,8 +208,8 @@ fun randomOpenActionConfig(): OpenAction {
     return OpenAction(index = 0)
 }
 
-fun randomAliasAction(): AliasAction {
-    val actions = List(OpenSearchRestTestCase.randomIntBetween(1, 10)) { randomAliasActions() }
+fun randomAliasAction(includeIndices: Boolean = false): AliasAction {
+    val actions = List(OpenSearchRestTestCase.randomIntBetween(1, 10)) { if (includeIndices) randomAliasActionWithIndices() else randomAliasActions() }
     return AliasAction(actions = actions, index = 0)
 }
 
@@ -217,7 +217,13 @@ fun randomAliasActions(): IndicesAliasesRequest.AliasActions {
     val types = listOf(IndicesAliasesRequest.AliasActions.Type.ADD, IndicesAliasesRequest.AliasActions.Type.REMOVE)
     return IndicesAliasesRequest.AliasActions(OpenSearchRestTestCase.randomSubsetOf(1, types).first())
         .alias(OpenSearchRestTestCase.randomAlphaOfLength(10))
-        .index(OpenSearchRestTestCase.randomAlphaOfLength(10))
+}
+
+fun randomAliasActionWithIndices(): IndicesAliasesRequest.AliasActions {
+    val types = listOf(IndicesAliasesRequest.AliasActions.Type.ADD, IndicesAliasesRequest.AliasActions.Type.REMOVE)
+    return IndicesAliasesRequest.AliasActions(OpenSearchRestTestCase.randomSubsetOf(1, types).first())
+        .alias(OpenSearchRestTestCase.randomAlphaOfLength(10))
+        .indices(OpenSearchRestTestCase.randomAlphaOfLength(10))
 }
 
 fun randomDestination(type: DestinationType = randomDestinationType()): Destination {

--- a/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/TestHelpers.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/TestHelpers.kt
@@ -6,12 +6,14 @@
 package org.opensearch.indexmanagement.indexstatemanagement
 
 import org.opensearch.action.admin.indices.alias.Alias
+import org.opensearch.action.admin.indices.alias.IndicesAliasesRequest
 import org.opensearch.common.unit.ByteSizeValue
 import org.opensearch.common.unit.TimeValue
 import org.opensearch.common.xcontent.ToXContent
 import org.opensearch.common.xcontent.XContentFactory
 import org.opensearch.index.RandomCreateIndexGenerator.randomAlias
 import org.opensearch.index.seqno.SequenceNumbers
+import org.opensearch.indexmanagement.indexstatemanagement.action.AliasAction
 import org.opensearch.indexmanagement.indexstatemanagement.action.AllocationAction
 import org.opensearch.indexmanagement.indexstatemanagement.action.CloseAction
 import org.opensearch.indexmanagement.indexstatemanagement.action.DeleteAction
@@ -204,6 +206,18 @@ fun randomCloseActionConfig(): CloseAction {
 
 fun randomOpenActionConfig(): OpenAction {
     return OpenAction(index = 0)
+}
+
+fun randomAliasAction(): AliasAction {
+    val actions = List(OpenSearchRestTestCase.randomIntBetween(1, 10)) { randomAliasActions() }
+    return AliasAction(actions = actions, index = 0)
+}
+
+fun randomAliasActions(): IndicesAliasesRequest.AliasActions {
+    val types = listOf(IndicesAliasesRequest.AliasActions.Type.ADD, IndicesAliasesRequest.AliasActions.Type.REMOVE)
+    return IndicesAliasesRequest.AliasActions(OpenSearchRestTestCase.randomSubsetOf(1, types).first())
+        .alias(OpenSearchRestTestCase.randomAlphaOfLength(10))
+        .index(OpenSearchRestTestCase.randomAlphaOfLength(10))
 }
 
 fun randomDestination(type: DestinationType = randomDestinationType()): Destination {
@@ -474,6 +488,11 @@ fun CloseAction.toJsonString(): String {
 }
 
 fun OpenAction.toJsonString(): String {
+    val builder = XContentFactory.jsonBuilder()
+    return this.toXContent(builder, ToXContent.EMPTY_PARAMS).string()
+}
+
+fun AliasAction.toJsonString(): String {
     val builder = XContentFactory.jsonBuilder()
     return this.toXContent(builder, ToXContent.EMPTY_PARAMS).string()
 }

--- a/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/action/AliasActionIT.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/action/AliasActionIT.kt
@@ -17,13 +17,13 @@ import java.time.temporal.ChronoUnit
 import java.util.Locale
 
 class AliasActionIT : IndexStateManagementRestTestCase() {
-    private val testIndexName = javaClass.simpleName.toLowerCase(Locale.ROOT)
+    private val testIndexName = javaClass.simpleName.lowercase(Locale.ROOT)
 
     fun `test adding alias to index`() {
         val indexName = "${testIndexName}_index_1"
         val policyID = "${testIndexName}_testPolicyName_1"
         val aliasName = "some_alias_to_add"
-        val actions = listOf(IndicesAliasesRequest.AliasActions.add().alias(aliasName).index(indexName))
+        val actions = listOf(IndicesAliasesRequest.AliasActions.add().alias(aliasName))
         val actionConfig = AliasAction(actions = actions, index = 0)
         val states = listOf(State("alias", listOf(actionConfig), listOf()))
 
@@ -66,7 +66,7 @@ class AliasActionIT : IndexStateManagementRestTestCase() {
         val indexName = "${testIndexName}_index_2"
         val policyID = "${testIndexName}_testPolicyName_2"
         val aliasName = "some_alias_to_add"
-        val actions = listOf(IndicesAliasesRequest.AliasActions.add().alias(aliasName).index("{{ctx.index}}"))
+        val actions = listOf(IndicesAliasesRequest.AliasActions.add().alias(aliasName))
         val actionConfig = AliasAction(actions = actions, index = 0)
         val states = listOf(State("alias", listOf(actionConfig), listOf()))
 
@@ -109,7 +109,7 @@ class AliasActionIT : IndexStateManagementRestTestCase() {
         val indexName = "${testIndexName}_index_3"
         val policyID = "${testIndexName}_testPolicyName_3"
         val aliasName = "some_alias_to_remove"
-        val actions = listOf(IndicesAliasesRequest.AliasActions.remove().alias(aliasName).index(indexName))
+        val actions = listOf(IndicesAliasesRequest.AliasActions.remove().alias(aliasName))
         val actionConfig = AliasAction(actions = actions, index = 0)
         val states = listOf(State("alias", listOf(actionConfig), listOf()))
 

--- a/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/action/AliasActionIT.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/action/AliasActionIT.kt
@@ -1,0 +1,150 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.indexmanagement.indexstatemanagement.action
+
+import org.opensearch.action.admin.indices.alias.IndicesAliasesRequest
+import org.opensearch.indexmanagement.indexstatemanagement.IndexStateManagementRestTestCase
+import org.opensearch.indexmanagement.indexstatemanagement.model.Policy
+import org.opensearch.indexmanagement.indexstatemanagement.model.State
+import org.opensearch.indexmanagement.indexstatemanagement.randomErrorNotification
+import org.opensearch.indexmanagement.indexstatemanagement.step.alias.AttemptAliasStep
+import org.opensearch.indexmanagement.waitFor
+import java.time.Instant
+import java.time.temporal.ChronoUnit
+import java.util.Locale
+
+class AliasActionIT : IndexStateManagementRestTestCase() {
+    private val testIndexName = javaClass.simpleName.toLowerCase(Locale.ROOT)
+
+    fun `test adding alias to index`() {
+        val indexName = "${testIndexName}_index_1"
+        val policyID = "${testIndexName}_testPolicyName_1"
+        val aliasName = "some_alias_to_add"
+        val actions = listOf(IndicesAliasesRequest.AliasActions.add().alias(aliasName).index(indexName))
+        val actionConfig = AliasAction(actions = actions, index = 0)
+        val states = listOf(State("alias", listOf(actionConfig), listOf()))
+
+        val policy = Policy(
+            id = policyID,
+            description = "$testIndexName description",
+            schemaVersion = 1L,
+            lastUpdatedTime = Instant.now().truncatedTo(ChronoUnit.MILLIS),
+            errorNotification = randomErrorNotification(),
+            defaultState = states[0].name,
+            states = states
+        )
+        createPolicy(policy, policyID)
+        createIndex(indexName, policyID)
+        val managedIndexConfig = getExistingManagedIndexConfig(indexName)
+
+        // Change the start time so the job will trigger in 2 seconds.
+        updateManagedIndexConfigStartTime(managedIndexConfig)
+
+        waitFor { assertEquals(policyID, getExplainManagedIndexMetaData(indexName).policyID) }
+
+        waitFor {
+            val alias = getAlias(indexName, "")
+            assertTrue("Alias was already added to index", !alias.containsKey(aliasName))
+        }
+
+        // Need to wait two cycles.
+        // Change the start time so the job will trigger in 2 seconds.
+        updateManagedIndexConfigStartTime(managedIndexConfig)
+
+        waitFor {
+            val info = getExplainManagedIndexMetaData(indexName).info as Map<String, Any?>
+            assertEquals("Alias was not successfully updated", AttemptAliasStep.getSuccessMessage(indexName), info["message"])
+            val alias = getAlias(indexName, "")
+            assertTrue("Alias was not added to index", alias.containsKey(aliasName))
+        }
+    }
+
+    fun `test adding alias to index using ctx`() {
+        val indexName = "${testIndexName}_index_2"
+        val policyID = "${testIndexName}_testPolicyName_2"
+        val aliasName = "some_alias_to_add"
+        val actions = listOf(IndicesAliasesRequest.AliasActions.add().alias(aliasName).index("{{ctx.index}}"))
+        val actionConfig = AliasAction(actions = actions, index = 0)
+        val states = listOf(State("alias", listOf(actionConfig), listOf()))
+
+        val policy = Policy(
+            id = policyID,
+            description = "$testIndexName description",
+            schemaVersion = 1L,
+            lastUpdatedTime = Instant.now().truncatedTo(ChronoUnit.MILLIS),
+            errorNotification = randomErrorNotification(),
+            defaultState = states[0].name,
+            states = states
+        )
+        createPolicy(policy, policyID)
+        createIndex(indexName, policyID)
+        val managedIndexConfig = getExistingManagedIndexConfig(indexName)
+
+        // Change the start time so the job will trigger in 2 seconds.
+        updateManagedIndexConfigStartTime(managedIndexConfig)
+
+        waitFor { assertEquals(policyID, getExplainManagedIndexMetaData(indexName).policyID) }
+
+        waitFor {
+            val alias = getAlias(indexName, "")
+            assertTrue("Alias was already added to index", !alias.containsKey(aliasName))
+        }
+
+        // Need to wait two cycles.
+        // Change the start time so the job will trigger in 2 seconds.
+        updateManagedIndexConfigStartTime(managedIndexConfig)
+
+        waitFor {
+            val info = getExplainManagedIndexMetaData(indexName).info as Map<String, Any?>
+            assertEquals("Alias was not successfully updated", AttemptAliasStep.getSuccessMessage(indexName), info["message"])
+            val alias = getAlias(indexName, "")
+            assertTrue("Alias was not added to index", alias.containsKey(aliasName))
+        }
+    }
+
+    fun `test removing alias from index`() {
+        val indexName = "${testIndexName}_index_3"
+        val policyID = "${testIndexName}_testPolicyName_3"
+        val aliasName = "some_alias_to_remove"
+        val actions = listOf(IndicesAliasesRequest.AliasActions.remove().alias(aliasName).index(indexName))
+        val actionConfig = AliasAction(actions = actions, index = 0)
+        val states = listOf(State("alias", listOf(actionConfig), listOf()))
+
+        val policy = Policy(
+            id = policyID,
+            description = "$testIndexName description",
+            schemaVersion = 1L,
+            lastUpdatedTime = Instant.now().truncatedTo(ChronoUnit.MILLIS),
+            errorNotification = randomErrorNotification(),
+            defaultState = states[0].name,
+            states = states
+        )
+        createPolicy(policy, policyID)
+        createIndex(indexName, policyID, aliasName)
+        val managedIndexConfig = getExistingManagedIndexConfig(indexName)
+
+        // Change the start time so the job will trigger in 2 seconds.
+        updateManagedIndexConfigStartTime(managedIndexConfig)
+
+        waitFor { assertEquals(policyID, getExplainManagedIndexMetaData(indexName).policyID) }
+
+        waitFor {
+            val alias = getAlias(indexName, "")
+            assertTrue("Alias was not added to index", alias.containsKey(aliasName))
+        }
+
+        // Need to wait two cycles.
+        // Change the start time so the job will trigger in 2 seconds.
+        updateManagedIndexConfigStartTime(managedIndexConfig)
+
+        waitFor {
+            val info = getExplainManagedIndexMetaData(indexName).info as Map<String, Any?>
+            assertEquals("Alias was not successfully updated", AttemptAliasStep.getSuccessMessage(indexName), info["message"])
+            val alias = getAlias(indexName, "")
+            assertTrue("Alias was not removed from index", !alias.containsKey(aliasName))
+        }
+    }
+}

--- a/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/action/AliasActionIT.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/action/AliasActionIT.kt
@@ -10,7 +10,7 @@ import org.opensearch.indexmanagement.indexstatemanagement.IndexStateManagementR
 import org.opensearch.indexmanagement.indexstatemanagement.model.Policy
 import org.opensearch.indexmanagement.indexstatemanagement.model.State
 import org.opensearch.indexmanagement.indexstatemanagement.randomErrorNotification
-import org.opensearch.indexmanagement.indexstatemanagement.step.alias.AttemptAliasStep
+import org.opensearch.indexmanagement.indexstatemanagement.step.alias.AttemptAliasActionsStep
 import org.opensearch.indexmanagement.waitFor
 import java.time.Instant
 import java.time.temporal.ChronoUnit
@@ -56,7 +56,7 @@ class AliasActionIT : IndexStateManagementRestTestCase() {
 
         waitFor {
             val info = getExplainManagedIndexMetaData(indexName).info as Map<String, Any?>
-            assertEquals("Alias was not successfully updated", AttemptAliasStep.getSuccessMessage(indexName), info["message"])
+            assertEquals("Alias was not successfully updated", AttemptAliasActionsStep.getSuccessMessage(indexName), info["message"])
             val alias = getAlias(indexName, "")
             assertTrue("Alias was not added to index", alias.containsKey(aliasName))
         }
@@ -99,7 +99,7 @@ class AliasActionIT : IndexStateManagementRestTestCase() {
 
         waitFor {
             val info = getExplainManagedIndexMetaData(indexName).info as Map<String, Any?>
-            assertEquals("Alias was not successfully updated", AttemptAliasStep.getSuccessMessage(indexName), info["message"])
+            assertEquals("Alias was not successfully updated", AttemptAliasActionsStep.getSuccessMessage(indexName), info["message"])
             val alias = getAlias(indexName, "")
             assertTrue("Alias was not added to index", alias.containsKey(aliasName))
         }
@@ -142,7 +142,7 @@ class AliasActionIT : IndexStateManagementRestTestCase() {
 
         waitFor {
             val info = getExplainManagedIndexMetaData(indexName).info as Map<String, Any?>
-            assertEquals("Alias was not successfully updated", AttemptAliasStep.getSuccessMessage(indexName), info["message"])
+            assertEquals("Alias was not successfully updated", AttemptAliasActionsStep.getSuccessMessage(indexName), info["message"])
             val alias = getAlias(indexName, "")
             assertTrue("Alias was not removed from index", !alias.containsKey(aliasName))
         }

--- a/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/model/XContentTests.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/model/XContentTests.kt
@@ -40,6 +40,7 @@ import org.opensearch.indexmanagement.opensearchapi.convertToMap
 import org.opensearch.indexmanagement.opensearchapi.parseWithType
 import org.opensearch.indexmanagement.spi.indexstatemanagement.model.ManagedIndexMetaData
 import org.opensearch.test.OpenSearchTestCase
+import kotlin.test.assertFailsWith
 
 class XContentTests : OpenSearchTestCase() {
 
@@ -274,11 +275,21 @@ class XContentTests : OpenSearchTestCase() {
     }
 
     fun `test alias action parsing`() {
-        val aliasAction = randomAliasAction()
-
+        val aliasAction = randomAliasAction(false)
         val aliasActionString = aliasAction.toJsonString()
         val parsedAliasAction = ISMActionsParser.instance.parse(parser(aliasActionString), 0)
         assertEquals("Round tripping AliasAction doesn't work", aliasAction.convertToMap(), parsedAliasAction.convertToMap())
+    }
+
+    fun `test alias action parsing with index`() {
+        assertFailsWith<IllegalArgumentException>(
+            message = "Alias actions are only allowed on managed indices.",
+            block = {
+                val aliasAction = randomAliasAction(true)
+                val aliasActionString = aliasAction.toJsonString()
+                ISMActionsParser.instance.parse(parser(aliasActionString), 0)
+            }
+        )
     }
 
     private fun parser(xc: String): XContentParser {

--- a/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/model/XContentTests.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/model/XContentTests.kt
@@ -13,6 +13,7 @@ import org.opensearch.indexmanagement.indexstatemanagement.action.RollupAction
 import org.opensearch.indexmanagement.common.model.notification.Channel
 import org.opensearch.indexmanagement.indexstatemanagement.model.destination.DestinationType
 import org.opensearch.indexmanagement.indexstatemanagement.nonNullRandomConditions
+import org.opensearch.indexmanagement.indexstatemanagement.randomAliasAction
 import org.opensearch.indexmanagement.indexstatemanagement.randomAllocationActionConfig
 import org.opensearch.indexmanagement.indexstatemanagement.randomChangePolicy
 import org.opensearch.indexmanagement.indexstatemanagement.randomChannel
@@ -270,6 +271,14 @@ class XContentTests : OpenSearchTestCase() {
         val channelString = channel.toJsonString()
         val parsedChannel = Channel.parse(parser(channelString))
         assertEquals("Round tripping Channel doesn't work", channel, parsedChannel)
+    }
+
+    fun `test alias action parsing`() {
+        val aliasAction = randomAliasAction()
+
+        val aliasActionString = aliasAction.toJsonString()
+        val parsedAliasAction = ISMActionsParser.instance.parse(parser(aliasActionString), 0)
+        assertEquals("Round tripping AliasAction doesn't work", aliasAction.convertToMap(), parsedAliasAction.convertToMap())
     }
 
     private fun parser(xc: String): XContentParser {

--- a/src/test/resources/mappings/cached-opendistro-ism-config.json
+++ b/src/test/resources/mappings/cached-opendistro-ism-config.json
@@ -1,6 +1,6 @@
 {
   "_meta" : {
-    "schema_version": 16
+    "schema_version": 17
   },
   "dynamic": "strict",
   "properties": {
@@ -156,6 +156,14 @@
                     },
                     "delay": {
                       "type": "keyword"
+                    }
+                  }
+                },
+                "alias": {
+                  "properties": {
+                    "actions": {
+                      "type": "object",
+                      "enabled": false
                     }
                   }
                 },

--- a/worksheets/ism/alias_action.http
+++ b/worksheets/ism/alias_action.http
@@ -1,0 +1,196 @@
+1. Rollover index policy with deletion of indices when the doc count exceeds a certain value.
+1.1. Create an ISM policy
+
+curl -X PUT "localhost:9200/_plugins/_ism/policies/rollover_policy?pretty" -H 'Content-Type: application/json' -d'
+{
+  "policy": {
+    "description": "Example rollover policy.",
+    "default_state": "rollover",
+    "states": [
+      {
+        "name": "rollover",
+        "actions": [
+          {
+            "rollover": {
+              "min_doc_count": 1
+            }
+          }
+        ],
+        "transitions": [{
+            "state_name": "alias",
+            "conditions": {
+              "min_doc_count": "2"
+            }
+          }]
+      },
+      {
+        "name": "alias",
+        "actions": [
+          {
+            "alias": {
+              "actions": [
+                {
+                  "remove": {
+                      "alias": "log"
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      }
+    ],
+    "ism_template": {
+      "index_patterns": ["log*"],
+      "priority": 100
+    }
+  }
+}
+'
+
+1.2 Create an index template to enable the policy on:
+
+curl -X PUT "localhost:9200/_index_template/ism_rollover?" -H 'Content-Type: application/json' -d'
+{
+  "index_patterns": ["log*"],
+  "template": {
+   "settings": {
+    "plugins.index_state_management.rollover_alias": "log"
+   }
+ }
+}
+'
+
+1.3 Change the cluster settings to trigger jobs every minute:
+
+curl -X PUT "localhost:9200/_cluster/settings?pretty=true" -H 'Content-Type: application/json' -d'
+{
+  "persistent" : {
+    "plugins.index_state_management.job_interval" : 1
+  }
+}
+'
+
+1.4 Create a new index:
+
+curl -X PUT "localhost:9200/log-000001" -H 'Content-Type: application/json' -d'
+{
+  "aliases": {
+    "log": {
+      "is_write_index": true
+    }
+  }
+}
+'
+
+1.5 Add a document to the index to trigger the job:
+
+curl -X POST "localhost:9200/log-000001/_doc" -H 'Content-Type: application/json' -d'
+{
+  "message": "dummy"
+}
+'
+
+1.6 The first job will trigger the rollover action and a new index will be created.
+1.7 Add another document to the two indices like step 1.5.
+1.8 The new job will cause the second index to point to the log alias and the older one will be removed due to alias action.
+1.9. Verify these steps using alias and index API:
+
+curl -X GET "localhost:9200/_cat/indices?pretty"
+
+curl -X GET "localhost:9200/_cat/aliases?pretty"
+
+
+2. Fail the case if a user tries to apply alias action on a specific index/indices.
+2.1 Create the following policy:
+
+curl -X PUT "localhost:9200/_plugins/_ism/policies/remove_action_policy?pretty" -H 'Content-Type: application/json' -d'
+{
+  "policy": {
+    "description": "Example remove action policy.",
+    "default_state": "alias",
+    "states": [
+      {
+        "name": "alias",
+        "actions": [
+          {
+            "alias": {
+              "actions": [
+                {
+                  "add": {
+                      "alias": "log"
+                  }
+                },
+                {
+                  "remove": {
+                      "index": "log-00001",
+                      "alias": "log"
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      }
+    ],
+    "ism_template": {
+      "index_patterns": ["log*"],
+      "priority": 100
+    }
+  }
+}
+'
+
+2.2 This will create an Illegal argument exception with the error: "Alias action can only work on its applied index so don't accept index/indices parameter."
+
+3. Fail the case if a user tries to remove index using alias action.
+3.1 Create the following policy:
+
+curl -X PUT "localhost:9200/_plugins/_ism/policies/remove_index_policy?pretty" -H 'Content-Type: application/json' -d'
+{
+  "policy": {
+    "description": "Example remove index policy.",
+    "default_state": "alias",
+    "states": [
+      {
+        "name": "alias",
+        "actions": [
+          {
+            "alias": {
+              "actions": [
+                {
+                  "remove_index": {
+                      "index": "log"
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      }
+    ],
+    "ism_template": {
+      "index_patterns": ["log*"],
+      "priority": 100
+    }
+  }
+}
+'
+
+3.2 This will create an Illegal argument exception with the error: "Only ADD and REMOVE actions are allowed."
+
+
+-----------------------
+
+NOTE: Use the following command to make the cluster green:
+
+curl -X PUT "localhost:9200/log-000001/_settings" -H 'Content-Type: application/json' -d'
+{
+    "index" : {
+        "number_of_replicas" : 0
+    }
+}
+'
+
+
+


### PR DESCRIPTION
Signed-off-by: Megha Goyal <goyamegh@amazon.com>

*Issue #, if available:*
 #35 (#304)

*Description of changes:* 
Adds support for an alias action in ISM.
Gives complete support for all update alias API options by reusing the alias actions parser internally and explicitly not defining the mappings in our config index.

Coming from the GitHub feature request, the use cases people asked for:

> 1. My use case is, If we have an alias for an index with rollover ILM policy, can we remove it from alias after some predefined days, let's say 30 days? I know there is a way to delete an index once its old, but in our case we do not want to delete but want the index to be removed from alias and have the alias switch and point to indices whose age is less than 30 days.

 This should be easily doable with the Alias action, just have a state that gets transitioned into after the index is 30 days old (or 30 days rollover age) and then remove the alias.

> 2. My use case is: we provide search_alias to search our dataset. We publish new version of dataset every week as a new index (e.g. dataset-yyyy-MM-dd. We want the search_alias always pointing to the latest published dataset. The process is: ingest new data to a new index, once ingestion finish, re-pointing search_alias to the new index, remove old index from the search_alias

Should be possible, the newly created index can remove the alias from all search-index-* indices and then add the alias it itself in a single call. The main thing would be knowing when ingestion finished for the new index.. which you could just use some absolute time using the transition condition if you know it only takes x amount of time.


*CheckList:*
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/index-management/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).


**Testing steps:**

1. Rollover index with deletion of indices when the doc count exceeds a certain value.
1.1. Create an ISM policy
```
curl -X PUT "localhost:9200/_plugins/_ism/policies/rollover_policy?pretty" -H 'Content-Type: application/json' -d'
{
  "policy": {
    "description": "Example rollover policy.",
    "default_state": "rollover",
    "states": [
      {
        "name": "rollover",
        "actions": [
          {
            "rollover": {
              "min_doc_count": 1
            }
          }
        ],
        "transitions": [{
            "state_name": "alias",
            "conditions": {
              "min_doc_count": "2"
            }
          }]
      },
      {
        "name": "alias",
        "actions": [
          {
            "alias": {
              "actions": [
                {
                  "remove": {
                      "alias": "log"
                  }
                }
              ]
            }
          }
        ]
      }
    ],
    "ism_template": {
      "index_patterns": ["log*"],
      "priority": 100
    }
  }
}
'
```
1.2 Create an index template to enable the policy on:
```
curl -X PUT "localhost:9200/_index_template/ism_rollover1?" -H 'Content-Type: application/json' -d'
{
  "index_patterns": ["1log*"],
  "template": {
   "settings": {
    "plugins.index_state_management.rollover_alias": "1log"
   }
 }
}
'
```
1.3 Change the cluster settings to trigger jobs every minute:
```
curl -X PUT "localhost:9200/_cluster/settings?pretty=true" -H 'Content-Type: application/json' -d'
{
  "persistent" : {
    "plugins.index_state_management.job_interval" : 1
  }
}
'
```
1.4 Create a new index:
```
curl -X PUT "localhost:9200/log-000001" -H 'Content-Type: application/json' -d'
{
  "aliases": {
    "log": {
      "is_write_index": true
    }
  }
}
'
```
1.5 Add a document to the index to trigger the job:
```

curl -X POST "localhost:9200/log-000001/_doc" -H 'Content-Type: application/json' -d'
{
  "message": "dummy"
}
'
```
1.6 The first job will trigger the rollover action and a new index will be created. 
1.7 Add another document to the two indices like step 1.5.
1.8 The new job will cause the second index to point to the log alias and the older one will be removed due to alias action.
1.9. Verify these steps using alias and index API:
```
curl -X GET "localhost:9200/_cat/indices?pretty"

curl -X GET "localhost:9200/_cat/aliases?pretty"
```


2. Fail the case if a user tries to remove index using alias action.
2.1 Create the following policy:
```
curl -X PUT "localhost:9200/_plugins/_ism/policies/remove_index_policy12345?pretty" -H 'Content-Type: application/json' -d'
{
  "policy": {
    "description": "Example rollover policy.",
    "default_state": "rollover",
    "states": [
      {
        "name": "rollover",
        "actions": [
          {
            "rollover": {
              "min_doc_count": 1
            }
          }
        ],
        "transitions": [{
            "state_name": "alias",
            "conditions": {
              "min_doc_count": "2"
            }
          }]
      },
      {
        "name": "alias",
        "actions": [
          {
            "alias": {
              "actions": [
                {
                  "add": {
                      "alias": "log"
                  }
                },
                {
                  "remove": {
                      "index": "log-00001"
                  }
                }
              ]
            }
          }
        ]
      }
    ],
    "ism_template": {
      "index_patterns": ["MMMMMMMMttestlog*"],
      "priority": 100
    }
  }
}
'
```
2.2 This will create an Illegal argument exception with the error: "Remove_index is not allowed here."