### PR TITLE
Unify test clean logic

### DIFF
--- a/.github/workflows/bwc-test-workflow.yml
+++ b/.github/workflows/bwc-test-workflow.yml
@@ -13,10 +13,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # This step uses the setup-java Github action: https://github.com/actions/setup-java
-      - name: Set Up JDK 11
+      - name: Set Up JDK
         uses: actions/setup-java@v1
         with:
-          java-version: 11
+          java-version: 17
       # index-management
       - name: Checkout Branch
         uses: actions/checkout@v2

--- a/.github/workflows/multi-node-test-workflow.yml
+++ b/.github/workflows/multi-node-test-workflow.yml
@@ -14,10 +14,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # This step uses the setup-java Github action: https://github.com/actions/setup-java
-      - name: Set Up JDK 11
+      - name: Set Up JDK
         uses: actions/setup-java@v1
         with:
-          java-version: 11
+          java-version: 17
       # index-management
       - name: Checkout Branch
         uses: actions/checkout@v2

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/ManagedIndexRunner.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/ManagedIndexRunner.kt
@@ -403,7 +403,13 @@ object ManagedIndexRunner :
         @Suppress("ComplexCondition", "MaxLineLength")
         if (updateResult.metadataSaved && state != null && action != null && step != null && currentActionMetaData != null) {
             if (validationServiceEnabled) {
-                val validationResult = actionValidation.validate(action.type, stepContext.metadata.index)
+                val validationResult = withClosableContext(
+                    IndexManagementSecurityContext(
+                        managedIndexConfig.id, settings, threadPool.threadContext, managedIndexConfig.policy.user
+                    )
+                ) {
+                    actionValidation.validate(action.type, stepContext.metadata.index)
+                }
                 if (validationResult.validationStatus == Validate.ValidationStatus.RE_VALIDATING) {
                     logger.warn("Validation Status is: RE_VALIDATING. The action is {}, state is {}, step is {}.\", action.type, state.name, step.name")
                     publishErrorNotification(policy, managedIndexMetaData)

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/transport/action/explain/TransportExplainAction.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/transport/action/explain/TransportExplainAction.kt
@@ -383,7 +383,7 @@ class TransportExplainAction @Inject constructor(
                         filteredIndices.add(indexNames[i])
                         filteredMetadata.add(indexMetadatas[i])
                         filteredPolicies.add(indexPolicyIDs[i])
-                        validationResults[i]?.let { filteredValidationResult.add(it) }
+                        validationResults[i].let { filteredValidationResult.add(it) }
                         enabledState[indexNames[i]]?.let { enabledStatus[indexNames[i]] = it }
                         appliedPolicies[indexNames[i]]?.let { filteredAppliedPolicies[indexNames[i]] = it }
                     } catch (e: OpenSearchSecurityException) {

--- a/src/main/kotlin/org/opensearch/indexmanagement/util/JobSchedulerUtils.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/util/JobSchedulerUtils.kt
@@ -13,7 +13,7 @@ import org.opensearch.jobscheduler.spi.JobExecutionContext
 import org.opensearch.jobscheduler.spi.LockModel
 import org.opensearch.jobscheduler.spi.ScheduledJobParameter
 
-private val logger = LogManager.getLogger("JobSchedulerUtils")
+private val logger = LogManager.getLogger("o.o.i.u.JobSchedulerUtils")
 
 /**
  * Util method to attempt to get the lock on the requested scheduled job using the backoff policy.

--- a/src/test/kotlin/org/opensearch/indexmanagement/IndexManagementIndicesIT.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/IndexManagementIndicesIT.kt
@@ -71,9 +71,9 @@ class IndexManagementIndicesIT : IndexStateManagementRestTestCase() {
     }
 
     fun `test update management index mapping with new schema version`() {
-        wipeAllODFEIndices()
-        waitForPendingTasks(adminClient())
-        assertIndexDoesNotExist(INDEX_MANAGEMENT_INDEX)
+        waitFor {
+            assertIndexDoesNotExist(INDEX_MANAGEMENT_INDEX)
+        }
 
         val mapping = indexManagementMappings.trim().trimStart('{').trimEnd('}')
             .replace("\"schema_version\": $configSchemaVersion", "\"schema_version\": 0")

--- a/src/test/kotlin/org/opensearch/indexmanagement/IndexManagementIndicesIT.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/IndexManagementIndicesIT.kt
@@ -71,9 +71,8 @@ class IndexManagementIndicesIT : IndexStateManagementRestTestCase() {
     }
 
     fun `test update management index mapping with new schema version`() {
-        waitFor {
-            assertIndexDoesNotExist(INDEX_MANAGEMENT_INDEX)
-        }
+        wipeAllIndices()
+        assertIndexDoesNotExist(INDEX_MANAGEMENT_INDEX)
 
         val mapping = indexManagementMappings.trim().trimStart('{').trimEnd('}')
             .replace("\"schema_version\": $configSchemaVersion", "\"schema_version\": 0")

--- a/src/test/kotlin/org/opensearch/indexmanagement/IndexStateManagementSecurityBehaviorIT.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/IndexStateManagementSecurityBehaviorIT.kt
@@ -52,10 +52,6 @@ class IndexStateManagementSecurityBehaviorIT : SecurityRestTestCase() {
     private val testRole = "test_role"
     var testClient: RestClient? = null
 
-    override fun preserveIndicesUponCompletion(): Boolean {
-        return true
-    }
-
     @Before
     fun setupUsersAndRoles() {
         updateClusterSetting(ManagedIndexSettings.JITTER.key, "0.0", false)

--- a/src/test/kotlin/org/opensearch/indexmanagement/ODFERestTestCase.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/ODFERestTestCase.kt
@@ -6,15 +6,9 @@
 package org.opensearch.indexmanagement
 
 import org.apache.http.HttpHost
-import org.opensearch.action.admin.cluster.node.tasks.list.ListTasksAction
-import org.opensearch.client.Request
-import org.opensearch.client.Response
 import org.opensearch.client.RestClient
 import org.opensearch.common.io.PathUtils
 import org.opensearch.common.settings.Settings
-import org.opensearch.common.xcontent.DeprecationHandler
-import org.opensearch.common.xcontent.NamedXContentRegistry
-import org.opensearch.common.xcontent.XContentType
 import org.opensearch.commons.ConfigConstants.OPENSEARCH_SECURITY_SSL_HTTP_ENABLED
 import org.opensearch.commons.ConfigConstants.OPENSEARCH_SECURITY_SSL_HTTP_KEYSTORE_FILEPATH
 import org.opensearch.commons.ConfigConstants.OPENSEARCH_SECURITY_SSL_HTTP_KEYSTORE_KEYPASSWORD
@@ -23,7 +17,6 @@ import org.opensearch.commons.ConfigConstants.OPENSEARCH_SECURITY_SSL_HTTP_PEMCE
 import org.opensearch.commons.rest.SecureRestClientBuilder
 import org.opensearch.test.rest.OpenSearchRestTestCase
 import java.io.IOException
-import java.util.Date
 
 abstract class ODFERestTestCase : OpenSearchRestTestCase() {
 
@@ -32,60 +25,6 @@ abstract class ODFERestTestCase : OpenSearchRestTestCase() {
     fun securityEnabled(): Boolean = System.getProperty("security", "false")!!.toBoolean()
 
     override fun getProtocol(): String = if (isHttps()) "https" else "http"
-
-    companion object {
-        @JvmStatic
-        @Throws(IOException::class)
-        protected fun waitForRunningTasks(client: RestClient) {
-            val runningTasks: MutableSet<String> = runningTasks(client.performRequest(Request("GET", "/_tasks?detailed")))
-            if (runningTasks.isEmpty()) {
-                return
-            }
-            val stillRunning = ArrayList<String>(runningTasks)
-            fail("${Date()}: There are still tasks running after this test that might break subsequent tests: \n${stillRunning.joinToString("\n")}.")
-        }
-
-        @Suppress("UNCHECKED_CAST")
-        @Throws(IOException::class)
-        private fun runningTasks(response: Response): MutableSet<String> {
-            val runningTasks: MutableSet<String> = HashSet()
-            val nodes = entityAsMap(response)["nodes"] as Map<String, Any>?
-            for ((_, value) in nodes!!) {
-                val nodeInfo = value as Map<String, Any>
-                val nodeTasks = nodeInfo["tasks"] as Map<String, Any>?
-                for ((_, value1) in nodeTasks!!) {
-                    val task = value1 as Map<String, Any>
-                    // Ignore the task list API - it doesn't count against us
-                    if (task["action"] == ListTasksAction.NAME || task["action"] == ListTasksAction.NAME + "[n]") continue
-                    // runningTasks.add(task["action"].toString() + " | " + task["description"].toString())
-                    runningTasks.add(task.toString())
-                }
-            }
-            return runningTasks
-        }
-
-        @JvmStatic
-        protected fun waitForThreadPools(client: RestClient) {
-            val response = client.performRequest(Request("GET", "/_cat/thread_pool?format=json"))
-
-            val xContentType = XContentType.fromMediaType(response.entity.contentType.value)
-            xContentType.xContent().createParser(
-                NamedXContentRegistry.EMPTY, DeprecationHandler.THROW_UNSUPPORTED_OPERATION,
-                response.entity.content
-            ).use { parser ->
-                for (index in parser.list()) {
-                    val jsonObject: Map<*, *> = index as java.util.HashMap<*, *>
-                    val active = (jsonObject["active"] as String).toInt()
-                    val queue = (jsonObject["queue"] as String).toInt()
-                    val name = jsonObject["name"]
-                    val trueActive = if (name == "management") active - 1 else active
-                    if (trueActive > 0 || queue > 0) {
-                        fail("Still active threadpools in cluster: $jsonObject")
-                    }
-                }
-            }
-        }
-    }
 
     /**
      * Returns the REST client settings used for super-admin actions like cleaning up after the test has completed.

--- a/src/test/kotlin/org/opensearch/indexmanagement/ODFERestTestCase.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/ODFERestTestCase.kt
@@ -9,10 +9,8 @@ import org.apache.http.HttpHost
 import org.junit.After
 import org.opensearch.action.admin.cluster.node.tasks.list.ListTasksAction
 import org.opensearch.client.Request
-import org.opensearch.client.RequestOptions
 import org.opensearch.client.Response
 import org.opensearch.client.RestClient
-import org.opensearch.client.WarningsHandler
 import org.opensearch.common.io.PathUtils
 import org.opensearch.common.settings.Settings
 import org.opensearch.common.xcontent.DeprecationHandler
@@ -26,7 +24,7 @@ import org.opensearch.commons.ConfigConstants.OPENSEARCH_SECURITY_SSL_HTTP_PEMCE
 import org.opensearch.commons.rest.SecureRestClientBuilder
 import org.opensearch.test.rest.OpenSearchRestTestCase
 import java.io.IOException
-import java.time.Instant
+import java.util.Date
 
 abstract class ODFERestTestCase : OpenSearchRestTestCase() {
 
@@ -36,80 +34,48 @@ abstract class ODFERestTestCase : OpenSearchRestTestCase() {
 
     override fun getProtocol(): String = if (isHttps()) "https" else "http"
 
-    @Suppress("UNCHECKED_CAST")
-    @Throws(IOException::class)
-    private fun runningTasks(response: Response): MutableSet<String> {
-        val runningTasks: MutableSet<String> = HashSet()
-        val nodes = entityAsMap(response)["nodes"] as Map<String, Any>?
-        for ((_, value) in nodes!!) {
-            val nodeInfo = value as Map<String, Any>
-            val nodeTasks = nodeInfo["tasks"] as Map<String, Any>?
-            for ((_, value1) in nodeTasks!!) {
-                val task = value1 as Map<String, Any>
-                runningTasks.add(task["action"].toString())
-            }
-        }
-        return runningTasks
-    }
-
     @After
     fun waitForCleanup() {
         waitFor {
-            waitForRunningTasks()
             waitForThreadPools()
             waitForPendingTasks(adminClient())
         }
     }
 
-    @Throws(IOException::class)
-    private fun waitForRunningTasks() {
-        waitFor(timeout = Instant.ofEpochSecond(5)) {
-            val runningTasks: MutableSet<String> = runningTasks(adminClient().performRequest(Request("GET", "/_tasks")))
-            // Ignore the task list API - it doesn't count against us
-            runningTasks.remove(ListTasksAction.NAME)
-            runningTasks.remove(ListTasksAction.NAME + "[n]")
+    companion object {
+        @JvmStatic
+        @Throws(IOException::class)
+        protected fun waitForRunningTasks(client: RestClient) {
+            val runningTasks: MutableSet<String> = runningTasks(client.performRequest(Request("GET", "/_tasks?detailed")))
             if (runningTasks.isEmpty()) {
-                return@waitFor
+                return
             }
             val stillRunning = ArrayList<String>(runningTasks)
-            fail("There are still tasks running after this test that might break subsequent tests $stillRunning.")
+            fail("${Date()}: There are still tasks running after this test that might break subsequent tests: \n${stillRunning.joinToString("\n")}.")
+        }
+
+        @Suppress("UNCHECKED_CAST")
+        @Throws(IOException::class)
+        private fun runningTasks(response: Response): MutableSet<String> {
+            val runningTasks: MutableSet<String> = HashSet()
+            val nodes = entityAsMap(response)["nodes"] as Map<String, Any>?
+            for ((_, value) in nodes!!) {
+                val nodeInfo = value as Map<String, Any>
+                val nodeTasks = nodeInfo["tasks"] as Map<String, Any>?
+                for ((_, value1) in nodeTasks!!) {
+                    val task = value1 as Map<String, Any>
+                    // Ignore the task list API - it doesn't count against us
+                    if (task["action"] == ListTasksAction.NAME || task["action"] == ListTasksAction.NAME + "[n]") continue
+                    // runningTasks.add(task["action"].toString() + " | " + task["description"].toString())
+                    runningTasks.add(task.toString())
+                }
+            }
+            return runningTasks
         }
     }
 
     private fun waitForThreadPools() {
-        waitFor {
-            val response = client().performRequest(Request("GET", "/_cat/thread_pool?format=json"))
-
-            val xContentType = XContentType.fromMediaType(response.entity.contentType.value)
-            xContentType.xContent().createParser(
-                NamedXContentRegistry.EMPTY, DeprecationHandler.THROW_UNSUPPORTED_OPERATION,
-                response.entity.content
-            ).use { parser ->
-                for (index in parser.list()) {
-                    val jsonObject: Map<*, *> = index as java.util.HashMap<*, *>
-                    val active = (jsonObject["active"] as String).toInt()
-                    val queue = (jsonObject["queue"] as String).toInt()
-                    val name = jsonObject["name"]
-                    val trueActive = if (name == "management") active - 1 else active
-                    if (trueActive > 0 || queue > 0) {
-                        fail("Still active threadpools in cluster: $jsonObject")
-                    }
-                }
-            }
-        }
-    }
-
-    open fun preserveODFEIndicesAfterTest(): Boolean = false
-
-    @Throws(IOException::class)
-    open fun wipeAllODFEIndices() {
-        if (preserveODFEIndicesAfterTest()) return
-
-        // Delete all data stream indices
-        client().performRequest(Request("DELETE", "/_data_stream/*"))
-
-        // Delete all indices
-        val response = client().performRequest(Request("GET", "/_cat/indices?format=json&expand_wildcards=all"))
+        val response = client().performRequest(Request("GET", "/_cat/thread_pool?format=json"))
 
         val xContentType = XContentType.fromMediaType(response.entity.contentType.value)
         xContentType.xContent().createParser(
@@ -118,19 +84,17 @@ abstract class ODFERestTestCase : OpenSearchRestTestCase() {
         ).use { parser ->
             for (index in parser.list()) {
                 val jsonObject: Map<*, *> = index as java.util.HashMap<*, *>
-                val indexName: String = jsonObject["index"] as String
-                // .opendistro_security isn't allowed to delete from cluster
-                if (".opendistro_security" != indexName) {
-                    val request = Request("DELETE", "/$indexName")
-                    // TODO: remove PERMISSIVE option after moving system index access to REST API call
-                    val options = RequestOptions.DEFAULT.toBuilder()
-                    options.setWarningsHandler(WarningsHandler.PERMISSIVE)
-                    request.options = options.build()
-                    adminClient().performRequest(request)
+                val active = (jsonObject["active"] as String).toInt()
+                val queue = (jsonObject["queue"] as String).toInt()
+                val name = jsonObject["name"]
+                val trueActive = if (name == "management") active - 1 else active
+                if (trueActive > 0 || queue > 0) {
+                    fail("Still active threadpools in cluster: $jsonObject")
                 }
             }
         }
     }
+
     /**
      * Returns the REST client settings used for super-admin actions like cleaning up after the test has completed.
      */

--- a/src/test/kotlin/org/opensearch/indexmanagement/RollupSecurityBehaviorIT.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/RollupSecurityBehaviorIT.kt
@@ -43,10 +43,6 @@ class RollupSecurityBehaviorIT : SecurityRestTestCase() {
     private val testRole = "test_role"
     var testUserClient: RestClient? = null
 
-    override fun preserveIndicesUponCompletion(): Boolean {
-        return true
-    }
-
     @Before
     fun setupUsersAndRoles() {
         updateClusterSetting(ManagedIndexSettings.JITTER.key, "0.0", false)

--- a/src/test/kotlin/org/opensearch/indexmanagement/SecurityBehaviorIT.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/SecurityBehaviorIT.kt
@@ -26,10 +26,6 @@ class SecurityBehaviorIT : SecurityRestTestCase() {
     private val john = "john"
     private var johnClient: RestClient? = null
 
-    override fun preserveIndicesUponCompletion(): Boolean {
-        return true
-    }
-
     @Before
     fun setupUsersAndRoles() {
         updateClusterSetting(ManagedIndexSettings.JITTER.key, "0.0", false)

--- a/src/test/kotlin/org/opensearch/indexmanagement/TransformSecurityBehaviorIT.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/TransformSecurityBehaviorIT.kt
@@ -37,10 +37,6 @@ class TransformSecurityBehaviorIT : SecurityRestTestCase() {
     private val testRole = "test_role"
     var testUserClient: RestClient? = null
 
-    override fun preserveIndicesUponCompletion(): Boolean {
-        return true
-    }
-
     @Before
     fun setupUsersAndRoles() {
         updateClusterSetting(ManagedIndexSettings.JITTER.key, "0.0", false)

--- a/src/test/kotlin/org/opensearch/indexmanagement/bwc/IndexManagementBackwardsCompatibilityIT.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/bwc/IndexManagementBackwardsCompatibilityIT.kt
@@ -36,8 +36,6 @@ class IndexManagementBackwardsCompatibilityIT : IndexManagementRestTestCase() {
 
     override fun preserveTemplatesUponCompletion(): Boolean = true
 
-    override fun preserveODFEIndicesAfterTest(): Boolean = true
-
     override fun restClientSettings(): Settings {
         return Settings.builder()
             .put(super.restClientSettings())

--- a/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/IndexStateManagementIntegTestCase.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/IndexStateManagementIntegTestCase.kt
@@ -7,6 +7,7 @@ package org.opensearch.indexmanagement.indexstatemanagement
 
 import org.apache.http.entity.ContentType
 import org.apache.http.entity.StringEntity
+import org.junit.After
 import org.junit.Before
 import org.opensearch.OpenSearchParseException
 import org.opensearch.action.ActionRequest
@@ -28,6 +29,7 @@ import org.opensearch.common.xcontent.XContentParserUtils
 import org.opensearch.common.xcontent.XContentType
 import org.opensearch.common.xcontent.json.JsonXContent
 import org.opensearch.indexmanagement.IndexManagementPlugin
+import org.opensearch.indexmanagement.IndexManagementRestTestCase.Companion.wipeAllIndices
 import org.opensearch.indexmanagement.indexstatemanagement.model.ManagedIndexConfig
 import org.opensearch.indexmanagement.indexstatemanagement.model.Policy
 import org.opensearch.indexmanagement.indexstatemanagement.resthandler.RestExplainAction
@@ -55,6 +57,12 @@ import java.time.Duration
 import java.time.Instant
 
 abstract class IndexStateManagementIntegTestCase : OpenSearchIntegTestCase() {
+
+    @After
+    fun clearIndicesAfterEachTest() {
+        wipeAllIndices(getRestClient())
+    }
+
     @Before
     fun disableIndexStateManagementJitter() {
         // jitter would add a test-breaking delay to the integration tests

--- a/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/IndexStateManagementRestTestCase.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/IndexStateManagementRestTestCase.kt
@@ -10,6 +10,7 @@ import org.apache.http.HttpHeaders
 import org.apache.http.entity.ContentType.APPLICATION_JSON
 import org.apache.http.entity.StringEntity
 import org.apache.http.message.BasicHeader
+import org.junit.After
 import org.junit.Before
 import org.opensearch.OpenSearchParseException
 import org.opensearch.action.get.GetResponse
@@ -73,6 +74,11 @@ import java.time.Instant
 import java.util.Locale
 
 abstract class IndexStateManagementRestTestCase : IndexManagementRestTestCase() {
+
+    @After
+    fun clearIndicesAfterEachTest() {
+        wipeAllIndices()
+    }
 
     val explainResponseOpendistroPolicyIdSetting = "index.opendistro.index_state_management.policy_id"
     val explainResponseOpenSearchPolicyIdSetting = "index.plugins.index_state_management.policy_id"

--- a/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/action/ActionTimeoutIT.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/action/ActionTimeoutIT.kt
@@ -71,8 +71,8 @@ class ActionTimeoutIT : IndexStateManagementRestTestCase() {
 
     // https://github.com/opendistro-for-elasticsearch/index-management/issues/130
     fun `test action timeout doesn't bleed over into next action`() {
-        val indexName = "${testIndexName}_index_1"
-        val policyID = "${testIndexName}_testPolicyName_1"
+        val indexName = "${testIndexName}_index_2"
+        val policyID = "${testIndexName}_testPolicyName_2"
         val testPolicy = """
         {"policy":{"description":"Default policy","default_state":"rolloverstate","states":[
         {"name":"rolloverstate","actions":[{"timeout": "5s","open":{}},{"timeout":"1s","rollover":{"min_doc_count":100}}],

--- a/src/test/kotlin/org/opensearch/indexmanagement/refreshanalyzer/RefreshSearchAnalyzerActionIT.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/refreshanalyzer/RefreshSearchAnalyzerActionIT.kt
@@ -5,6 +5,7 @@
 
 package org.opensearch.indexmanagement.refreshanalyzer
 
+import org.junit.After
 import org.junit.Assume
 import org.junit.Before
 import org.opensearch.client.Request
@@ -19,6 +20,11 @@ import java.nio.charset.StandardCharsets
 import java.nio.file.Files
 
 class RefreshSearchAnalyzerActionIT : IndexManagementRestTestCase() {
+
+    @After
+    fun clearIndicesAfterEachTest() {
+        wipeAllIndices()
+    }
 
     @Before
     fun checkIfLocalCluster() {
@@ -165,7 +171,6 @@ class RefreshSearchAnalyzerActionIT : IndexManagementRestTestCase() {
     }
 
     companion object {
-
         fun writeToFile(filePath: String, contents: String) {
             val path = org.opensearch.common.io.PathUtils.get(filePath)
             Files.newBufferedWriter(path, Charset.forName("UTF-8")).use { writer -> writer.write(contents) }

--- a/src/test/kotlin/org/opensearch/indexmanagement/refreshanalyzer/RestRefreshSearchAnalyzerActionIT.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/refreshanalyzer/RestRefreshSearchAnalyzerActionIT.kt
@@ -5,6 +5,7 @@
 
 package org.opensearch.indexmanagement.refreshanalyzer
 
+import org.junit.AfterClass
 import org.opensearch.client.ResponseException
 import org.opensearch.common.settings.Settings
 import org.opensearch.indexmanagement.IndexManagementRestTestCase
@@ -14,6 +15,13 @@ import org.opensearch.rest.RestRequest.Method.POST
 import org.opensearch.rest.RestStatus
 
 class RestRefreshSearchAnalyzerActionIT : IndexManagementRestTestCase() {
+
+    companion object {
+        @AfterClass
+        @JvmStatic fun clearIndicesAfterClass() {
+            wipeAllIndices()
+        }
+    }
 
     fun `test missing indices`() {
         try {

--- a/src/test/kotlin/org/opensearch/indexmanagement/rollup/RollupRestTestCase.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/rollup/RollupRestTestCase.kt
@@ -11,6 +11,7 @@ import org.apache.http.entity.ContentType.APPLICATION_JSON
 import org.apache.http.entity.StringEntity
 import org.apache.http.message.BasicHeader
 import org.junit.AfterClass
+import org.junit.Before
 import org.opensearch.client.Response
 import org.opensearch.client.ResponseException
 import org.opensearch.client.RestClient
@@ -43,12 +44,19 @@ import java.time.Instant
 abstract class RollupRestTestCase : IndexManagementRestTestCase() {
 
     companion object {
-        @AfterClass @JvmStatic fun clearIndicesAfterClassCompletion() {
+        @AfterClass
+        @JvmStatic fun clearIndicesAfterClass() {
             wipeAllIndices()
         }
     }
 
-    override fun preserveIndicesUponCompletion(): Boolean = true
+    @Before
+    fun setDebugLogLevel() {
+        client().makeRequest(
+            "PUT", "_cluster/settings",
+            StringEntity("""{"transient":{"logger.org.opensearch.indexmanagement.rollup":"DEBUG"}}""", APPLICATION_JSON)
+        )
+    }
 
     protected fun createRollup(
         rollup: Rollup,

--- a/src/test/kotlin/org/opensearch/indexmanagement/rollup/runner/RollupRunnerIT.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/rollup/runner/RollupRunnerIT.kt
@@ -867,6 +867,10 @@ class RollupRunnerIT : RollupRestTestCase() {
         var rollupMetadata = getRollupMetadata(rollupMetadataID)
         assertTrue("Did not process any doc during rollup", rollupMetadata.stats.documentsProcessed > 0)
 
+        // TODO Flaky: version conflict could happen here
+        //  From log diving, it seems to be a race condition coming from RollupRunner
+        //  (need more dive to understand rollup business logic)
+        //  There are indexRollup happened between get and enable
         // restart job
         client().makeRequest(
             "PUT",

--- a/src/test/kotlin/org/opensearch/indexmanagement/snapshotmanagement/SnapshotManagementRestTestCase.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/snapshotmanagement/SnapshotManagementRestTestCase.kt
@@ -10,6 +10,7 @@ import org.apache.http.HttpHeaders
 import org.apache.http.entity.ContentType.APPLICATION_JSON
 import org.apache.http.entity.StringEntity
 import org.apache.http.message.BasicHeader
+import org.junit.After
 import org.junit.Before
 import org.opensearch.client.Response
 import org.opensearch.client.ResponseException
@@ -35,6 +36,11 @@ import java.time.Instant
 import java.time.Instant.now
 
 abstract class SnapshotManagementRestTestCase : IndexManagementRestTestCase() {
+
+    @After
+    fun clearIndicesAfterEachTest() {
+        wipeAllIndices()
+    }
 
     var timeout: Instant = Instant.ofEpochSecond(20)
 

--- a/src/test/kotlin/org/opensearch/indexmanagement/transform/TransformRestTestCase.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/transform/TransformRestTestCase.kt
@@ -40,12 +40,11 @@ import java.time.Instant
 abstract class TransformRestTestCase : IndexManagementRestTestCase() {
 
     companion object {
-        @AfterClass @JvmStatic fun clearIndicesAfterClassCompletion() {
+        @AfterClass
+        @JvmStatic fun clearIndicesAfterClass() {
             wipeAllIndices()
         }
     }
-
-    override fun preserveIndicesUponCompletion(): Boolean = true
 
     protected fun createTransform(
         transform: Transform,


### PR DESCRIPTION
Signed-off-by: bowenlan-amzn <bowenlan23@gmail.com>

*Issue #, if available:*

*Description of changes:*
Unify the wipeAllIndices logic in this repo.

Dived deep into the multinode large scale test failures because of remaining tasks after tests. Confirmed it's not realistic to wait for all tasks to disappear in multinode test suite, some observations:
- the cluster manager and data node may not be in sync and task can remain on data node for long time
- shard reroute makes the write task running for long time

This PR includes the small fix for this issue #608 

*CheckList:*
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/index-management/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
