### PR TITLE
Fix debug log for missing ISM config index

### DIFF
--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/ManagedIndexCoordinator.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/ManagedIndexCoordinator.kt
@@ -262,6 +262,11 @@ class ManagedIndexCoordinator(
      */
     @OpenForTesting
     suspend fun sweepClusterChangedEvent(event: ClusterChangedEvent) {
+        // If IM config doesn't exist skip
+        if (!ismIndices.indexManagementIndexExists()) {
+            logger.info("[.opendistro-ism-config] index had not been created")
+            return
+        }
         // indices delete event
         var removeManagedIndexReq = emptyList<DocWriteRequest<*>>()
         var indicesToClean = emptyList<Index>()

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/ManagedIndexCoordinator.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/ManagedIndexCoordinator.kt
@@ -264,7 +264,7 @@ class ManagedIndexCoordinator(
     suspend fun sweepClusterChangedEvent(event: ClusterChangedEvent) {
         // If IM config doesn't exist skip
         if (!ismIndices.indexManagementIndexExists()) {
-            logger.info("[.opendistro-ism-config] index had not been created")
+            logger.warn("[.opendistro-ism-config] config index does not exist")
             return
         }
         // indices delete event

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/ManagedIndexCoordinator.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/ManagedIndexCoordinator.kt
@@ -264,7 +264,7 @@ class ManagedIndexCoordinator(
     suspend fun sweepClusterChangedEvent(event: ClusterChangedEvent) {
         // If IM config doesn't exist skip
         if (!ismIndices.indexManagementIndexExists()) {
-            logger.warn("[.opendistro-ism-config] config index does not exist")
+            logger.debug("[.opendistro-ism-config] config index does not exist")
             return
         }
         // indices delete event


### PR DESCRIPTION
# More Accurate Error Message

*Issue 697*

*Description of changes:*

- I added a check to avoid an inappropriate error being logged if the cluster was changed and the managed index config was not created yet 
- Instead a debug log will be outputted whenever there is a change in the cluster state and there is no managed config index

------------------------------------------------------------------------------------------------------------
***These would be the results of the changed output logs in different cases:***
 ## Before Change:

1. Config index has not been created (fresh cluster essentially)
    1. Adding an index: no output
    2. Deleting an index:
```bash
[ERROR][o.o.i.i.ManagedIndexCoordinator] [integTest-0] get managed-index failed: [.opendistro-ism-config] IndexNotFoundException[no such index [.opendistro-ism-config]]
```
2. Config index has been created (e.g., an ISM policy has been created)     
    1. Adding an index: no output
    2. Deleting an index: no output
3. Config index has been deleted
    1. Adding an index: no output
    2. Deleting an index:
```bash
[ERROR][o.o.i.i.ManagedIndexCoordinator] [6c7e67c756fb] get managed-index failed: [.opendistro-ism-config] IndexNotFoundException[no such index [.opendistro-ism-config]]
```

 ## After Change:
1. Config index has not been created (fresh cluster essentially)
    1. Adding an index:
```bash
[WARN ][o.o.i.i.ManagedIndexCoordinator] [integTest-0] [.opendistro-ism-config] config index does not exist
```
    2. Deleting an index:
```bash
[DEBUG ][o.o.i.i.ManagedIndexCoordinator] [integTest-0] [.opendistro-ism-config] config index does not exist
```
2. Config index has been created (e.g., an ISM policy has been created)     
    1. Adding an index: no output
    2. Deleting an index: no output
3. Config index has been deleted
    1. Adding an index:
```bash
[DEBUG ][o.o.i.i.ManagedIndexCoordinator] [integTest-0] [.opendistro-ism-config] config index does not exist
```
    3. Deleting an index:
```bash
[DEBUG ][o.o.i.i.ManagedIndexCoordinator] [integTest-0] [.opendistro-ism-config] config index does not exist
```

*CheckList:*
- [ x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/index-management/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
