### PR TITLE
Operational readiness changes for snapshot management

### DIFF
--- a/src/main/kotlin/org/opensearch/indexmanagement/IndexManagementPlugin.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/IndexManagementPlugin.kt
@@ -532,7 +532,10 @@ class IndexManagementPlugin : JobSchedulerExtension, NetworkPlugin, ActionPlugin
             LegacyOpenDistroRollupSettings.ROLLUP_ENABLED,
             LegacyOpenDistroRollupSettings.ROLLUP_SEARCH_ENABLED,
             LegacyOpenDistroRollupSettings.ROLLUP_DASHBOARDS,
-            SnapshotManagementSettings.FILTER_BY_BACKEND_ROLES
+            SnapshotManagementSettings.FILTER_BY_BACKEND_ROLES,
+            SnapshotManagementSettings.MAXIMUM_SNAPSHOTS_PER_POLICY,
+            SnapshotManagementSettings.MAXIMUM_POLICIES_PER_REPOSITORY,
+            SnapshotManagementSettings.REPOSITORY_DENY_LIST
         )
     }
 

--- a/src/main/kotlin/org/opensearch/indexmanagement/IndexManagementPlugin.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/IndexManagementPlugin.kt
@@ -440,7 +440,7 @@ class IndexManagementPlugin : JobSchedulerExtension, NetworkPlugin, ActionPlugin
             client, clusterService, threadPool, indexManagementIndices, metadataService, templateService, indexMetadataProvider
         )
 
-        val smRunner = SMRunner.init(client, threadPool, settings, indexManagementIndices, clusterService)
+        val smRunner = SMRunner.init(client, threadPool, settings, indexManagementIndices, clusterService, jvmService)
 
         val pluginVersionSweepCoordinator = PluginVersionSweepCoordinator(skipFlag, settings, threadPool, clusterService)
 
@@ -535,7 +535,8 @@ class IndexManagementPlugin : JobSchedulerExtension, NetworkPlugin, ActionPlugin
             SnapshotManagementSettings.FILTER_BY_BACKEND_ROLES,
             SnapshotManagementSettings.MAXIMUM_SNAPSHOTS_PER_POLICY,
             SnapshotManagementSettings.MAXIMUM_POLICIES_PER_REPOSITORY,
-            SnapshotManagementSettings.REPOSITORY_DENY_LIST
+            SnapshotManagementSettings.REPOSITORY_DENY_LIST,
+            SnapshotManagementSettings.CIRCUIT_BREAKER_JVM_THRESHOLD,
         )
     }
 

--- a/src/main/kotlin/org/opensearch/indexmanagement/snapshotmanagement/SMUtils.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/snapshotmanagement/SMUtils.kt
@@ -52,6 +52,7 @@ import java.time.format.DateTimeFormatter
 import java.time.temporal.ChronoUnit
 import java.util.Locale
 import org.opensearch.common.time.DateFormatters
+import org.opensearch.indexmanagement.snapshotmanagement.settings.SnapshotManagementSettings.Companion.REPOSITORY_DENY_LIST
 
 private val log = LogManager.getLogger("o.i.s.SnapshotManagementHelper")
 
@@ -361,4 +362,16 @@ fun getTimeLimitExceededMessage(timeLimit: TimeValue, workflow: WorkflowType): S
         }
     }
     return "Time limit $timeLimit exceeded during snapshot $workflowStr step"
+}
+
+fun checkRepositoryDenyList(denylist: List<String>, policyRepository: String) {
+    val match = denylist.stream().anyMatch { pattern: String ->
+        Regex("^$pattern.*").matches(policyRepository)
+    }
+    if (match) {
+        throw OpenSearchStatusException(
+            "Policy repository $policyRepository is blocked. Please ask admin to update cluster setting ${REPOSITORY_DENY_LIST.key}.",
+            RestStatus.BAD_REQUEST
+        )
+    }
 }

--- a/src/main/kotlin/org/opensearch/indexmanagement/snapshotmanagement/api/transport/index/TransportIndexSMPolicyAction.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/snapshotmanagement/api/transport/index/TransportIndexSMPolicyAction.kt
@@ -6,7 +6,10 @@
 package org.opensearch.indexmanagement.snapshotmanagement.api.transport.index
 
 import org.apache.logging.log4j.LogManager
+import org.opensearch.OpenSearchStatusException
 import org.opensearch.action.index.IndexResponse
+import org.opensearch.action.search.SearchRequest
+import org.opensearch.action.search.SearchResponse
 import org.opensearch.action.support.ActionFilters
 import org.opensearch.client.Client
 import org.opensearch.cluster.service.ClusterService
@@ -16,15 +19,27 @@ import org.opensearch.common.util.concurrent.ThreadContext
 import org.opensearch.common.xcontent.ToXContent
 import org.opensearch.common.xcontent.XContentFactory
 import org.opensearch.commons.authuser.User
+import org.opensearch.index.IndexNotFoundException
+import org.opensearch.index.query.QueryBuilders
 import org.opensearch.indexmanagement.IndexManagementIndices
 import org.opensearch.indexmanagement.IndexManagementPlugin.Companion.INDEX_MANAGEMENT_INDEX
+import org.opensearch.indexmanagement.opensearchapi.contentParser
+import org.opensearch.indexmanagement.opensearchapi.parseWithType
 import org.opensearch.indexmanagement.opensearchapi.suspendUntil
 import org.opensearch.indexmanagement.snapshotmanagement.api.transport.BaseTransportAction
 import org.opensearch.indexmanagement.snapshotmanagement.api.transport.SMActions.INDEX_SM_POLICY_ACTION_NAME
+import org.opensearch.indexmanagement.snapshotmanagement.model.SMPolicy
 import org.opensearch.indexmanagement.snapshotmanagement.settings.SnapshotManagementSettings.Companion.FILTER_BY_BACKEND_ROLES
+import org.opensearch.indexmanagement.snapshotmanagement.settings.SnapshotManagementSettings.Companion.MAXIMUM_POLICIES_PER_REPOSITORY
+import org.opensearch.indexmanagement.snapshotmanagement.settings.SnapshotManagementSettings.Companion.MAXIMUM_SNAPSHOTS_PER_POLICY
+import org.opensearch.indexmanagement.snapshotmanagement.settings.SnapshotManagementSettings.Companion.REPOSITORY_DENY_LIST
 import org.opensearch.indexmanagement.util.IndexUtils
 import org.opensearch.indexmanagement.util.SecurityUtils
+import org.opensearch.rest.RestStatus
+import org.opensearch.search.builder.SearchSourceBuilder
 import org.opensearch.transport.TransportService
+import org.opensearch.indexmanagement.snapshotmanagement.checkRepositoryDenyList
+import org.opensearch.indexmanagement.snapshotmanagement.util.SEARCH_MAX_HITS
 
 class TransportIndexSMPolicyAction @Inject constructor(
     client: Client,
@@ -40,10 +55,22 @@ class TransportIndexSMPolicyAction @Inject constructor(
     private val log = LogManager.getLogger(javaClass)
 
     @Volatile private var filterByEnabled = FILTER_BY_BACKEND_ROLES.get(settings)
+    @Volatile private var maxPoliciesPerRepo = MAXIMUM_POLICIES_PER_REPOSITORY.get(settings)
+    @Volatile private var maxSnapshotsPerPolicy = MAXIMUM_SNAPSHOTS_PER_POLICY.get(settings)
+    @Volatile private var repositoryDenyList = REPOSITORY_DENY_LIST.get(settings)
 
     init {
         clusterService.clusterSettings.addSettingsUpdateConsumer(FILTER_BY_BACKEND_ROLES) {
             filterByEnabled = it
+        }
+        clusterService.clusterSettings.addSettingsUpdateConsumer(MAXIMUM_POLICIES_PER_REPOSITORY) {
+            maxPoliciesPerRepo = it
+        }
+        clusterService.clusterSettings.addSettingsUpdateConsumer(MAXIMUM_SNAPSHOTS_PER_POLICY) {
+            maxSnapshotsPerPolicy = it
+        }
+        clusterService.clusterSettings.addSettingsUpdateConsumer(REPOSITORY_DENY_LIST) {
+            repositoryDenyList = it
         }
     }
 
@@ -62,7 +89,14 @@ class TransportIndexSMPolicyAction @Inject constructor(
     }
 
     private suspend fun indexSMPolicy(request: IndexSMPolicyRequest, user: User?): IndexSMPolicyResponse {
-        val policy = request.policy.copy(schemaVersion = IndexUtils.indexManagementConfigSchemaVersion, user = user)
+
+        var policy = request.policy.copy(schemaVersion = IndexUtils.indexManagementConfigSchemaVersion, user = user)
+        val policyRepository = policy.snapshotConfig["repository"] as String
+
+        checkRepositoryDenyList(repositoryDenyList, policyRepository)
+        policy = checkMaxCount(policy)
+        checkMaxPoliciesPerRepository(policy, policyRepository)
+
         val indexReq = request.index(INDEX_MANAGEMENT_INDEX)
             .source(policy.toXContent(XContentFactory.jsonBuilder(), ToXContent.EMPTY_PARAMS))
             .id(policy.id)
@@ -70,5 +104,84 @@ class TransportIndexSMPolicyAction @Inject constructor(
         val indexRes: IndexResponse = client.suspendUntil { index(indexReq, it) }
 
         return IndexSMPolicyResponse(indexRes.id, indexRes.version, indexRes.seqNo, indexRes.primaryTerm, policy, indexRes.status())
+    }
+
+    private suspend fun checkMaxPoliciesPerRepository(policy: SMPolicy, policyRepository: String) {
+        val policies: List<SMPolicy> = try {
+            val searchRequest = SearchRequest()
+                .source(
+                    SearchSourceBuilder().query(
+                        QueryBuilders.existsQuery(SMPolicy.SM_TYPE)
+                    ).size(SEARCH_MAX_HITS)
+                )
+                .indices(INDEX_MANAGEMENT_INDEX)
+            val response: SearchResponse = client.suspendUntil { search(searchRequest, it) }
+            response.hits.hits.map {
+                contentParser(it.sourceRef).parseWithType(it.id, it.seqNo, it.primaryTerm, SMPolicy.Companion::parse)
+            }
+        } catch (e: IndexNotFoundException) {
+            emptyList()
+        } catch (e: Exception) {
+            throw OpenSearchStatusException(
+                "Failed to retrieve policies before create/update policy because $e",
+                RestStatus.INTERNAL_SERVER_ERROR
+            )
+        }
+        policies.map {
+            val policiesWithSameRepo = mutableSetOf(policy.policyName)
+            if (it.snapshotConfig["repository"] == policyRepository) {
+                policiesWithSameRepo.add(it.policyName)
+                if (policiesWithSameRepo.size > maxPoliciesPerRepo) {
+                    throw OpenSearchStatusException(
+                        "Only $maxPoliciesPerRepo policies are allowed for repository $policyRepository. " +
+                            "Please ask admin to update cluster setting ${MAXIMUM_POLICIES_PER_REPOSITORY.key}.",
+                        RestStatus.BAD_REQUEST
+                    )
+                }
+            }
+        }
+    }
+
+    private fun checkMaxCount(policy: SMPolicy): SMPolicy {
+        var updatedPolicy = policy
+        //  if deletion condition is not null and deletion.maxCount is null or larger than maxSnapshotsPerPolicy, update it
+        //  if policy deletion is null and maxSnapshotsPerPolicy is not -1, add policy deletion w/ maximum snapshot condition
+        val policyDeletionCondition = policy.deletion
+        val policyMaxRetentionCount = policy.deletion?.condition?.maxCount
+        if (maxSnapshotsPerPolicy != -1) {
+            if (policyDeletionCondition != null) {
+                if (policyMaxRetentionCount != null && policyMaxRetentionCount > maxSnapshotsPerPolicy ||
+                    policyMaxRetentionCount == null
+                ) {
+                    updatedPolicy = policy.copy(
+                        deletion = policyDeletionCondition.copy(
+                            condition = policyDeletionCondition.condition.copy(
+                                maxCount = maxSnapshotsPerPolicy
+                            )
+                        )
+                    )
+                    log.warn(
+                        "Update the deletion.condition.max_count of policy ${policy.policyName} to " +
+                            "the value of cluster setting ${MAXIMUM_SNAPSHOTS_PER_POLICY.key}."
+                    )
+                }
+            }
+            if (policyDeletionCondition == null) {
+                updatedPolicy = policy.copy(
+                    deletion = SMPolicy.Deletion(
+                        schedule = policy.creation.schedule,
+                        condition = SMPolicy.DeleteCondition(
+                            minCount = 1,
+                            maxCount = maxSnapshotsPerPolicy
+                        )
+                    )
+                )
+                log.warn(
+                    "Create deletion condition with max_count of cluster setting ${MAXIMUM_SNAPSHOTS_PER_POLICY.key}'s value " +
+                        "for policy ${policy.policyName}."
+                )
+            }
+        }
+        return updatedPolicy
     }
 }

--- a/src/main/kotlin/org/opensearch/indexmanagement/snapshotmanagement/settings/SnapshotManagementSettings.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/snapshotmanagement/settings/SnapshotManagementSettings.kt
@@ -5,14 +5,45 @@
 package org.opensearch.indexmanagement.snapshotmanagement.settings
 
 import org.opensearch.common.settings.Setting
+import java.util.function.Function
 
 @Suppress("UtilityClassWithPublicConstructor")
 class SnapshotManagementSettings {
 
     companion object {
+        private const val defaultMaxPoliciesPerRepo = 1
+        const val defaultMaxSnapshotsPerPolicy = 400
+        val defaultRepositoryDenyList = listOf("cs-", "_all", "\\*", "c\\*", "cs\\*")
+
         val FILTER_BY_BACKEND_ROLES: Setting<Boolean> = Setting.boolSetting(
             "plugins.snapshot_management.filter_by_backend_roles",
             false,
+            Setting.Property.NodeScope,
+            Setting.Property.Dynamic
+        )
+
+        val MAXIMUM_POLICIES_PER_REPOSITORY: Setting<Int> = Setting.intSetting(
+            "plugins.snapshot_management.maximum_policies_per_repository",
+            defaultMaxPoliciesPerRepo,
+            1,
+            Setting.Property.NodeScope,
+            Setting.Property.Dynamic
+        )
+
+        // -1 indicates this restriction is disabled
+        val MAXIMUM_SNAPSHOTS_PER_POLICY: Setting<Int> = Setting.intSetting(
+            "plugins.snapshot_management.maximum_snapshots_per_policy",
+            defaultMaxSnapshotsPerPolicy,
+            -1,
+            Setting.Property.NodeScope,
+            Setting.Property.Dynamic
+        )
+
+        // Any repository input starts with pattern in the denylist will be blocked
+        val REPOSITORY_DENY_LIST: Setting<List<String>> = Setting.listSetting(
+            "plugins.snapshot_management.repository_deny_list",
+            defaultRepositoryDenyList,
+            Function.identity(),
             Setting.Property.NodeScope,
             Setting.Property.Dynamic
         )

--- a/src/main/kotlin/org/opensearch/indexmanagement/snapshotmanagement/settings/SnapshotManagementSettings.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/snapshotmanagement/settings/SnapshotManagementSettings.kt
@@ -14,6 +14,7 @@ class SnapshotManagementSettings {
         private const val defaultMaxPoliciesPerRepo = 1
         const val defaultMaxSnapshotsPerPolicy = 400
         val defaultRepositoryDenyList = listOf("cs-", "_all", "\\*", "c\\*", "cs\\*")
+        const val minJvmThread = 0
 
         val FILTER_BY_BACKEND_ROLES: Setting<Boolean> = Setting.boolSetting(
             "plugins.snapshot_management.filter_by_backend_roles",
@@ -44,6 +45,15 @@ class SnapshotManagementSettings {
             "plugins.snapshot_management.repository_deny_list",
             defaultRepositoryDenyList,
             Function.identity(),
+            Setting.Property.NodeScope,
+            Setting.Property.Dynamic
+        )
+
+        val CIRCUIT_BREAKER_JVM_THRESHOLD: Setting<Int> = Setting.intSetting(
+            "plugins.snapshot_management.circuit_breaker.jvm.threshold",
+            85,
+            minJvmThread,
+            100,
             Setting.Property.NodeScope,
             Setting.Property.Dynamic
         )

--- a/src/main/kotlin/org/opensearch/indexmanagement/snapshotmanagement/util/RestHandlerUtils.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/snapshotmanagement/util/RestHandlerUtils.kt
@@ -13,6 +13,7 @@ import org.opensearch.rest.RestRequest
 
 const val SM_POLICY_NAME_KEYWORD = "$SM_TYPE.$NAME_FIELD"
 const val DEFAULT_SM_POLICY_SORT_FIELD = SM_POLICY_NAME_KEYWORD
+const val SEARCH_MAX_HITS = 10000
 
 fun RestRequest.getValidSMPolicyName(): String {
     val policyName = this.param("policyName", "")

--- a/src/test/kotlin/org/opensearch/indexmanagement/IndexManagementRestTestCase.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/IndexManagementRestTestCase.kt
@@ -6,6 +6,7 @@
 package org.opensearch.indexmanagement
 
 import org.apache.http.entity.ContentType
+import org.apache.http.entity.ContentType.APPLICATION_JSON
 import org.apache.http.entity.StringEntity
 import org.junit.AfterClass
 import org.junit.Before
@@ -161,6 +162,22 @@ abstract class IndexManagementRestTestCase : ODFERestTestCase() {
             }
             return result
         }
+    }
+
+    protected fun updateClusterSetting(key: String, value: String, escapeValue: Boolean = true) {
+        val formattedValue = if (escapeValue) "\"$value\"" else value
+        val request = """
+            {
+                "persistent": {
+                    "$key": $formattedValue
+                }
+            }
+        """.trimIndent()
+        val res = client().makeRequest(
+            "PUT", "_cluster/settings", emptyMap(),
+            StringEntity(request, APPLICATION_JSON)
+        )
+        assertEquals("Request failed", RestStatus.OK, res.restStatus())
     }
 
     override fun preserveIndicesUponCompletion(): Boolean = true

--- a/src/test/kotlin/org/opensearch/indexmanagement/SecurityRestTestCase.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/SecurityRestTestCase.kt
@@ -12,8 +12,6 @@
 package org.opensearch.indexmanagement
 
 import org.apache.http.HttpHeaders
-import org.apache.http.entity.ContentType
-import org.apache.http.entity.StringEntity
 import org.apache.http.message.BasicHeader
 import org.opensearch.client.Request
 import org.opensearch.client.Response
@@ -127,22 +125,6 @@ abstract class SecurityRestTestCase : IndexManagementRestTestCase() {
         ) = super.getTransform(transformId, header, userClient)
 
         fun getTransformMetadataExt(metadataId: String) = super.getTransformMetadata(metadataId)
-    }
-
-    protected fun updateClusterSetting(key: String, value: String, escapeValue: Boolean = true) {
-        val formattedValue = if (escapeValue) "\"$value\"" else value
-        val request = """
-            {
-                "persistent": {
-                    "$key": $formattedValue
-                }
-            }
-        """.trimIndent()
-        val res = client().makeRequest(
-            "PUT", "_cluster/settings", emptyMap(),
-            StringEntity(request, ContentType.APPLICATION_JSON)
-        )
-        assertEquals("Request failed", RestStatus.OK, res.restStatus())
     }
 
     protected fun createRollup(

--- a/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/IndexStateManagementRestTestCase.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/IndexStateManagementRestTestCase.kt
@@ -285,22 +285,6 @@ abstract class IndexStateManagementRestTestCase : IndexManagementRestTestCase() 
         return managedIndex?.policyID
     }
 
-    protected fun updateClusterSetting(key: String, value: String, escapeValue: Boolean = true) {
-        val formattedValue = if (escapeValue) "\"$value\"" else value
-        val request = """
-            {
-                "persistent": {
-                    "$key": $formattedValue
-                }
-            }
-        """.trimIndent()
-        val res = client().makeRequest(
-            "PUT", "_cluster/settings", emptyMap(),
-            StringEntity(request, APPLICATION_JSON)
-        )
-        assertEquals("Request failed", RestStatus.OK, res.restStatus())
-    }
-
     protected fun updateIndexStateManagementJitterSetting(value: Double) {
         updateClusterSetting(ManagedIndexSettings.JITTER.key, value.toString(), false)
     }

--- a/src/test/kotlin/org/opensearch/indexmanagement/snapshotmanagement/SMUtilsTests.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/snapshotmanagement/SMUtilsTests.kt
@@ -5,9 +5,11 @@
 
 package org.opensearch.indexmanagement.snapshotmanagement
 
+import org.opensearch.OpenSearchStatusException
 import org.opensearch.indexmanagement.opensearchapi.parseWithType
 import org.opensearch.indexmanagement.randomCronSchedule
 import org.opensearch.indexmanagement.snapshotmanagement.model.SMPolicy
+import org.opensearch.indexmanagement.snapshotmanagement.settings.SnapshotManagementSettings
 import org.opensearch.test.OpenSearchTestCase
 import java.time.Instant.now
 import kotlin.test.assertFailsWith
@@ -43,5 +45,14 @@ class SMUtilsTests : OpenSearchTestCase() {
         // val randomCronSchedule = CronSchedule("14 13 31 2 *", randomZone())
         val nextTime = randomCronSchedule.getNextExecutionTime(now())
         assertNotNull("next time should not be null", nextTime)
+    }
+
+    fun `test repository deny list check`() {
+        val repository = listOf("cs-repo", "_all", "*", "*any", "c*", "c*any", "cs*", "cs*any")
+        repository.map {
+            assertFailsWith<OpenSearchStatusException> {
+                checkRepositoryDenyList(SnapshotManagementSettings.defaultRepositoryDenyList, it)
+            }
+        }
     }
 }

--- a/src/test/kotlin/org/opensearch/indexmanagement/snapshotmanagement/TestUtils.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/snapshotmanagement/TestUtils.kt
@@ -105,19 +105,19 @@ fun randomSMPolicy(
     deletionMaxAge: TimeValue? = null,
     deletionMinCount: Int = randomIntBetween(1, 5),
     deletionNull: Boolean = false,
-    snapshotConfig: MutableMap<String, Any> = mutableMapOf(
-        "repository" to "repo",
-    ),
+    snapshotConfig: MutableMap<String, Any> = mutableMapOf(),
     dateFormat: String? = null,
     jobEnabledTime: Instant? = randomInstant(),
     jobSchedule: IntervalSchedule = IntervalSchedule(randomInstant(), 1, ChronoUnit.MINUTES),
     seqNo: Long = SequenceNumbers.UNASSIGNED_SEQ_NO,
     primaryTerm: Long = SequenceNumbers.UNASSIGNED_PRIMARY_TERM,
-    notificationConfig: NotificationConfig? = null
+    notificationConfig: NotificationConfig? = null,
+    repository: String = "repo",
 ): SMPolicy {
     if (dateFormat != null) {
         snapshotConfig["date_format"] = dateFormat
     }
+    snapshotConfig["repository"] = repository
     return SMPolicy(
         id = smPolicyNameToDocId(policyName),
         schemaVersion = schemaVersion,

--- a/src/test/kotlin/org/opensearch/indexmanagement/snapshotmanagement/resthandler/RestExplainSnapshotManagementIT.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/snapshotmanagement/resthandler/RestExplainSnapshotManagementIT.kt
@@ -5,6 +5,8 @@
 
 package org.opensearch.indexmanagement.snapshotmanagement.resthandler
 
+import org.junit.After
+import org.junit.Before
 import org.opensearch.client.ResponseException
 import org.opensearch.common.xcontent.XContentType
 import org.opensearch.indexmanagement.IndexManagementPlugin.Companion.INDEX_MANAGEMENT_INDEX
@@ -14,6 +16,7 @@ import org.opensearch.indexmanagement.snapshotmanagement.model.SMMetadata
 import org.opensearch.indexmanagement.snapshotmanagement.model.SMMetadata.WorkflowMetadata.Companion.TRIGGER_FIELD
 import org.opensearch.indexmanagement.snapshotmanagement.model.SMPolicy
 import org.opensearch.indexmanagement.snapshotmanagement.randomSMPolicy
+import org.opensearch.indexmanagement.snapshotmanagement.settings.SnapshotManagementSettings
 import org.opensearch.indexmanagement.waitFor
 import org.opensearch.jobscheduler.spi.schedule.IntervalSchedule
 import org.opensearch.rest.RestStatus
@@ -22,6 +25,16 @@ import java.time.temporal.ChronoUnit
 
 @Suppress("UNCHECKED_CAST")
 class RestExplainSnapshotManagementIT : SnapshotManagementRestTestCase() {
+
+    @Before
+    fun allowMultiplePolicies() {
+        updateClusterSetting(SnapshotManagementSettings.MAXIMUM_POLICIES_PER_REPOSITORY.key, "10")
+    }
+
+    @After
+    fun clearUp() {
+        updateClusterSetting(SnapshotManagementSettings.MAXIMUM_POLICIES_PER_REPOSITORY.key, "1")
+    }
 
     fun `test explaining a snapshot management policy`() {
         val smPolicy = createSMPolicy(

--- a/src/test/kotlin/org/opensearch/indexmanagement/snapshotmanagement/resthandler/RestGetSnapshotManagementIT.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/snapshotmanagement/resthandler/RestGetSnapshotManagementIT.kt
@@ -7,6 +7,8 @@ package org.opensearch.indexmanagement.snapshotmanagement.resthandler
 
 import org.apache.http.HttpHeaders
 import org.apache.http.message.BasicHeader
+import org.junit.After
+import org.junit.Before
 import org.opensearch.client.ResponseException
 import org.opensearch.indexmanagement.IndexManagementPlugin
 import org.opensearch.indexmanagement.makeRequest
@@ -16,9 +18,20 @@ import org.opensearch.indexmanagement.snapshotmanagement.model.SMPolicy
 import org.opensearch.indexmanagement.snapshotmanagement.model.SMPolicy.Companion.ENABLED_TIME_FIELD
 import org.opensearch.indexmanagement.snapshotmanagement.model.SMPolicy.Companion.SM_TYPE
 import org.opensearch.indexmanagement.snapshotmanagement.randomSMPolicy
+import org.opensearch.indexmanagement.snapshotmanagement.settings.SnapshotManagementSettings
 import org.opensearch.rest.RestStatus
 
 class RestGetSnapshotManagementIT : SnapshotManagementRestTestCase() {
+
+    @Before
+    fun allowMultiplePolicies() {
+        updateClusterSetting(SnapshotManagementSettings.MAXIMUM_POLICIES_PER_REPOSITORY.key, "10")
+    }
+
+    @After
+    fun clearUp() {
+        updateClusterSetting(SnapshotManagementSettings.MAXIMUM_POLICIES_PER_REPOSITORY.key, "1")
+    }
 
     fun `test getting a snapshot management policy`() {
         var smPolicy = createSMPolicy(randomSMPolicy().copy(jobEnabled = false, jobEnabledTime = null))


### PR DESCRIPTION
Signed-off-by: bowenlan-amzn <bowenlan23@gmail.com>

*Issue #, if available:*

*Description of changes:*

From operational perspective, added 4 guardrail dynamic settings

- maximum_policies_per_repository
- maximum_snapshots_per_policy: if the policy create more than this value, the oldest snapshot will be deleted
- repository_deny_list: any repository input start with pattern in this list will be blocked (`\\` is the escape character, java requires this)
- circuit_breaker.jvm.threshold: if current system jvm is higher than this value, job run is skipped

*CheckList:*
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/index-management/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
