### PR TITLE
Rollup QSQ follow-up

### DIFF
--- a/src/main/kotlin/org/opensearch/indexmanagement/IndexManagementIndices.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/IndexManagementIndices.kt
@@ -8,7 +8,6 @@ package org.opensearch.indexmanagement
 
 import org.apache.logging.log4j.LogManager
 import org.apache.logging.log4j.Logger
-import org.opensearch.OpenSearchStatusException
 import org.opensearch.ResourceAlreadyExistsException
 import org.opensearch.action.ActionListener
 import org.opensearch.action.admin.indices.alias.Alias
@@ -29,7 +28,6 @@ import org.opensearch.indexmanagement.indexstatemanagement.util.INDEX_NUMBER_OF_
 import org.opensearch.indexmanagement.opensearchapi.suspendUntil
 import org.opensearch.indexmanagement.util.IndexUtils
 import org.opensearch.indexmanagement.util.OpenForTesting
-import org.opensearch.rest.RestStatus
 import kotlin.coroutines.resume
 import kotlin.coroutines.resumeWithException
 import kotlin.coroutines.suspendCoroutine
@@ -86,15 +84,10 @@ class IndexManagementIndices(
                 }
             )
         }
-        if (response.isAcknowledged) {
-            return true
-        } else {
-            logger.error("Unable to create or update $INDEX_MANAGEMENT_INDEX with newest mapping.")
-            throw OpenSearchStatusException(
-                "Unable to create or update $INDEX_MANAGEMENT_INDEX with newest mapping.",
-                RestStatus.INTERNAL_SERVER_ERROR
-            )
+        if (!response.isAcknowledged) {
+            logger.warn("create or update $INDEX_MANAGEMENT_INDEX with newest mapping was not acknowledged.")
         }
+        return true
     }
 
     fun indexManagementIndexExists(): Boolean = clusterService.state().routingTable.hasIndex(INDEX_MANAGEMENT_INDEX)

--- a/src/main/kotlin/org/opensearch/indexmanagement/IndexManagementPlugin.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/IndexManagementPlugin.kt
@@ -24,9 +24,9 @@ import org.opensearch.common.settings.Setting
 import org.opensearch.common.settings.Settings
 import org.opensearch.common.settings.SettingsFilter
 import org.opensearch.common.util.concurrent.ThreadContext
+import org.opensearch.common.xcontent.XContentParserUtils.ensureExpectedToken
 import org.opensearch.core.xcontent.NamedXContentRegistry
 import org.opensearch.core.xcontent.XContentParser.Token
-import org.opensearch.common.xcontent.XContentParserUtils.ensureExpectedToken
 import org.opensearch.env.Environment
 import org.opensearch.env.NodeEnvironment
 import org.opensearch.indexmanagement.controlcenter.notification.ControlCenterIndices
@@ -123,6 +123,7 @@ import org.opensearch.indexmanagement.rollup.settings.RollupSettings
 import org.opensearch.indexmanagement.rollup.util.QueryShardContextFactory
 import org.opensearch.indexmanagement.rollup.util.RollupFieldValueExpressionResolver
 import org.opensearch.indexmanagement.settings.IndexManagementSettings
+import org.opensearch.indexmanagement.snapshotmanagement.SMRunner
 import org.opensearch.indexmanagement.snapshotmanagement.api.resthandler.RestCreateSMPolicyHandler
 import org.opensearch.indexmanagement.snapshotmanagement.api.resthandler.RestDeleteSMPolicyHandler
 import org.opensearch.indexmanagement.snapshotmanagement.api.resthandler.RestExplainSMPolicyHandler
@@ -138,7 +139,6 @@ import org.opensearch.indexmanagement.snapshotmanagement.api.transport.get.Trans
 import org.opensearch.indexmanagement.snapshotmanagement.api.transport.index.TransportIndexSMPolicyAction
 import org.opensearch.indexmanagement.snapshotmanagement.api.transport.start.TransportStartSMAction
 import org.opensearch.indexmanagement.snapshotmanagement.api.transport.stop.TransportStopSMAction
-import org.opensearch.indexmanagement.snapshotmanagement.SMRunner
 import org.opensearch.indexmanagement.snapshotmanagement.model.SMMetadata
 import org.opensearch.indexmanagement.snapshotmanagement.model.SMPolicy
 import org.opensearch.indexmanagement.snapshotmanagement.settings.SnapshotManagementSettings
@@ -382,7 +382,7 @@ class IndexManagementPlugin : JobSchedulerExtension, NetworkPlugin, ActionPlugin
             namedWriteableRegistry,
             environment
         )
-        rollupInterceptor = RollupInterceptor(clusterService, settings, indexNameExpressionResolver)
+        rollupInterceptor = RollupInterceptor(clusterService, client, settings, indexNameExpressionResolver)
         val jvmService = JvmService(environment.settings())
         val transformRunner = TransformRunner.initialize(
             client,

--- a/src/main/kotlin/org/opensearch/indexmanagement/rollup/action/mapping/TransportUpdateRollupMappingAction.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/rollup/action/mapping/TransportUpdateRollupMappingAction.kt
@@ -21,16 +21,15 @@ import org.opensearch.common.bytes.BytesReference
 import org.opensearch.common.inject.Inject
 import org.opensearch.common.io.stream.StreamInput
 import org.opensearch.common.io.stream.Writeable
-import org.opensearch.core.xcontent.MediaType
 import org.opensearch.common.xcontent.XContentFactory
 import org.opensearch.common.xcontent.XContentHelper
 import org.opensearch.common.xcontent.XContentType
+import org.opensearch.core.xcontent.MediaType
 import org.opensearch.indexmanagement.indexstatemanagement.util.XCONTENT_WITHOUT_TYPE
 import org.opensearch.indexmanagement.rollup.util.RollupFieldValueExpressionResolver
 import org.opensearch.indexmanagement.util.IndexUtils.Companion._META
 import org.opensearch.threadpool.ThreadPool
 import org.opensearch.transport.TransportService
-import java.lang.Exception
 
 class TransportUpdateRollupMappingAction @Inject constructor(
     threadPool: ThreadPool,
@@ -101,15 +100,8 @@ class TransportUpdateRollupMappingAction @Inject constructor(
                 val updatedRollups = mapOf<String, Any>("rollups" to rollupJobEntries)
                 metaMappings[_META] = updatedRollups
             } else {
-                if ((rollups as Map<*, *>).containsKey(request.rollup.id)) {
-                    log.debug("Meta rollup mappings already contain rollup ${request.rollup.id} for index [$index]")
-                    return listener.onFailure(
-                        IllegalStateException("Meta rollup mappings already contain rollup ${request.rollup.id} for index [$index]")
-                    )
-                }
-
                 // In this case rollup mappings exists and there is no entry for request.rollup.id
-                val rollupJobEntries = rollups.toMutableMap()
+                val rollupJobEntries = (rollups as Map<*, *>).toMutableMap()
                 rollupJobEntries[request.rollup.id] = rollup
                 val updatedRollups = mapOf<String, Any>("rollups" to rollupJobEntries)
                 metaMappings[_META] = updatedRollups

--- a/src/main/kotlin/org/opensearch/indexmanagement/rollup/query/QueryStringQueryUtil.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/rollup/query/QueryStringQueryUtil.kt
@@ -24,11 +24,11 @@ object QueryStringQueryUtil {
 
     fun rewriteQueryStringQuery(
         queryBuilder: QueryBuilder,
-        concreteIndexName: String
+        sourceIndexMappings: Map<String, Any>
     ): QueryStringQueryBuilder {
         val qsqBuilder = queryBuilder as QueryStringQueryBuilder
         // Parse query_string query and extract all discovered fields
-        val (fieldsFromQueryString, otherFields) = extractFieldsFromQueryString(queryBuilder, concreteIndexName)
+        val (fieldsFromQueryString, otherFields) = extractFieldsFromQueryString(queryBuilder, sourceIndexMappings)
         // Rewrite query_string
         var newQueryString = qsqBuilder.queryString()
         fieldsFromQueryString.forEach { field ->
@@ -93,8 +93,8 @@ object QueryStringQueryUtil {
     }
 
     @Suppress("ComplexMethod", "LongMethod", "ThrowsCount", "EmptyCatchBlock")
-    fun extractFieldsFromQueryString(queryBuilder: QueryBuilder, concreteIndexName: String): Pair<List<String>, Map<String, Float>> {
-        val context = QueryShardContextFactory.createShardContext(concreteIndexName)
+    fun extractFieldsFromQueryString(queryBuilder: QueryBuilder, sourceIndexMappings: Map<String, Any>): Pair<List<String>, Map<String, Float>> {
+        val context = QueryShardContextFactory.createShardContext(sourceIndexMappings)
         val qsqBuilder = queryBuilder as QueryStringQueryBuilder
         val rewrittenQueryString = if (qsqBuilder.escape()) QueryParser.escape(qsqBuilder.queryString()) else qsqBuilder.queryString()
         val queryParser: QueryStringQueryParserExt

--- a/src/main/resources/mappings/opendistro-ism-config.json
+++ b/src/main/resources/mappings/opendistro-ism-config.json
@@ -1,6 +1,6 @@
 {
   "_meta" : {
-    "schema_version": 17
+    "schema_version": 18
   },
   "dynamic": "strict",
   "properties": {
@@ -1038,6 +1038,10 @@
               }
             }
           }
+        },
+        "source_index_field_mappings": {
+          "type": "object",
+          "enabled": false
         }
       }
     },

--- a/src/test/kotlin/org/opensearch/indexmanagement/IndexManagementRestTestCase.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/IndexManagementRestTestCase.kt
@@ -12,17 +12,17 @@ import org.junit.Before
 import org.junit.rules.DisableOnDebug
 import org.opensearch.action.admin.cluster.node.tasks.list.ListTasksAction
 import org.opensearch.client.Request
-import org.opensearch.client.Response
-import org.opensearch.client.RestClient
 import org.opensearch.client.RequestOptions
-import org.opensearch.client.WarningsHandler
+import org.opensearch.client.Response
 import org.opensearch.client.ResponseException
+import org.opensearch.client.RestClient
+import org.opensearch.client.WarningsHandler
 import org.opensearch.common.Strings
 import org.opensearch.common.io.PathUtils
 import org.opensearch.common.settings.Settings
+import org.opensearch.common.xcontent.XContentType
 import org.opensearch.core.xcontent.DeprecationHandler
 import org.opensearch.core.xcontent.NamedXContentRegistry
-import org.opensearch.common.xcontent.XContentType
 import org.opensearch.indexmanagement.indexstatemanagement.util.INDEX_HIDDEN
 import org.opensearch.rest.RestStatus
 import java.io.IOException
@@ -32,12 +32,10 @@ import javax.management.MBeanServerInvocationHandler
 import javax.management.ObjectName
 import javax.management.remote.JMXConnectorFactory
 import javax.management.remote.JMXServiceURL
-import kotlin.collections.ArrayList
-import kotlin.collections.HashSet
 
 abstract class IndexManagementRestTestCase : ODFERestTestCase() {
 
-    val configSchemaVersion = 17
+    val configSchemaVersion = 18
     val historySchemaVersion = 5
 
     // Having issues with tests leaking into other tests and mappings being incorrect and they are not caught by any pending task wait check as

--- a/src/test/resources/mappings/cached-opendistro-ism-config.json
+++ b/src/test/resources/mappings/cached-opendistro-ism-config.json
@@ -1,6 +1,6 @@
 {
   "_meta" : {
-    "schema_version": 17
+    "schema_version": 18
   },
   "dynamic": "strict",
   "properties": {
@@ -1038,6 +1038,10 @@
               }
             }
           }
+        },
+        "source_index_field_mappings": {
+          "type": "object",
+          "enabled": false
         }
       }
     },


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

1. Added saving of field mappings from sourceIndex inside rollup job in sourceIndexFieldMappings field
2. Added populating newly added field sourceIndexFieldMappings during Rollup Create/Update action
3. Added updating rollup job inside rollup index mapping _meta field from RollupInterceptor, to handle old rollup jobs created before this PR.


*CheckList:*
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/index-management/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
