### PR TITLE
Date nanos rollup fix

### DIFF
--- a/build-tools/pkgbuild.gradle
+++ b/build-tools/pkgbuild.gradle
@@ -13,7 +13,7 @@ afterEvaluate {
         version = "${project.version}" - "-SNAPSHOT"
 
         into '/usr/share/opensearch/plugins'
-        from(zipTree(bundlePlugin.archiveFile)) {
+        from(zipTree(bundlePlugin.archivePath)) {
             into opensearchplugin.name
         }
 
@@ -41,11 +41,10 @@ afterEvaluate {
         arch = 'NOARCH'
         dependsOn 'assemble'
         finalizedBy 'renameRpm'
-        tasks.register("renameRpm", Copy) {
+        task renameRpm(type: Copy) {
             from("$buildDir/distributions")
             into("$buildDir/distributions")
-            include archiveFileName
-            rename archiveFileName, "${packageName}-${version}.rpm"
+            rename "$archiveFileName", "${packageName}-${archiveVersion}.rpm"
             doLast { delete file("$buildDir/distributions/$archiveFileName") }
         }
     }
@@ -53,11 +52,10 @@ afterEvaluate {
         arch = 'all'
         dependsOn 'assemble'
         finalizedBy 'renameDeb'
-        tasks.register("renameDeb", Copy) {
+        task renameDeb(type: Copy) {
             from("$buildDir/distributions")
             into("$buildDir/distributions")
-            include archiveFileName
-            rename archiveFileName, "${packageName}-${version}.deb"
+            rename "$archiveFileName", "${packageName}-${archiveVersion}.deb"
             doLast { delete file("$buildDir/distributions/$archiveFileName") }
         }
     }

--- a/build-tools/pkgbuild.gradle
+++ b/build-tools/pkgbuild.gradle
@@ -13,7 +13,7 @@ afterEvaluate {
         version = "${project.version}" - "-SNAPSHOT"
 
         into '/usr/share/opensearch/plugins'
-        from(zipTree(bundlePlugin.archivePath)) {
+        from(zipTree(bundlePlugin.archiveFile)) {
             into opensearchplugin.name
         }
 
@@ -41,9 +41,11 @@ afterEvaluate {
         arch = 'NOARCH'
         dependsOn 'assemble'
         finalizedBy 'renameRpm'
-        task renameRpm(type: Copy) {
+        tasks.register("renameRpm", Copy) {
             from("$buildDir/distributions")
-            rename "$archiveFileName", "${packageName}-${archiveVersion}.rpm"
+            into("$buildDir/distributions")
+            include archiveFileName
+            rename archiveFileName, "${packageName}-${version}.rpm"
             doLast { delete file("$buildDir/distributions/$archiveFileName") }
         }
     }
@@ -51,9 +53,11 @@ afterEvaluate {
         arch = 'all'
         dependsOn 'assemble'
         finalizedBy 'renameDeb'
-        task renameDeb(type: Copy) {
+        tasks.register("renameDeb", Copy) {
             from("$buildDir/distributions")
-            rename "$archiveFileName", "${packageName}-${archiveVersion}.deb"
+            into("$buildDir/distributions")
+            include archiveFileName
+            rename archiveFileName, "${packageName}-${version}.deb"
             doLast { delete file("$buildDir/distributions/$archiveFileName") }
         }
     }

--- a/build-tools/pkgbuild.gradle
+++ b/build-tools/pkgbuild.gradle
@@ -43,7 +43,6 @@ afterEvaluate {
         finalizedBy 'renameRpm'
         task renameRpm(type: Copy) {
             from("$buildDir/distributions")
-            into("$buildDir/distributions")
             rename "$archiveFileName", "${packageName}-${archiveVersion}.rpm"
             doLast { delete file("$buildDir/distributions/$archiveFileName") }
         }
@@ -54,7 +53,6 @@ afterEvaluate {
         finalizedBy 'renameDeb'
         task renameDeb(type: Copy) {
             from("$buildDir/distributions")
-            into("$buildDir/distributions")
             rename "$archiveFileName", "${packageName}-${archiveVersion}.deb"
             doLast { delete file("$buildDir/distributions/$archiveFileName") }
         }

--- a/src/main/kotlin/org/opensearch/indexmanagement/rollup/util/RollupUtils.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/rollup/util/RollupUtils.kt
@@ -12,11 +12,11 @@ import org.opensearch.action.search.SearchRequest
 import org.opensearch.cluster.ClusterState
 import org.opensearch.cluster.metadata.IndexMetadata
 import org.opensearch.common.xcontent.LoggingDeprecationHandler
-import org.opensearch.core.xcontent.NamedXContentRegistry
 import org.opensearch.common.xcontent.XContentHelper
-import org.opensearch.core.xcontent.XContentParser.Token
 import org.opensearch.common.xcontent.XContentParserUtils.ensureExpectedToken
 import org.opensearch.common.xcontent.XContentType
+import org.opensearch.core.xcontent.NamedXContentRegistry
+import org.opensearch.core.xcontent.XContentParser.Token
 import org.opensearch.index.query.BoolQueryBuilder
 import org.opensearch.index.query.BoostingQueryBuilder
 import org.opensearch.index.query.ConstantScoreQueryBuilder
@@ -63,6 +63,7 @@ import org.opensearch.search.aggregations.metrics.SumAggregationBuilder
 import org.opensearch.search.aggregations.metrics.ValueCountAggregationBuilder
 import org.opensearch.search.builder.SearchSourceBuilder
 
+const val DATE_FIELD_STRICT_DATE_OPTIONAL_TIME_FORMAT = "strict_date_optional_time"
 const val DATE_FIELD_EPOCH_MILLIS_FORMAT = "epoch_millis"
 
 @Suppress("ReturnCount")

--- a/src/test/kotlin/org/opensearch/indexmanagement/rollup/RollupMetadataServiceTests.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/rollup/RollupMetadataServiceTests.kt
@@ -735,7 +735,7 @@ class RollupMetadataServiceTests : OpenSearchTestCase() {
 
         // TODO: Mockito 2 supposedly should be able to mock final classes but there were errors when trying to do so
         //   Will need to check if there is a workaround or a better way to mock getting hits.hits since this current approach is verbose
-        val docField = DocumentField(dateHistogram.sourceField, listOf(getInstant(timestamp).toEpochMilli().toString()))
+        val docField = DocumentField(dateHistogram.sourceField, listOf(timestamp))
         val searchHit = SearchHit(0)
         searchHit.setDocumentField(dateHistogram.sourceField, docField)
         val searchHits = SearchHits(arrayOf(searchHit), null, 0.0F)

--- a/src/test/kotlin/org/opensearch/indexmanagement/rollup/runner/RollupRunnerIT.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/rollup/runner/RollupRunnerIT.kt
@@ -1280,7 +1280,7 @@ class RollupRunnerIT : RollupRestTestCase() {
         refreshAllIndices()
 
         val job = Rollup(
-            id = "rollup_with_alias_99243411",
+            id = "rollup_with_alias_992434131",
             schemaVersion = 1L,
             enabled = true,
             jobSchedule = IntervalSchedule(Instant.now(), 1, ChronoUnit.DAYS),


### PR DESCRIPTION
*Issue #, if available:* #767

*Description of changes:*

Added trimming of nanos part of "epoch_millis" timestamp when date_histogram type used is date_nanos

*CheckList:*
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/index-management/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
