### PR TITLE
[Backport 2.4] Unify test clean logic (#609)

### DIFF
--- a/.github/workflows/bwc-test-workflow.yml
+++ b/.github/workflows/bwc-test-workflow.yml
@@ -1,0 +1,32 @@
+name: Backward compatibility test workflow
+on:
+  pull_request:
+    branches:
+      - "*"
+  push:
+    branches:
+      - "*"
+
+jobs:
+  test:
+    # This job runs on Linux
+    runs-on: ubuntu-latest
+    steps:
+      # This step uses the setup-java Github action: https://github.com/actions/setup-java
+      - name: Set Up JDK
+        uses: actions/setup-java@v1
+        with:
+          java-version: 17
+      # index-management
+      - name: Checkout Branch
+        uses: actions/checkout@v2
+      - name: Run IM Backwards Compatibility Tests
+        run: |
+          echo "Running backwards compatibility tests..."
+          ./gradlew bwcTestSuite
+      - name: Upload failed logs
+        uses: actions/upload-artifact@v2
+        if: failure()
+        with:
+          name: logs
+          path: build/testclusters/indexmanagementBwcCluster*/logs/*

--- a/.github/workflows/multi-node-test-workflow.yml
+++ b/.github/workflows/multi-node-test-workflow.yml
@@ -16,10 +16,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # This step uses the setup-java Github action: https://github.com/actions/setup-java
-      - name: Set Up JDK 11
+      - name: Set Up JDK
         uses: actions/setup-java@v1
         with:
-          java-version: 11
+          java-version: 17
       # index-management
       - name: Checkout Branch
         uses: actions/checkout@v2

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/ManagedIndexRunner.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/ManagedIndexRunner.kt
@@ -404,7 +404,13 @@ object ManagedIndexRunner :
         @Suppress("ComplexCondition", "MaxLineLength")
         if (updateResult.metadataSaved && state != null && action != null && step != null && currentActionMetaData != null) {
             if (validationServiceEnabled) {
-                val validationResult = actionValidation.validate(action.type, stepContext.metadata.index)
+                val validationResult = withClosableContext(
+                    IndexManagementSecurityContext(
+                        managedIndexConfig.id, settings, threadPool.threadContext, managedIndexConfig.policy.user
+                    )
+                ) {
+                    actionValidation.validate(action.type, stepContext.metadata.index)
+                }
                 if (validationResult.validationStatus == Validate.ValidationStatus.RE_VALIDATING) {
                     logger.warn("Validation Status is: RE_VALIDATING. The action is {}, state is {}, step is {}.\", action.type, state.name, step.name")
                     publishErrorNotification(policy, managedIndexMetaData)

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/transport/action/explain/TransportExplainAction.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/transport/action/explain/TransportExplainAction.kt
@@ -383,7 +383,7 @@ class TransportExplainAction @Inject constructor(
                         filteredIndices.add(indexNames[i])
                         filteredMetadata.add(indexMetadatas[i])
                         filteredPolicies.add(indexPolicyIDs[i])
-                        validationResults[i]?.let { filteredValidationResult.add(it) }
+                        validationResults[i].let { filteredValidationResult.add(it) }
                         enabledState[indexNames[i]]?.let { enabledStatus[indexNames[i]] = it }
                         appliedPolicies[indexNames[i]]?.let { filteredAppliedPolicies[indexNames[i]] = it }
                     } catch (e: OpenSearchSecurityException) {

--- a/src/main/kotlin/org/opensearch/indexmanagement/util/JobSchedulerUtils.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/util/JobSchedulerUtils.kt
@@ -13,7 +13,7 @@ import org.opensearch.jobscheduler.spi.JobExecutionContext
 import org.opensearch.jobscheduler.spi.LockModel
 import org.opensearch.jobscheduler.spi.ScheduledJobParameter
 
-private val logger = LogManager.getLogger("JobSchedulerUtils")
+private val logger = LogManager.getLogger("o.o.i.u.JobSchedulerUtils")
 
 /**
  * Util method to attempt to get the lock on the requested scheduled job using the backoff policy.

--- a/src/test/kotlin/org/opensearch/indexmanagement/IndexManagementIndicesIT.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/IndexManagementIndicesIT.kt
@@ -71,8 +71,7 @@ class IndexManagementIndicesIT : IndexStateManagementRestTestCase() {
     }
 
     fun `test update management index mapping with new schema version`() {
-        wipeAllODFEIndices()
-        waitForPendingTasks(adminClient())
+        wipeAllIndices()
         assertIndexDoesNotExist(INDEX_MANAGEMENT_INDEX)
 
         val mapping = indexManagementMappings.trim().trimStart('{').trimEnd('}')

--- a/src/test/kotlin/org/opensearch/indexmanagement/IndexManagementRestTestCase.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/IndexManagementRestTestCase.kt
@@ -10,20 +10,31 @@ import org.apache.http.entity.StringEntity
 import org.junit.AfterClass
 import org.junit.Before
 import org.junit.rules.DisableOnDebug
+import org.opensearch.action.admin.cluster.node.tasks.list.ListTasksAction
 import org.opensearch.client.Request
-import org.opensearch.client.RequestOptions
 import org.opensearch.client.Response
 import org.opensearch.client.RestClient
+import org.opensearch.client.RequestOptions
+import org.opensearch.client.WarningsHandler
+import org.opensearch.client.ResponseException
 import org.opensearch.common.Strings
+import org.opensearch.common.collect.Set
 import org.opensearch.common.io.PathUtils
 import org.opensearch.common.settings.Settings
+import org.opensearch.common.xcontent.DeprecationHandler
+import org.opensearch.common.xcontent.NamedXContentRegistry
+import org.opensearch.common.xcontent.XContentType
 import org.opensearch.indexmanagement.indexstatemanagement.util.INDEX_HIDDEN
 import org.opensearch.rest.RestStatus
+import java.io.IOException
 import java.nio.file.Files
+import java.util.*
 import javax.management.MBeanServerInvocationHandler
 import javax.management.ObjectName
 import javax.management.remote.JMXConnectorFactory
 import javax.management.remote.JMXServiceURL
+import kotlin.collections.ArrayList
+import kotlin.collections.HashSet
 
 abstract class IndexManagementRestTestCase : ODFERestTestCase() {
 
@@ -57,7 +68,6 @@ abstract class IndexManagementRestTestCase : ODFERestTestCase() {
 
     protected val isDebuggingTest = DisableOnDebug(null).isDebugging
     protected val isDebuggingRemoteCluster = System.getProperty("cluster.debug", "false")!!.toBoolean()
-    protected val isMultiNode = System.getProperty("cluster.number_of_nodes", "1").toInt() > 1
 
     protected val isLocalTest = clusterName() == "integTest"
     private fun clusterName(): String {
@@ -152,7 +162,115 @@ abstract class IndexManagementRestTestCase : ODFERestTestCase() {
         }
     }
 
+    override fun preserveIndicesUponCompletion(): Boolean = true
     companion object {
+        @JvmStatic
+        protected val isMultiNode = System.getProperty("cluster.number_of_nodes", "1").toInt() > 1
+        protected val defaultKeepIndexSet = setOf(".opendistro_security")
+        /**
+         * We override preserveIndicesUponCompletion to true and use this function to clean up indices
+         * Meant to be used in @After or @AfterClass of your feature test suite
+         */
+        fun wipeAllIndices(client: RestClient = adminClient(), keepIndex: kotlin.collections.Set<String> = defaultKeepIndexSet) {
+            try {
+                client.performRequest(Request("DELETE", "_data_stream/*"))
+            } catch (e: ResponseException) {
+                // We hit a version of ES that doesn't serialize DeleteDataStreamAction.Request#wildcardExpressionsOriginallySpecified field or
+                // that doesn't support data streams so it's safe to ignore
+                val statusCode = e.response.statusLine.statusCode
+                if (!Set.of(404, 405, 500).contains(statusCode)) {
+                    throw e
+                }
+            }
+
+            val response = client.performRequest(Request("GET", "/_cat/indices?format=json&expand_wildcards=all"))
+            val xContentType = XContentType.fromMediaType(response.entity.contentType.value)
+            xContentType.xContent().createParser(
+                NamedXContentRegistry.EMPTY, DeprecationHandler.THROW_UNSUPPORTED_OPERATION,
+                response.entity.content
+            ).use { parser ->
+                for (index in parser.list()) {
+                    val jsonObject: Map<*, *> = index as java.util.HashMap<*, *>
+                    val indexName: String = jsonObject["index"] as String
+                    // .opendistro_security isn't allowed to delete from cluster
+                    if (!keepIndex.contains(indexName)) {
+                        val request = Request("DELETE", "/$indexName")
+                        // TODO: remove PERMISSIVE option after moving system index access to REST API call
+                        val options = RequestOptions.DEFAULT.toBuilder()
+                        options.setWarningsHandler(WarningsHandler.PERMISSIVE)
+                        request.options = options.build()
+                        client.performRequest(request)
+                    }
+                }
+            }
+
+            waitFor {
+                if (!isMultiNode) {
+                    waitForRunningTasks(client)
+                    waitForPendingTasks(client)
+                    waitForThreadPools(client)
+                } else {
+                    // Multi node test is not suitable to waitFor
+                    // We have seen long-running write task that fails the waitFor
+                    //  probably because of cluster manager - data node task not in sync
+                    // So instead we just sleep 1s after wiping indices
+                    Thread.sleep(1_000)
+                }
+            }
+        }
+
+        @JvmStatic
+        @Throws(IOException::class)
+        protected fun waitForRunningTasks(client: RestClient) {
+            val runningTasks: MutableSet<String> = runningTasks(client.performRequest(Request("GET", "/_tasks?detailed")))
+            if (runningTasks.isEmpty()) {
+                return
+            }
+            val stillRunning = ArrayList<String>(runningTasks)
+            fail("${Date()}: There are still tasks running after this test that might break subsequent tests: \n${stillRunning.joinToString("\n")}.")
+        }
+
+        @Suppress("UNCHECKED_CAST")
+        @Throws(IOException::class)
+        private fun runningTasks(response: Response): MutableSet<String> {
+            val runningTasks: MutableSet<String> = HashSet()
+            val nodes = entityAsMap(response)["nodes"] as Map<String, Any>?
+            for ((_, value) in nodes!!) {
+                val nodeInfo = value as Map<String, Any>
+                val nodeTasks = nodeInfo["tasks"] as Map<String, Any>?
+                for ((_, value1) in nodeTasks!!) {
+                    val task = value1 as Map<String, Any>
+                    // Ignore the task list API - it doesn't count against us
+                    if (task["action"] == ListTasksAction.NAME || task["action"] == ListTasksAction.NAME + "[n]") continue
+                    // runningTasks.add(task["action"].toString() + " | " + task["description"].toString())
+                    runningTasks.add(task.toString())
+                }
+            }
+            return runningTasks
+        }
+
+        @JvmStatic
+        protected fun waitForThreadPools(client: RestClient) {
+            val response = client.performRequest(Request("GET", "/_cat/thread_pool?format=json"))
+
+            val xContentType = XContentType.fromMediaType(response.entity.contentType.value)
+            xContentType.xContent().createParser(
+                NamedXContentRegistry.EMPTY, DeprecationHandler.THROW_UNSUPPORTED_OPERATION,
+                response.entity.content
+            ).use { parser ->
+                for (index in parser.list()) {
+                    val jsonObject: Map<*, *> = index as java.util.HashMap<*, *>
+                    val active = (jsonObject["active"] as String).toInt()
+                    val queue = (jsonObject["queue"] as String).toInt()
+                    val name = jsonObject["name"]
+                    val trueActive = if (name == "management") active - 1 else active
+                    if (trueActive > 0 || queue > 0) {
+                        fail("Still active threadpools in cluster: $jsonObject")
+                    }
+                }
+            }
+        }
+
         internal interface IProxy {
             val version: String?
             var sessionId: String?

--- a/src/test/kotlin/org/opensearch/indexmanagement/IndexStateManagementSecurityBehaviorIT.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/IndexStateManagementSecurityBehaviorIT.kt
@@ -52,10 +52,6 @@ class IndexStateManagementSecurityBehaviorIT : SecurityRestTestCase() {
     private val testRole = "test_role"
     var testClient: RestClient? = null
 
-    override fun preserveIndicesUponCompletion(): Boolean {
-        return true
-    }
-
     @Before
     fun setupUsersAndRoles() {
         updateClusterSetting(ManagedIndexSettings.JITTER.key, "0.0", false)

--- a/src/test/kotlin/org/opensearch/indexmanagement/ODFERestTestCase.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/ODFERestTestCase.kt
@@ -6,18 +6,9 @@
 package org.opensearch.indexmanagement
 
 import org.apache.http.HttpHost
-import org.junit.After
-import org.opensearch.action.admin.cluster.node.tasks.list.ListTasksAction
-import org.opensearch.client.Request
-import org.opensearch.client.RequestOptions
-import org.opensearch.client.Response
 import org.opensearch.client.RestClient
-import org.opensearch.client.WarningsHandler
 import org.opensearch.common.io.PathUtils
 import org.opensearch.common.settings.Settings
-import org.opensearch.common.xcontent.DeprecationHandler
-import org.opensearch.common.xcontent.NamedXContentRegistry
-import org.opensearch.common.xcontent.XContentType
 import org.opensearch.commons.ConfigConstants.OPENSEARCH_SECURITY_SSL_HTTP_ENABLED
 import org.opensearch.commons.ConfigConstants.OPENSEARCH_SECURITY_SSL_HTTP_KEYSTORE_FILEPATH
 import org.opensearch.commons.ConfigConstants.OPENSEARCH_SECURITY_SSL_HTTP_KEYSTORE_KEYPASSWORD
@@ -35,99 +26,6 @@ abstract class ODFERestTestCase : OpenSearchRestTestCase() {
 
     override fun getProtocol(): String = if (isHttps()) "https" else "http"
 
-    @Suppress("UNCHECKED_CAST")
-    @Throws(IOException::class)
-    private fun runningTasks(response: Response): MutableSet<String> {
-        val runningTasks: MutableSet<String> = HashSet()
-        val nodes = entityAsMap(response)["nodes"] as Map<String, Any>?
-        for ((_, value) in nodes!!) {
-            val nodeInfo = value as Map<String, Any>
-            val nodeTasks = nodeInfo["tasks"] as Map<String, Any>?
-            for ((_, value1) in nodeTasks!!) {
-                val task = value1 as Map<String, Any>
-                runningTasks.add(task["action"].toString())
-            }
-        }
-        return runningTasks
-    }
-
-    @After
-    fun waitForCleanup() {
-        waitFor {
-            waitForRunningTasks()
-            waitForThreadPools()
-            waitForPendingTasks(adminClient())
-        }
-    }
-
-    @Throws(IOException::class)
-    private fun waitForRunningTasks() {
-        val runningTasks: MutableSet<String> = runningTasks(adminClient().performRequest(Request("GET", "/_tasks")))
-        // Ignore the task list API - it doesn't count against us
-        runningTasks.remove(ListTasksAction.NAME)
-        runningTasks.remove(ListTasksAction.NAME + "[n]")
-        if (runningTasks.isEmpty()) {
-            return
-        }
-        val stillRunning = ArrayList<String>(runningTasks)
-        fail("There are still tasks running after this test that might break subsequent tests $stillRunning.")
-    }
-
-    private fun waitForThreadPools() {
-        waitFor {
-            val response = client().performRequest(Request("GET", "/_cat/thread_pool?format=json"))
-
-            val xContentType = XContentType.fromMediaType(response.entity.contentType.value)
-            xContentType.xContent().createParser(
-                NamedXContentRegistry.EMPTY, DeprecationHandler.THROW_UNSUPPORTED_OPERATION,
-                response.entity.content
-            ).use { parser ->
-                for (index in parser.list()) {
-                    val jsonObject: Map<*, *> = index as java.util.HashMap<*, *>
-                    val active = (jsonObject["active"] as String).toInt()
-                    val queue = (jsonObject["queue"] as String).toInt()
-                    val name = jsonObject["name"]
-                    val trueActive = if (name == "management") active - 1 else active
-                    if (trueActive > 0 || queue > 0) {
-                        fail("Still active threadpools in cluster: $jsonObject")
-                    }
-                }
-            }
-        }
-    }
-
-    open fun preserveODFEIndicesAfterTest(): Boolean = false
-
-    @Throws(IOException::class)
-    open fun wipeAllODFEIndices() {
-        if (preserveODFEIndicesAfterTest()) return
-
-        // Delete all data stream indices
-        client().performRequest(Request("DELETE", "/_data_stream/*"))
-
-        // Delete all indices
-        val response = client().performRequest(Request("GET", "/_cat/indices?format=json&expand_wildcards=all"))
-
-        val xContentType = XContentType.fromMediaType(response.entity.contentType.value)
-        xContentType.xContent().createParser(
-            NamedXContentRegistry.EMPTY, DeprecationHandler.THROW_UNSUPPORTED_OPERATION,
-            response.entity.content
-        ).use { parser ->
-            for (index in parser.list()) {
-                val jsonObject: Map<*, *> = index as java.util.HashMap<*, *>
-                val indexName: String = jsonObject["index"] as String
-                // .opendistro_security isn't allowed to delete from cluster
-                if (".opendistro_security" != indexName) {
-                    val request = Request("DELETE", "/$indexName")
-                    // TODO: remove PERMISSIVE option after moving system index access to REST API call
-                    val options = RequestOptions.DEFAULT.toBuilder()
-                    options.setWarningsHandler(WarningsHandler.PERMISSIVE)
-                    request.options = options.build()
-                    adminClient().performRequest(request)
-                }
-            }
-        }
-    }
     /**
      * Returns the REST client settings used for super-admin actions like cleaning up after the test has completed.
      */
@@ -152,13 +50,13 @@ abstract class ODFERestTestCase : OpenSearchRestTestCase() {
                     // create adminDN (super-admin) client
                     val uri = javaClass.classLoader.getResource("security/sample.pem").toURI()
                     val configPath = PathUtils.get(uri).parent.toAbsolutePath()
-                    SecureRestClientBuilder(settings, configPath).setSocketTimeout(60000).build()
+                    SecureRestClientBuilder(settings, configPath).setSocketTimeout(5000).build()
                 }
                 false -> {
                     // create client with passed user
                     val userName = System.getProperty("user")
                     val password = System.getProperty("password")
-                    SecureRestClientBuilder(hosts, isHttps(), userName, password).setSocketTimeout(60000).build()
+                    SecureRestClientBuilder(hosts, isHttps(), userName, password).setSocketTimeout(5000).build()
                 }
             }
         } else {

--- a/src/test/kotlin/org/opensearch/indexmanagement/RollupSecurityBehaviorIT.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/RollupSecurityBehaviorIT.kt
@@ -43,10 +43,6 @@ class RollupSecurityBehaviorIT : SecurityRestTestCase() {
     private val testRole = "test_role"
     var testUserClient: RestClient? = null
 
-    override fun preserveIndicesUponCompletion(): Boolean {
-        return true
-    }
-
     @Before
     fun setupUsersAndRoles() {
         updateClusterSetting(ManagedIndexSettings.JITTER.key, "0.0", false)

--- a/src/test/kotlin/org/opensearch/indexmanagement/SecurityBehaviorIT.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/SecurityBehaviorIT.kt
@@ -26,10 +26,6 @@ class SecurityBehaviorIT : SecurityRestTestCase() {
     private val john = "john"
     private var johnClient: RestClient? = null
 
-    override fun preserveIndicesUponCompletion(): Boolean {
-        return true
-    }
-
     @Before
     fun setupUsersAndRoles() {
         updateClusterSetting(ManagedIndexSettings.JITTER.key, "0.0", false)

--- a/src/test/kotlin/org/opensearch/indexmanagement/TransformSecurityBehaviorIT.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/TransformSecurityBehaviorIT.kt
@@ -37,10 +37,6 @@ class TransformSecurityBehaviorIT : SecurityRestTestCase() {
     private val testRole = "test_role"
     var testUserClient: RestClient? = null
 
-    override fun preserveIndicesUponCompletion(): Boolean {
-        return true
-    }
-
     @Before
     fun setupUsersAndRoles() {
         updateClusterSetting(ManagedIndexSettings.JITTER.key, "0.0", false)

--- a/src/test/kotlin/org/opensearch/indexmanagement/bwc/IndexManagementBackwardsCompatibilityIT.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/bwc/IndexManagementBackwardsCompatibilityIT.kt
@@ -36,8 +36,6 @@ class IndexManagementBackwardsCompatibilityIT : IndexManagementRestTestCase() {
 
     override fun preserveTemplatesUponCompletion(): Boolean = true
 
-    override fun preserveODFEIndicesAfterTest(): Boolean = true
-
     override fun restClientSettings(): Settings {
         return Settings.builder()
             .put(super.restClientSettings())

--- a/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/IndexStateManagementIntegTestCase.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/IndexStateManagementIntegTestCase.kt
@@ -7,6 +7,7 @@ package org.opensearch.indexmanagement.indexstatemanagement
 
 import org.apache.http.entity.ContentType
 import org.apache.http.entity.StringEntity
+import org.junit.After
 import org.junit.Before
 import org.opensearch.OpenSearchParseException
 import org.opensearch.action.ActionRequest
@@ -28,6 +29,7 @@ import org.opensearch.common.xcontent.XContentParserUtils
 import org.opensearch.common.xcontent.XContentType
 import org.opensearch.common.xcontent.json.JsonXContent
 import org.opensearch.indexmanagement.IndexManagementPlugin
+import org.opensearch.indexmanagement.IndexManagementRestTestCase.Companion.wipeAllIndices
 import org.opensearch.indexmanagement.indexstatemanagement.model.ManagedIndexConfig
 import org.opensearch.indexmanagement.indexstatemanagement.model.Policy
 import org.opensearch.indexmanagement.indexstatemanagement.resthandler.RestExplainAction
@@ -55,6 +57,12 @@ import java.time.Duration
 import java.time.Instant
 
 abstract class IndexStateManagementIntegTestCase : OpenSearchIntegTestCase() {
+
+    @After
+    fun clearIndicesAfterEachTest() {
+        wipeAllIndices(getRestClient())
+    }
+
     @Before
     fun disableIndexStateManagementJitter() {
         // jitter would add a test-breaking delay to the integration tests

--- a/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/IndexStateManagementRestTestCase.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/IndexStateManagementRestTestCase.kt
@@ -10,6 +10,7 @@ import org.apache.http.HttpHeaders
 import org.apache.http.entity.ContentType.APPLICATION_JSON
 import org.apache.http.entity.StringEntity
 import org.apache.http.message.BasicHeader
+import org.junit.After
 import org.junit.Before
 import org.opensearch.OpenSearchParseException
 import org.opensearch.action.get.GetResponse
@@ -73,6 +74,11 @@ import java.time.Instant
 import java.util.Locale
 
 abstract class IndexStateManagementRestTestCase : IndexManagementRestTestCase() {
+
+    @After
+    fun clearIndicesAfterEachTest() {
+        wipeAllIndices()
+    }
 
     val explainResponseOpendistroPolicyIdSetting = "index.opendistro.index_state_management.policy_id"
     val explainResponseOpenSearchPolicyIdSetting = "index.plugins.index_state_management.policy_id"

--- a/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/action/ActionTimeoutIT.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/action/ActionTimeoutIT.kt
@@ -72,8 +72,8 @@ class ActionTimeoutIT : IndexStateManagementRestTestCase() {
 
     // https://github.com/opendistro-for-elasticsearch/index-management/issues/130
     fun `test action timeout doesn't bleed over into next action`() {
-        val indexName = "${testIndexName}_index_1"
-        val policyID = "${testIndexName}_testPolicyName_1"
+        val indexName = "${testIndexName}_index_2"
+        val policyID = "${testIndexName}_testPolicyName_2"
         val testPolicy = """
         {"policy":{"description":"Default policy","default_state":"rolloverstate","states":[
         {"name":"rolloverstate","actions":[{"timeout": "5s","open":{}},{"timeout":"1s","rollover":{"min_doc_count":100}}],

--- a/src/test/kotlin/org/opensearch/indexmanagement/refreshanalyzer/RefreshSearchAnalyzerActionIT.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/refreshanalyzer/RefreshSearchAnalyzerActionIT.kt
@@ -5,6 +5,7 @@
 
 package org.opensearch.indexmanagement.refreshanalyzer
 
+import org.junit.After
 import org.junit.Assume
 import org.junit.Before
 import org.opensearch.client.Request
@@ -19,6 +20,11 @@ import java.nio.charset.StandardCharsets
 import java.nio.file.Files
 
 class RefreshSearchAnalyzerActionIT : IndexManagementRestTestCase() {
+
+    @After
+    fun clearIndicesAfterEachTest() {
+        wipeAllIndices()
+    }
 
     @Before
     fun checkIfLocalCluster() {
@@ -165,7 +171,6 @@ class RefreshSearchAnalyzerActionIT : IndexManagementRestTestCase() {
     }
 
     companion object {
-
         fun writeToFile(filePath: String, contents: String) {
             val path = org.opensearch.common.io.PathUtils.get(filePath)
             Files.newBufferedWriter(path, Charset.forName("UTF-8")).use { writer -> writer.write(contents) }

--- a/src/test/kotlin/org/opensearch/indexmanagement/refreshanalyzer/RestRefreshSearchAnalyzerActionIT.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/refreshanalyzer/RestRefreshSearchAnalyzerActionIT.kt
@@ -5,6 +5,7 @@
 
 package org.opensearch.indexmanagement.refreshanalyzer
 
+import org.junit.AfterClass
 import org.opensearch.client.ResponseException
 import org.opensearch.common.settings.Settings
 import org.opensearch.indexmanagement.IndexManagementRestTestCase
@@ -14,6 +15,13 @@ import org.opensearch.rest.RestRequest.Method.POST
 import org.opensearch.rest.RestStatus
 
 class RestRefreshSearchAnalyzerActionIT : IndexManagementRestTestCase() {
+
+    companion object {
+        @AfterClass
+        @JvmStatic fun clearIndicesAfterClass() {
+            wipeAllIndices()
+        }
+    }
 
     fun `test missing indices`() {
         try {

--- a/src/test/kotlin/org/opensearch/indexmanagement/rollup/RollupRestTestCase.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/rollup/RollupRestTestCase.kt
@@ -11,6 +11,7 @@ import org.apache.http.entity.ContentType.APPLICATION_JSON
 import org.apache.http.entity.StringEntity
 import org.apache.http.message.BasicHeader
 import org.junit.AfterClass
+import org.junit.Before
 import org.opensearch.client.Response
 import org.opensearch.client.ResponseException
 import org.opensearch.client.RestClient
@@ -43,12 +44,19 @@ import java.time.Instant
 abstract class RollupRestTestCase : IndexManagementRestTestCase() {
 
     companion object {
-        @AfterClass @JvmStatic fun clearIndicesAfterClassCompletion() {
+        @AfterClass
+        @JvmStatic fun clearIndicesAfterClass() {
             wipeAllIndices()
         }
     }
 
-    override fun preserveIndicesUponCompletion(): Boolean = true
+    @Before
+    fun setDebugLogLevel() {
+        client().makeRequest(
+            "PUT", "_cluster/settings",
+            StringEntity("""{"transient":{"logger.org.opensearch.indexmanagement.rollup":"DEBUG"}}""", APPLICATION_JSON)
+        )
+    }
 
     protected fun createRollup(
         rollup: Rollup,

--- a/src/test/kotlin/org/opensearch/indexmanagement/rollup/runner/RollupRunnerIT.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/rollup/runner/RollupRunnerIT.kt
@@ -865,6 +865,10 @@ class RollupRunnerIT : RollupRestTestCase() {
         var rollupMetadata = getRollupMetadata(rollupMetadataID)
         assertTrue("Did not process any doc during rollup", rollupMetadata.stats.documentsProcessed > 0)
 
+        // TODO Flaky: version conflict could happen here
+        //  From log diving, it seems to be a race condition coming from RollupRunner
+        //  (need more dive to understand rollup business logic)
+        //  There are indexRollup happened between get and enable
         // restart job
         client().makeRequest(
             "PUT",

--- a/src/test/kotlin/org/opensearch/indexmanagement/snapshotmanagement/SnapshotManagementRestTestCase.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/snapshotmanagement/SnapshotManagementRestTestCase.kt
@@ -10,6 +10,7 @@ import org.apache.http.HttpHeaders
 import org.apache.http.entity.ContentType.APPLICATION_JSON
 import org.apache.http.entity.StringEntity
 import org.apache.http.message.BasicHeader
+import org.junit.After
 import org.junit.Before
 import org.opensearch.client.Response
 import org.opensearch.client.ResponseException
@@ -35,6 +36,11 @@ import java.time.Instant
 import java.time.Instant.now
 
 abstract class SnapshotManagementRestTestCase : IndexManagementRestTestCase() {
+
+    @After
+    fun clearIndicesAfterEachTest() {
+        wipeAllIndices()
+    }
 
     var timeout: Instant = Instant.ofEpochSecond(20)
 

--- a/src/test/kotlin/org/opensearch/indexmanagement/transform/TransformRestTestCase.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/transform/TransformRestTestCase.kt
@@ -40,12 +40,11 @@ import java.time.Instant
 abstract class TransformRestTestCase : IndexManagementRestTestCase() {
 
     companion object {
-        @AfterClass @JvmStatic fun clearIndicesAfterClassCompletion() {
+        @AfterClass
+        @JvmStatic fun clearIndicesAfterClass() {
             wipeAllIndices()
         }
     }
-
-    override fun preserveIndicesUponCompletion(): Boolean = true
 
     protected fun createTransform(
         transform: Transform,


### PR DESCRIPTION
* Unify wipe indices logic after tests

Signed-off-by: bowenlan-amzn <bowenlan23@gmail.com>

* Enhance wipeAllIndices function

Signed-off-by: bowenlan-amzn <bowenlan23@gmail.com>

* Customize cleanup for multi node test

Signed-off-by: bowenlan-amzn <bowenlan23@gmail.com>

Signed-off-by: bowenlan-amzn <bowenlan23@gmail.com>
(cherry picked from commit d91df69c11d4411be6cb297772a006b310cd43f7)

*Issue #, if available:*

*Description of changes:*

*CheckList:*
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/index-management/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
