### PR TITLE
Fixed usages of deprecated methods and constants from OSCore and common-util

### DIFF
--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/resthandler/RestAddPolicyAction.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/resthandler/RestAddPolicyAction.kt
@@ -7,6 +7,7 @@ package org.opensearch.indexmanagement.indexstatemanagement.resthandler
 
 import org.opensearch.client.node.NodeClient
 import org.opensearch.common.Strings
+import org.opensearch.common.xcontent.MediaType
 import org.opensearch.common.xcontent.XContentHelper
 import org.opensearch.indexmanagement.IndexManagementPlugin.Companion.ISM_BASE_URI
 import org.opensearch.indexmanagement.IndexManagementPlugin.Companion.LEGACY_ISM_BASE_URI
@@ -54,7 +55,7 @@ class RestAddPolicyAction : BaseRestHandler() {
         }
 
         val body = if (request.hasContent()) {
-            XContentHelper.convertToMap(request.requiredContent(), false, request.xContentType).v2()
+            XContentHelper.convertToMap(request.requiredContent(), false, request.xContentType as (MediaType)).v2()
         } else {
             mapOf()
         }

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/resthandler/RestRetryFailedManagedIndexAction.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/resthandler/RestRetryFailedManagedIndexAction.kt
@@ -8,6 +8,7 @@ package org.opensearch.indexmanagement.indexstatemanagement.resthandler
 import org.opensearch.client.node.NodeClient
 import org.opensearch.common.Strings
 import org.opensearch.common.logging.DeprecationLogger
+import org.opensearch.common.xcontent.MediaType
 import org.opensearch.common.xcontent.XContentHelper
 import org.opensearch.indexmanagement.IndexManagementPlugin.Companion.ISM_BASE_URI
 import org.opensearch.indexmanagement.IndexManagementPlugin.Companion.LEGACY_ISM_BASE_URI
@@ -54,7 +55,7 @@ class RestRetryFailedManagedIndexAction : BaseRestHandler() {
             throw IllegalArgumentException("Missing indices")
         }
         val body = if (request.hasContent()) {
-            XContentHelper.convertToMap(request.requiredContent(), false, request.xContentType).v2()
+            XContentHelper.convertToMap(request.requiredContent(), false, request.xContentType as (MediaType)).v2()
         } else {
             mapOf()
         }

--- a/src/main/kotlin/org/opensearch/indexmanagement/opensearchapi/OpenSearchExtensions.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/opensearchapi/OpenSearchExtensions.kt
@@ -76,7 +76,7 @@ fun contentParser(bytesReference: BytesReference): XContentParser {
 /** Convert an object to maps and lists representation */
 fun ToXContent.convertToMap(): Map<String, Any> {
     val bytesReference = XContentHelper.toXContent(this, XContentType.JSON, false)
-    return XContentHelper.convertToMap(bytesReference, false, XContentType.JSON as? (MediaType)).v2()
+    return XContentHelper.convertToMap(bytesReference, false, XContentType.JSON as (MediaType)).v2()
 }
 
 fun XContentParser.instant(): Instant? {
@@ -200,7 +200,7 @@ fun OpenSearchException.isRetryable(): Boolean {
  */
 fun XContentBuilder.string(): String = BytesReference.bytes(this).utf8ToString()
 
-fun XContentBuilder.toMap(): Map<String, Any> = XContentHelper.convertToMap(BytesReference.bytes(this), false, XContentType.JSON as? (MediaType)).v2()
+fun XContentBuilder.toMap(): Map<String, Any> = XContentHelper.convertToMap(BytesReference.bytes(this), false, XContentType.JSON as (MediaType)).v2()
 
 /**
  * Converts [OpenSearchClient] methods that take a callback into a kotlin suspending function.

--- a/src/main/kotlin/org/opensearch/indexmanagement/opensearchapi/OpenSearchExtensions.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/opensearchapi/OpenSearchExtensions.kt
@@ -30,6 +30,7 @@ import org.opensearch.common.settings.Settings
 import org.opensearch.common.unit.TimeValue
 import org.opensearch.common.util.concurrent.ThreadContext
 import org.opensearch.common.xcontent.LoggingDeprecationHandler
+import org.opensearch.common.xcontent.MediaType
 import org.opensearch.common.xcontent.NamedXContentRegistry
 import org.opensearch.common.xcontent.ToXContent
 import org.opensearch.common.xcontent.XContentBuilder
@@ -66,14 +67,16 @@ const val OPENDISTRO_SECURITY_PROTECTED_INDICES_CONF_REQUEST = "_opendistro_secu
 fun contentParser(bytesReference: BytesReference): XContentParser {
     return XContentHelper.createParser(
         NamedXContentRegistry.EMPTY,
-        LoggingDeprecationHandler.INSTANCE, bytesReference, XContentType.JSON
+        LoggingDeprecationHandler.INSTANCE,
+        bytesReference,
+        XContentType.JSON
     )
 }
 
 /** Convert an object to maps and lists representation */
 fun ToXContent.convertToMap(): Map<String, Any> {
     val bytesReference = XContentHelper.toXContent(this, XContentType.JSON, false)
-    return XContentHelper.convertToMap(bytesReference, false, XContentType.JSON).v2()
+    return XContentHelper.convertToMap(bytesReference, false, XContentType.JSON as? (MediaType)).v2()
 }
 
 fun XContentParser.instant(): Instant? {
@@ -197,7 +200,7 @@ fun OpenSearchException.isRetryable(): Boolean {
  */
 fun XContentBuilder.string(): String = BytesReference.bytes(this).utf8ToString()
 
-fun XContentBuilder.toMap(): Map<String, Any> = XContentHelper.convertToMap(BytesReference.bytes(this), false, XContentType.JSON).v2()
+fun XContentBuilder.toMap(): Map<String, Any> = XContentHelper.convertToMap(BytesReference.bytes(this), false, XContentType.JSON as? (MediaType)).v2()
 
 /**
  * Converts [OpenSearchClient] methods that take a callback into a kotlin suspending function.

--- a/src/main/kotlin/org/opensearch/indexmanagement/rollup/action/mapping/TransportUpdateRollupMappingAction.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/rollup/action/mapping/TransportUpdateRollupMappingAction.kt
@@ -21,6 +21,7 @@ import org.opensearch.common.bytes.BytesReference
 import org.opensearch.common.inject.Inject
 import org.opensearch.common.io.stream.StreamInput
 import org.opensearch.common.io.stream.Writeable
+import org.opensearch.common.xcontent.MediaType
 import org.opensearch.common.xcontent.XContentFactory
 import org.opensearch.common.xcontent.XContentHelper
 import org.opensearch.common.xcontent.XContentType
@@ -81,7 +82,7 @@ class TransportUpdateRollupMappingAction @Inject constructor(
         val rollup = XContentHelper.convertToMap(
             BytesReference.bytes(request.rollup.toXContent(XContentFactory.jsonBuilder(), XCONTENT_WITHOUT_TYPE)),
             false,
-            XContentType.JSON
+            XContentType.JSON as (MediaType)
         ).v2()
         val metaMappings = mutableMapOf<String, Any>()
         // TODO: Clean this up

--- a/src/test/kotlin/org/opensearch/indexmanagement/ODFERestTestCase.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/ODFERestTestCase.kt
@@ -8,11 +8,13 @@ package org.opensearch.indexmanagement
 import org.apache.hc.core5.http.HttpHost
 import org.opensearch.client.RestClient
 import org.opensearch.common.io.PathUtils
+import org.opensearch.common.settings.MockSecureSettings
+import org.opensearch.common.settings.SecureSettings
 import org.opensearch.common.settings.Settings
 import org.opensearch.commons.ConfigConstants.OPENSEARCH_SECURITY_SSL_HTTP_ENABLED
 import org.opensearch.commons.ConfigConstants.OPENSEARCH_SECURITY_SSL_HTTP_KEYSTORE_FILEPATH
-import org.opensearch.commons.ConfigConstants.OPENSEARCH_SECURITY_SSL_HTTP_KEYSTORE_KEYPASSWORD
-import org.opensearch.commons.ConfigConstants.OPENSEARCH_SECURITY_SSL_HTTP_KEYSTORE_PASSWORD
+import org.opensearch.commons.ConfigConstants.OPENSEARCH_SECURITY_SSL_HTTP_KEYSTORE_KEYPASSWORD_SETTING
+import org.opensearch.commons.ConfigConstants.OPENSEARCH_SECURITY_SSL_HTTP_KEYSTORE_PASSWORD_SETTING
 import org.opensearch.commons.ConfigConstants.OPENSEARCH_SECURITY_SSL_HTTP_PEMCERT_FILEPATH
 import org.opensearch.commons.rest.SecureRestClientBuilder
 import org.opensearch.test.rest.OpenSearchRestTestCase
@@ -29,6 +31,13 @@ abstract class ODFERestTestCase : OpenSearchRestTestCase() {
     /**
      * Returns the REST client settings used for super-admin actions like cleaning up after the test has completed.
      */
+    protected open fun createSecureSettings(): SecureSettings? {
+        val mockSecureSettings = MockSecureSettings()
+        mockSecureSettings.setString(OPENSEARCH_SECURITY_SSL_HTTP_KEYSTORE_PASSWORD_SETTING.key, "changeit")
+        mockSecureSettings.setString(OPENSEARCH_SECURITY_SSL_HTTP_KEYSTORE_KEYPASSWORD_SETTING.key, "changeit")
+        return mockSecureSettings
+    }
+
     override fun restAdminSettings(): Settings {
         return Settings
             .builder()
@@ -36,8 +45,7 @@ abstract class ODFERestTestCase : OpenSearchRestTestCase() {
             .put(OPENSEARCH_SECURITY_SSL_HTTP_ENABLED, isHttps())
             .put(OPENSEARCH_SECURITY_SSL_HTTP_PEMCERT_FILEPATH, "sample.pem")
             .put(OPENSEARCH_SECURITY_SSL_HTTP_KEYSTORE_FILEPATH, "test-kirk.jks")
-            .put(OPENSEARCH_SECURITY_SSL_HTTP_KEYSTORE_PASSWORD, "changeit")
-            .put(OPENSEARCH_SECURITY_SSL_HTTP_KEYSTORE_KEYPASSWORD, "changeit")
+            .setSecureSettings(createSecureSettings())
             .build()
     }
 

--- a/src/test/kotlin/org/opensearch/indexmanagement/rollup/resthandler/RestStopRollupActionIT.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/rollup/resthandler/RestStopRollupActionIT.kt
@@ -214,7 +214,7 @@ class RestStopRollupActionIT : RollupRestTestCase() {
             roles = emptyList(),
             pageSize = 10,
             delay = 0,
-            continuous = false,
+            continuous = true,
             dimensions = listOf(
                 DateHistogram(sourceField = "tpep_pickup_datetime", fixedInterval = "1h"),
                 Terms("RatecodeID", "RatecodeID"),


### PR DESCRIPTION
*Issue #, if available:*

- Build failure on main branch after 3.0.0 version bump

*Description of changes:*

- Fixed usages of deprecated methods and constants from OSCore and common-util
- Fixed flaky test: RestStopRollupActionIT: test stopping rollup with metadata

*CheckList:*
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/index-management/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
