### PR TITLE
Bump 2.5.0

### DIFF
--- a/.github/workflows/docker-security-test-workflow.yml
+++ b/.github/workflows/docker-security-test-workflow.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Checkout Branch
         uses: actions/checkout@v2
       - name: Build Index Management
-        run: ./gradlew assemble -Dbuild.snapshot=false
+        run: ./gradlew assemble
       - name: Pull and Run Docker
         run: |
           plugin=`basename $(ls build/distributions/*.zip)`

--- a/.github/workflows/security-test-workflow.yml
+++ b/.github/workflows/security-test-workflow.yml
@@ -21,13 +21,9 @@ jobs:
       # index-management
       - name: Checkout Branch
         uses: actions/checkout@v2
-      - name: Start cluster with security plugin
-        run: |
-          ./gradlew run -Dsecurity=true &
-          sleep 120
       - name: Run integration tests
         run: | 
-          ./gradlew integTestRemote -Dsecurity=true -Dhttps=true -Dtests.rest.cluster="localhost:9200" -Dtests.cluster="localhost:9200" -Dtests.clustername="integTest" -Duser=admin -Dpassword=admin
+          ./gradlew integTest -Dsecurity=true -Dhttps=true
       - name: Upload failed logs
         uses: actions/upload-artifact@v2
         if: failure()

--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,7 @@ import java.util.concurrent.TimeUnit
 buildscript {
     ext {
         isSnapshot = "true" == System.getProperty("build.snapshot", "true")
-        opensearch_version = System.getProperty("opensearch.version", "2.4.0-SNAPSHOT")
+        opensearch_version = System.getProperty("opensearch.version", "2.5.0-SNAPSHOT")
         buildVersionQualifier = System.getProperty("build.version_qualifier", "")
         // 2.2.0-SNAPSHOT -> 2.2.0.0-SNAPSHOT
         version_tokens = opensearch_version.tokenize('-')
@@ -59,7 +59,7 @@ buildscript {
 
         kotlin_version = System.getProperty("kotlin.version", "1.6.10")
 
-        security_plugin_version = System.getProperty("security.version", security_no_snapshot)
+        security_plugin_version = System.getProperty("security.version", opensearch_build)
     }
 
     repositories {

--- a/src/test/kotlin/org/opensearch/indexmanagement/ODFERestTestCase.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/ODFERestTestCase.kt
@@ -50,9 +50,7 @@ abstract class ODFERestTestCase : OpenSearchRestTestCase() {
                     // create adminDN (super-admin) client
                     val uri = javaClass.classLoader.getResource("security/sample.pem")?.toURI()
                     val configPath = PathUtils.get(uri).parent.toAbsolutePath()
-                    // TODO once common utils is updated in maven, we can use this method to define hosts
-                    // SecureRestClientBuilder(settings, configPath, hosts).setSocketTimeout(5000).build()
-                    SecureRestClientBuilder(settings, configPath).setSocketTimeout(5000).build()
+                    SecureRestClientBuilder(settings, configPath, hosts).setSocketTimeout(5000).build()
                 }
                 false -> {
                     // create client with passed user


### PR DESCRIPTION
Signed-off-by: bowenlan-amzn <bowenlan23@gmail.com>

*Issue #, if available:*
#612 

*Description of changes:*

Bump version to 2.5.0, update the security workflow to run directly w/o starting a local cluster.

*CheckList:*
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/index-management/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
