### PR TITLE
Revert version to 2.6 for AutoSync

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,7 @@ import java.util.concurrent.TimeUnit
 buildscript {
     ext {
         isSnapshot = "true" == System.getProperty("build.snapshot", "true")
-        opensearch_version = System.getProperty("opensearch.version", "2.7.0-SNAPSHOT")
+        opensearch_version = System.getProperty("opensearch.version", "2.6.0-SNAPSHOT")
         buildVersionQualifier = System.getProperty("build.version_qualifier", "")
         // 2.2.0-SNAPSHOT -> 2.2.0.0-SNAPSHOT
         version_tokens = opensearch_version.tokenize('-')


### PR DESCRIPTION
*Description of changes:*

Change 2.x version back to 2.6 as AutoSync requested

*CheckList:*
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/index-management/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
