### PR TITLE
Rollup Interceptor sourceIndex NPE fix

### DIFF
--- a/src/main/kotlin/org/opensearch/indexmanagement/rollup/interceptor/RollupInterceptor.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/rollup/interceptor/RollupInterceptor.kt
@@ -242,7 +242,7 @@ class RollupInterceptor(
                 fieldMappings.add(RollupFieldMapping(RollupFieldMapping.Companion.FieldType.DIMENSION, query.fieldName(), Dimension.Type.TERMS.type))
             }
             is QueryStringQueryBuilder -> {
-                if (concreteSourceIndexName == null) {
+                if (concreteSourceIndexName.isNullOrEmpty()) {
                     throw IllegalArgumentException("Can't parse query_string query without sourceIndex mappings!")
                 }
                 // Throws IllegalArgumentException if unable to parse query

--- a/src/main/kotlin/org/opensearch/indexmanagement/rollup/interceptor/RollupInterceptor.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/rollup/interceptor/RollupInterceptor.kt
@@ -115,7 +115,7 @@ class RollupInterceptor(
     fun getConcreteSourceIndex(sourceIndex: String, resolver: IndexNameExpressionResolver, clusterState: ClusterState): String {
         val concreteIndexNames = resolver.concreteIndexNames(clusterState, IndicesOptions.LENIENT_EXPAND_OPEN, sourceIndex)
         if (concreteIndexNames.isEmpty()) {
-            throw IllegalStateException("Cannot resolve rollup sourceIndex [$sourceIndex]")
+            throw IllegalArgumentException("Cannot resolve rollup sourceIndex [$sourceIndex]")
         }
         return IndexUtils.getConcreteIndex(sourceIndex, concreteIndexNames, clusterState)
     }

--- a/src/main/kotlin/org/opensearch/indexmanagement/rollup/interceptor/RollupInterceptor.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/rollup/interceptor/RollupInterceptor.kt
@@ -193,7 +193,7 @@ class RollupInterceptor(
         return fieldMappings
     }
 
-    @Suppress("ComplexMethod", "ThrowsCount")
+    @Suppress("ComplexMethod", "ThrowsCount", "LongMethod")
     private fun getQueryMetadata(
         query: QueryBuilder?,
         concreteSourceIndexName: String?,
@@ -202,7 +202,6 @@ class RollupInterceptor(
         if (query == null) {
             return fieldMappings
         }
-
         when (query) {
             is TermQueryBuilder -> {
                 fieldMappings.add(RollupFieldMapping(RollupFieldMapping.Companion.FieldType.DIMENSION, query.fieldName(), Dimension.Type.TERMS.type))
@@ -259,7 +258,6 @@ class RollupInterceptor(
                 throw IllegalArgumentException("The ${query.name} query is currently not supported in rollups")
             }
         }
-
         return fieldMappings
     }
 

--- a/src/main/kotlin/org/opensearch/indexmanagement/util/IndexUtils.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/util/IndexUtils.kt
@@ -234,24 +234,5 @@ class IndexUtils {
             return clusterState.metadata
                 .indicesLookup[indexName]!!.type == IndexAbstraction.Type.CONCRETE_INDEX
         }
-
-        fun getConcreteIndex(indexName: String, concreteIndices: Array<String>, clusterState: ClusterState): String {
-
-            if (concreteIndices.isEmpty()) {
-                throw IllegalArgumentException("ConcreteIndices list can't be empty!")
-            }
-
-            var concreteIndexName: String
-            if (concreteIndices.size == 1 && isConcreteIndex(concreteIndices[0], clusterState)) {
-                concreteIndexName = concreteIndices[0]
-            } else if (isAlias(indexName, clusterState) || isDataStream(indexName, clusterState)) {
-                concreteIndexName = getWriteIndex(indexName, clusterState)
-                    ?: getNewestIndexByCreationDate(concreteIndices, clusterState) //
-            } else {
-                concreteIndexName = getNewestIndexByCreationDate(concreteIndices, clusterState)
-            }
-
-            return concreteIndexName
-        }
     }
 }

--- a/src/main/kotlin/org/opensearch/indexmanagement/util/IndexUtils.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/util/IndexUtils.kt
@@ -15,9 +15,9 @@ import org.opensearch.cluster.metadata.IndexAbstraction
 import org.opensearch.cluster.metadata.IndexMetadata
 import org.opensearch.common.hash.MurmurHash3
 import org.opensearch.common.xcontent.LoggingDeprecationHandler
+import org.opensearch.common.xcontent.XContentType
 import org.opensearch.core.xcontent.NamedXContentRegistry
 import org.opensearch.core.xcontent.XContentParser.Token
-import org.opensearch.common.xcontent.XContentType
 import org.opensearch.indexmanagement.IndexManagementIndices
 import org.opensearch.indexmanagement.IndexManagementPlugin
 import java.nio.ByteBuffer
@@ -242,8 +242,8 @@ class IndexUtils {
             }
 
             var concreteIndexName: String
-            if (concreteIndices.size == 1 && isConcreteIndex(indexName, clusterState)) {
-                concreteIndexName = indexName
+            if (concreteIndices.size == 1 && isConcreteIndex(concreteIndices[0], clusterState)) {
+                concreteIndexName = concreteIndices[0]
             } else if (isAlias(indexName, clusterState) || isDataStream(indexName, clusterState)) {
                 concreteIndexName = getWriteIndex(indexName, clusterState)
                     ?: getNewestIndexByCreationDate(concreteIndices, clusterState) //

--- a/src/test/kotlin/org/opensearch/indexmanagement/rollup/interceptor/RollupInterceptorIT.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/rollup/interceptor/RollupInterceptorIT.kt
@@ -1712,20 +1712,20 @@ class RollupInterceptorIT : RollupRestTestCase() {
     }
 
     fun `test roll up search query_string query with index pattern as source`() {
-        val sourceIndex = "source_rollup_search_qsq_1"
-        val targetIndex = "target_rollup_qsq_search_1"
+        val sourceIndex = "source_111_rollup_search_qsq_98243"
+        val targetIndex = "target_rollup_qsq_search_98243"
 
         createSampleIndexForQSQTest(sourceIndex)
 
         val rollup = Rollup(
-            id = "basic_query_string_query_rollup_search111",
+            id = "basic_query_string_query_rollup_search98243",
             enabled = true,
             schemaVersion = 1L,
             jobSchedule = IntervalSchedule(Instant.now(), 1, ChronoUnit.MINUTES),
             jobLastUpdatedTime = Instant.now(),
             jobEnabledTime = Instant.now(),
             description = "basic search test",
-            sourceIndex = "source_roll*",
+            sourceIndex = "source_111*",
             targetIndex = targetIndex,
             metadataID = null,
             roles = emptyList(),


### PR DESCRIPTION
*Issue #, if available:* #764

*Description of changes:*

Added proper resolving of sourceIndex inside RollupInterceptor. 

Concrete sourceIndex is required for QueryStringQuery parsing

*CheckList:*
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/index-management/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
