### PR TITLE
Enabled specifying the format once the transform date_histogram is us…

### DIFF
--- a/src/main/kotlin/org/opensearch/indexmanagement/common/model/dimension/DateHistogram.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/common/model/dimension/DateHistogram.kt
@@ -28,7 +28,8 @@ data class DateHistogram(
     override val targetField: String = sourceField,
     val fixedInterval: String? = null,
     val calendarInterval: String? = null,
-    val timezone: ZoneId = ZoneId.of(UTC)
+    val timezone: ZoneId = ZoneId.of(UTC),
+    val format: String? = null
 ) : Dimension(Type.DATE_HISTOGRAM, sourceField, targetField) {
 
     init {
@@ -54,6 +55,7 @@ data class DateHistogram(
         return builder.field(DIMENSION_SOURCE_FIELD_FIELD, sourceField)
             .field(DIMENSION_TARGET_FIELD_FIELD, targetField)
             .field(DATE_HISTOGRAM_TIMEZONE_FIELD, timezone.id)
+            .field(FORMAT, format)
             .endObject()
             .endObject()
     }
@@ -69,6 +71,7 @@ data class DateHistogram(
     override fun toSourceBuilder(appendType: Boolean): CompositeValuesSourceBuilder<*> {
         val calendarInterval = this.calendarInterval
         val fixedInterval = this.fixedInterval
+        val format = this.format
         val name = if (appendType) "${this.targetField}.${Type.DATE_HISTOGRAM.type}" else this.targetField
 
         return DateHistogramValuesSourceBuilder(name)
@@ -81,6 +84,9 @@ data class DateHistogram(
                 }
                 fixedInterval?.let {
                     this.fixedInterval(DateHistogramInterval(it))
+                }
+                format?.let {
+                    this.format(it)
                 }
             }
     }
@@ -128,6 +134,7 @@ data class DateHistogram(
         const val FIXED_INTERVAL_FIELD = "fixed_interval"
         const val CALENDAR_INTERVAL_FIELD = "calendar_interval"
         const val DATE_HISTOGRAM_TIMEZONE_FIELD = "timezone"
+        const val FORMAT = "format"
 
         @Suppress("ComplexMethod", "LongMethod")
         @JvmStatic
@@ -138,6 +145,7 @@ data class DateHistogram(
             var fixedInterval: String? = null
             var calendarInterval: String? = null
             var timezone = ZoneId.of(UTC)
+            var format: String? = null
 
             ensureExpectedToken(Token.START_OBJECT, xcp.currentToken(), xcp)
             while (xcp.nextToken() != Token.END_OBJECT) {
@@ -150,6 +158,7 @@ data class DateHistogram(
                     DATE_HISTOGRAM_TIMEZONE_FIELD -> timezone = ZoneId.of(xcp.text())
                     DIMENSION_SOURCE_FIELD_FIELD -> sourceField = xcp.text()
                     DIMENSION_TARGET_FIELD_FIELD -> targetField = xcp.text()
+                    FORMAT -> format = xcp.textOrNull()
                     else -> throw IllegalArgumentException("Invalid field [$fieldName] found in date histogram")
                 }
             }
@@ -159,7 +168,8 @@ data class DateHistogram(
                 targetField = requireNotNull(targetField) { "Target field must not be null" },
                 fixedInterval = fixedInterval,
                 calendarInterval = calendarInterval,
-                timezone = timezone
+                timezone = timezone,
+                format = format
             )
         }
 

--- a/src/main/resources/mappings/opendistro-ism-config.json
+++ b/src/main/resources/mappings/opendistro-ism-config.json
@@ -1,6 +1,6 @@
 {
   "_meta" : {
-    "schema_version": 17
+    "schema_version": 18
   },
   "dynamic": "strict",
   "properties": {
@@ -1196,6 +1196,9 @@
                   "type": "keyword"
                 },
                 "timezone": {
+                  "type": "keyword"
+                },
+                "format": {
                   "type": "keyword"
                 }
               }

--- a/src/test/kotlin/org/opensearch/indexmanagement/IndexManagementRestTestCase.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/IndexManagementRestTestCase.kt
@@ -38,7 +38,7 @@ import kotlin.collections.HashSet
 
 abstract class IndexManagementRestTestCase : ODFERestTestCase() {
 
-    val configSchemaVersion = 17
+    val configSchemaVersion = 18
     val historySchemaVersion = 5
 
     // Having issues with tests leaking into other tests and mappings being incorrect and they are not caught by any pending task wait check as

--- a/src/test/resources/mappings/cached-opendistro-ism-config.json
+++ b/src/test/resources/mappings/cached-opendistro-ism-config.json
@@ -1,6 +1,6 @@
 {
   "_meta" : {
-    "schema_version": 17
+    "schema_version": 18
   },
   "dynamic": "strict",
   "properties": {
@@ -1196,6 +1196,9 @@
                   "type": "keyword"
                 },
                 "timezone": {
+                  "type": "keyword"
+                },
+                "format": {
                   "type": "keyword"
                 }
               }


### PR DESCRIPTION
…ed for bucket grouping

Enabled returning value_as_string field in the case of different values
Enabled specifying the format in the case of date_histogram. 

Signed-off-by: Stevan Buzejic <buzejic.stevan@gmail.com>

*Issue #, if available:*
#202 

*Description of changes:*

*CheckList:*
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/index-management/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
