### PR TITLE
Update snakeyaml to version 2.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -77,7 +77,7 @@ configurations.all {
         force 'org.apache.httpcomponents.client5:httpclient5:5.0.3'
         force 'org.apache.httpcomponents.client5:httpclient5-osgi:5.0.3'
         force "com.fasterxml.jackson.core:jackson-databind:${versions.jackson_databind}"
-        force 'org.yaml:snakeyaml:1.32'
+        force 'org.yaml:snakeyaml:2.0'
         force 'org.codehaus.plexus:plexus-utils:3.0.24'
         // This is required as the core test framework updated to depend on a newer version and conflicts with the version used by mockito
         force "net.bytebuddy:byte-buddy:1.14.3"


### PR DESCRIPTION
Snakeyaml released the version [2.0](https://bitbucket.org/snakeyaml/snakeyaml/wiki/Changes) which also addresses the https://github.com/advisories/GHSA-mjmj-j48q-9wg2.

Description of changes:
Similar to https://github.com/opensearch-project/OpenSearch/issues/5576
*CheckList:*
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/index-management/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
