### PR TITLE
Shrink action Fix

### DIFF
--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/action/ShrinkAction.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/action/ShrinkAction.kt
@@ -132,7 +132,7 @@ class ShrinkAction(
         const val TARGET_INDEX_TEMPLATE_FIELD = "target_index_name_template"
         const val ALIASES_FIELD = "aliases"
         const val FORCE_UNSAFE_FIELD = "force_unsafe"
-        const val LOCK_RESOURCE_TYPE = "shrink"
+        const val LOCK_RESOURCE_TYPE = ".opendistro-ism-config-shrink"
         const val LOCK_RESOURCE_NAME = "node_name"
         fun getSecurityFailureMessage(failure: String) = "Shrink action failed because of missing permissions: $failure"
     }

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/action/ShrinkAction.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/action/ShrinkAction.kt
@@ -132,8 +132,7 @@ class ShrinkAction(
         const val TARGET_INDEX_TEMPLATE_FIELD = "target_index_name_template"
         const val ALIASES_FIELD = "aliases"
         const val FORCE_UNSAFE_FIELD = "force_unsafe"
-        const val LOCK_RESOURCE_TYPE = ".opendistro-ism-config-shrink"
-        const val LOCK_RESOURCE_NAME = "node_name"
+        const val LOCK_SOURCE_JOB_ID = "shrink-node_name"
         fun getSecurityFailureMessage(failure: String) = "Shrink action failed because of missing permissions: $failure"
     }
 }

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/shrink/AttemptMoveShardsStep.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/shrink/AttemptMoveShardsStep.kt
@@ -278,17 +278,15 @@ class AttemptMoveShardsStep(private val action: ShrinkAction) : ShrinkStep(name,
         jobIntervalSeconds: Long?,
         indexName: String
     ): Pair<LockModel, String>? {
-        if (suitableNodes.isNotEmpty()) {
-            for (nodeName in suitableNodes) {
-                val lockID = getShrinkJobID(nodeName)
-                val lock: LockModel? = lockService.suspendUntil {
-                    acquireLockWithId(INDEX_MANAGEMENT_INDEX, getShrinkLockDuration(jobIntervalSeconds), lockID, it)
-                }
-                if (lock != null) {
-                    return lock to nodeName
-                } else {
-                    logger.info("Shrink action could not acquire lock of node [$nodeName] for [$indexName] .")
-                }
+        for (nodeName in suitableNodes) {
+            val lockID = getShrinkJobID(nodeName)
+            val lock: LockModel? = lockService.suspendUntil {
+                acquireLockWithId(INDEX_MANAGEMENT_INDEX, getShrinkLockDuration(jobIntervalSeconds), lockID, it)
+            }
+            if (lock != null) {
+                return lock to nodeName
+            } else {
+                logger.info("Shrink action could not acquire lock of node [$nodeName] for [$indexName] .")
             }
         }
         info = mapOf("message" to NO_UNLOCKED_NODES_MESSAGE)

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/shrink/AttemptMoveShardsStep.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/shrink/AttemptMoveShardsStep.kt
@@ -104,9 +104,9 @@ class AttemptMoveShardsStep(private val action: ShrinkAction) : ShrinkStep(name,
         val interval = getJobIntervalSeconds(context.metadata.indexUuid, client)
 
         // Get candidate nodes for shrink
-        val suitableNodes = findSuitableNodes(context, shardStats, indexSize) ?: return this
+        val suitableNodes = findSuitableNodes(context, shardStats, indexSize)
 
-        if (suitableNodes.size < 1) {
+        if (suitableNodes.isEmpty()) {
             info = mapOf("message" to NO_AVAILABLE_NODES_MESSAGE)
             stepStatus = StepStatus.CONDITION_NOT_MET
             return this

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/shrink/WaitForMoveShardsStep.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/shrink/WaitForMoveShardsStep.kt
@@ -87,7 +87,7 @@ class WaitForMoveShardsStep(private val action: ShrinkAction) : ShrinkStep(name,
         val response: IndicesStatsResponse = client.admin().indices().suspendUntil { stats(indexStatsRequests, it) }
         val shardStats = response.shards
         if (shardStats == null) {
-            setStepFailed(AttemptMoveShardsStep.FAILURE_MESSAGE, "Failed to move shards in shrink action as shard stats were null.")
+            cleanupAndFail(AttemptMoveShardsStep.FAILURE_MESSAGE, "Failed to move shards in shrink action as shard stats were null.")
             return null
         }
         return shardStats

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/util/StepUtils.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/util/StepUtils.kt
@@ -203,7 +203,10 @@ suspend fun resetReadOnlyAndRouting(index: String, client: Client, originalSetti
 }
 
 fun getShrinkLockID(nodeName: String): String {
-    return "$INDEX_MANAGEMENT_INDEX-$LOCK_SOURCE_JOB_ID-$nodeName"
+    return LockModel.generateLockId(
+        INDEX_MANAGEMENT_INDEX,
+        getShrinkJobID(nodeName)
+    )
 }
 
 fun getShrinkJobID(nodeName: String): String {

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/util/StepUtils.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/util/StepUtils.kt
@@ -52,9 +52,11 @@ suspend fun releaseShrinkLock(
 
 suspend fun deleteShrinkLock(
     shrinkActionProperties: ShrinkActionProperties,
-    lockService: LockService
+    lockService: LockService,
+    logger: Logger
 ): Boolean {
     val lockID = getShrinkLockID(shrinkActionProperties.nodeName)
+    logger.info("Deleting lock: $lockID")
     return lockService.suspendUntil { deleteLock(lockID, it) }
 }
 
@@ -163,7 +165,7 @@ fun getDiskSettings(clusterSettings: ClusterSettings): Settings {
  * Returns the amount of memory in the node which will be free below the high watermark level after adding 2*indexSizeInBytes, or -1
  * if adding 2*indexSizeInBytes goes over the high watermark threshold, or if nodeStats does not contain OsStats.
 */
-fun getNodeFreeMemoryAfterShrink(node: NodeStats, indexSizeInBytes: Long, clusterSettings: ClusterSettings): Long {
+fun getNodeFreeDiskSpaceAfterShrink(node: NodeStats, indexSizeInBytes: Long, clusterSettings: ClusterSettings): Long {
     val fsStats = node.fs
     if (fsStats != null) {
         val diskSpaceLeftInNode = fsStats.total.free.bytes

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/util/StepUtils.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/util/StepUtils.kt
@@ -25,8 +25,7 @@ import org.opensearch.common.settings.ClusterSettings
 import org.opensearch.common.settings.Settings
 import org.opensearch.common.unit.TimeValue
 import org.opensearch.indexmanagement.IndexManagementPlugin.Companion.INDEX_MANAGEMENT_INDEX
-import org.opensearch.indexmanagement.indexstatemanagement.action.ShrinkAction.Companion.LOCK_RESOURCE_NAME
-import org.opensearch.indexmanagement.indexstatemanagement.action.ShrinkAction.Companion.LOCK_RESOURCE_TYPE
+import org.opensearch.indexmanagement.indexstatemanagement.action.ShrinkAction.Companion.LOCK_SOURCE_JOB_ID
 import org.opensearch.indexmanagement.indexstatemanagement.step.shrink.AttemptMoveShardsStep
 import org.opensearch.indexmanagement.opensearchapi.suspendUntil
 import org.opensearch.indexmanagement.spi.indexstatemanagement.model.ManagedIndexMetaData
@@ -204,7 +203,11 @@ suspend fun resetReadOnlyAndRouting(index: String, client: Client, originalSetti
 }
 
 fun getShrinkLockID(nodeName: String): String {
-    return "$LOCK_RESOURCE_TYPE-$LOCK_RESOURCE_NAME-$nodeName"
+    return "$INDEX_MANAGEMENT_INDEX-$LOCK_SOURCE_JOB_ID-$nodeName"
+}
+
+fun getShrinkJobID(nodeName: String): String {
+    return "$LOCK_SOURCE_JOB_ID-$nodeName"
 }
 
 // Creates a map of shardIds to the set of node names which the shard copies reside on. For example, with 2 replicas

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/util/StepUtils.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/util/StepUtils.kt
@@ -95,11 +95,11 @@ fun getShrinkLockModel(
     lockSeqNo: Long,
     lockDurationSecond: Long
 ): LockModel {
-    val lockID = getShrinkLockID(nodeName)
+    val jobID = getShrinkJobID(nodeName)
     val lockCreationInstant: Instant = Instant.ofEpochSecond(lockEpochSecond)
     return LockModel(
         jobIndexName,
-        lockID,
+        jobID,
         lockCreationInstant,
         lockDurationSecond,
         false,

--- a/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/util/StepUtilsTests.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/util/StepUtilsTests.kt
@@ -37,7 +37,7 @@ class StepUtilsTests : OpenSearchTestCase() {
         )
         val lockModel = getShrinkLockModel(shrinkActionProperties)
         assertEquals("Incorrect lock model job index name", INDEX_MANAGEMENT_INDEX, lockModel.jobIndexName)
-        assertEquals("Incorrect lock model jobID", getShrinkLockID(shrinkActionProperties.nodeName), lockModel.jobId)
+        assertEquals("Incorrect lock model jobID", getShrinkJobID(shrinkActionProperties.nodeName), lockModel.jobId)
         assertEquals("Incorrect lock model duration", shrinkActionProperties.lockDurationSecond, lockModel.lockDurationSeconds)
         assertEquals("Incorrect lock model lockID", "${lockModel.jobIndexName}-${lockModel.jobId}", lockModel.lockId)
         assertEquals("Incorrect lock model sequence number", shrinkActionProperties.lockSeqNo, lockModel.seqNo)

--- a/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/util/StepUtilsTests.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/util/StepUtilsTests.kt
@@ -129,9 +129,9 @@ class StepUtilsTests : OpenSearchTestCase() {
         val clusterSettings = ClusterSettings(settings.build(), ClusterSettings.BUILT_IN_CLUSTER_SETTINGS)
         val remainingSpace = freeBytes - ((2 * indexSize) + threshold)
         if (remainingSpace > 0) {
-            assertEquals(remainingSpace, getNodeFreeMemoryAfterShrink(nodeStats, indexSize, clusterSettings))
+            assertEquals(remainingSpace, getNodeFreeDiskSpaceAfterShrink(nodeStats, indexSize, clusterSettings))
         } else {
-            assertEquals(-1L, getNodeFreeMemoryAfterShrink(nodeStats, indexSize, clusterSettings))
+            assertEquals(-1L, getNodeFreeDiskSpaceAfterShrink(nodeStats, indexSize, clusterSettings))
         }
     }
 }


### PR DESCRIPTION
*Issue #, if available:*

https://github.com/opensearch-project/index-management/issues/709

*Description of changes:*

1. If the index already has target number of shards, skip the shrink action. This guarantees indices not being shrunk unnecessarily. [CHANGE](https://github.com/opensearch-project/index-management/blob/0e7f320a55d34cd276d932ae08e10eb03df565cd/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/shrink/AttemptMoveShardsStep.kt#L94)
2. Use the correct id to release node lock. [CHANGE](https://github.com/opensearch-project/index-management/blob/0e7f320a55d34cd276d932ae08e10eb03df565cd/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/action/ShrinkAction.kt#L135)
3. Only exclude Decision.Type.NO during shard moving dry-run. [CHANGE](https://github.com/opensearch-project/index-management/blob/0e7f320a55d34cd276d932ae08e10eb03df565cd/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/shrink/AttemptMoveShardsStep.kt#L325)
4. Set index write block again before sending shrink request, in case of write block flipped by other processes in previous steps. [CHANGE](https://github.com/opensearch-project/index-management/blob/0e7f320a55d34cd276d932ae08e10eb03df565cd/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/shrink/AttemptShrinkStep.kt#L87)
5. Rename methods below to reflect logic clearly. 
*getNodeFreeMemoryAfterShrink -> getNodeFreeDiskSpaceAfterShrink
fail -> setStepFailed
updateAndGetShrinkActionProperties -> checkShrinkActionPropertiesAndRenewLock*
6. Update content of related loggers and comments. 


*CheckList:*
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/index-management/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
