### PR TITLE
Detect rollover transient failure and continues execution

### DIFF
--- a/spi/src/main/kotlin/org.opensearch.indexmanagement.spi/indexstatemanagement/Step.kt
+++ b/spi/src/main/kotlin/org.opensearch.indexmanagement.spi/indexstatemanagement/Step.kt
@@ -6,6 +6,7 @@
 package org.opensearch.indexmanagement.spi.indexstatemanagement
 
 import org.apache.logging.log4j.Logger
+import org.opensearch.client.Client
 import org.opensearch.common.io.stream.StreamInput
 import org.opensearch.common.io.stream.StreamOutput
 import org.opensearch.common.io.stream.Writeable
@@ -37,6 +38,10 @@ abstract class Step(val name: String, val isSafeToDisableOn: Boolean = true) {
     abstract fun getUpdatedManagedIndexMetadata(currentMetadata: ManagedIndexMetaData): ManagedIndexMetaData
 
     abstract fun isIdempotent(): Boolean
+
+    open suspend fun isTransientFailure(client: Client, stepContext: StepContext, managedIndexMetaData: ManagedIndexMetaData): Boolean {
+        return false
+    }
 
     final fun getStepStartTime(metadata: ManagedIndexMetaData): Instant {
         return when {

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/ManagedIndexRunner.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/ManagedIndexRunner.kt
@@ -222,6 +222,7 @@ object ManagedIndexRunner :
         return this
     }
     // Detects if a nonidempotent step was a transient failure or not
+    @Suppress("ReturnCount")
     suspend fun isTransientFailure(stepContext: StepContext): Boolean {
         val stepName = stepContext.metadata.stepMetaData?.name
         when (stepName) {

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/ManagedIndexRunner.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/ManagedIndexRunner.kt
@@ -15,6 +15,7 @@ import kotlinx.coroutines.withContext
 import org.apache.logging.log4j.LogManager
 import org.opensearch.action.admin.cluster.state.ClusterStateRequest
 import org.opensearch.action.admin.cluster.state.ClusterStateResponse
+import org.opensearch.action.admin.indices.alias.get.GetAliasesRequest
 import org.opensearch.action.bulk.BackoffPolicy
 import org.opensearch.action.bulk.BulkRequest
 import org.opensearch.action.bulk.BulkResponse
@@ -47,6 +48,7 @@ import org.opensearch.indexmanagement.indexstatemanagement.model.ErrorNotificati
 import org.opensearch.indexmanagement.indexstatemanagement.model.ManagedIndexConfig
 import org.opensearch.indexmanagement.indexstatemanagement.model.Policy
 import org.opensearch.indexmanagement.indexstatemanagement.opensearchapi.getManagedIndexMetadata
+import org.opensearch.indexmanagement.indexstatemanagement.opensearchapi.getRolloverAlias
 import org.opensearch.indexmanagement.indexstatemanagement.settings.ManagedIndexSettings.Companion.ALLOW_LIST
 import org.opensearch.indexmanagement.indexstatemanagement.settings.ManagedIndexSettings.Companion.ALLOW_LIST_NONE
 import org.opensearch.indexmanagement.indexstatemanagement.settings.ManagedIndexSettings.Companion.DEFAULT_ISM_ENABLED
@@ -219,6 +221,59 @@ object ManagedIndexRunner :
         this.extensionStatusChecker = extensionStatusChecker
         return this
     }
+    // Detects if a nonidempotent step was a transient failure or not
+    suspend fun isTransientFailure(stepContext: StepContext): Boolean {
+        val stepName = stepContext.metadata.stepMetaData?.name
+        when (stepName) {
+            "attempt_rollover" -> {
+                val stepStartTime = stepContext.metadata.stepMetaData?.startTime
+                // Retrieve the alias name
+                val indexName = stepContext.metadata.index
+                val metadata = stepContext.clusterService.state().metadata()
+                val indexAbstraction = metadata.indicesLookup[indexName]
+                val isDataStreamIndex = indexAbstraction?.parentDataStream != null
+
+                val aliasName = when {
+                    isDataStreamIndex -> indexAbstraction?.parentDataStream?.name
+                    else -> metadata.index(indexName).getRolloverAlias()
+                }
+                if (aliasName == null) {
+                    logger.debug("Index has no alias attached to it. Not a Transient Failure")
+                    return false
+                }
+                val response = client.suspendUntil { admin().indices().getAliases(GetAliasesRequest(aliasName), it) }
+                // Parse through all indices under that alias
+                val aliasIndices = response.aliases
+                aliasIndices.forEach { (index, _) ->
+                    val indexMetaData = getIndexMetadata(index)
+                    val indexCreationDate = indexMetaData?.creationDate
+                    // Transient failure detected: Index was created after step started, therefore it finished a rollover
+                    if (stepStartTime!! < indexCreationDate!!) {
+                        logger.debug("Have to rerun attempt rollover step due to transient failure ${stepContext.metadata.index}")
+                        return true
+                    }
+                }
+                // Did not find any indices created after the rollover policy step started, therefore is not a Transient failure
+                return false
+            }
+            "attempt_snapshot" -> {
+                // TODO implement logic for detecting transient failure in attempt snapshot step
+            }
+            "attempt_notification" -> {
+                // TODO implement logic for detecting transient failure in attempt notification step
+            }
+            "attempt_shrink_step" -> {
+                // TODO implement logic for detecting transient failure in attempt shrink step
+            }
+            "attempt_call_force_merge" -> {
+                // TODO implement logic for detecting transient failure in attempt call force merge step
+            }
+            else -> {
+                logger.debug("Detected unfamiliar nonIdempotent step:  $stepName")
+            }
+        }
+        return true
+    }
 
     override fun runJob(job: ScheduledJobParameter, context: JobExecutionContext) {
         if (job !is ManagedIndexConfig) {
@@ -358,7 +413,8 @@ object ManagedIndexRunner :
         if (managedIndexMetaData.stepMetaData?.stepStatus == Step.StepStatus.STARTING) {
             val isIdempotent = step?.isIdempotent()
             logger.info("Previous execution failed to update step status, isIdempotent=$isIdempotent")
-            if (isIdempotent != true) {
+            // If this step was not a transient failure fail the index
+            if (isIdempotent != true && !isTransientFailure(stepContext)) {
                 val info = mapOf("message" to "Previous action was not able to update IndexMetaData.")
                 val updated = updateManagedIndexMetaData(
                     managedIndexMetaData.copy(

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/forcemerge/AttemptCallForceMergeStep.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/forcemerge/AttemptCallForceMergeStep.kt
@@ -14,12 +14,14 @@ import org.apache.logging.log4j.LogManager
 import org.opensearch.ExceptionsHelper
 import org.opensearch.action.admin.indices.forcemerge.ForceMergeRequest
 import org.opensearch.action.admin.indices.forcemerge.ForceMergeResponse
+import org.opensearch.client.Client
 import org.opensearch.indexmanagement.indexstatemanagement.action.ForceMergeAction
 import org.opensearch.indexmanagement.opensearchapi.getUsefulCauseString
 import org.opensearch.indexmanagement.opensearchapi.suspendUntil
 import org.opensearch.indexmanagement.spi.indexstatemanagement.Step
 import org.opensearch.indexmanagement.spi.indexstatemanagement.model.ActionProperties
 import org.opensearch.indexmanagement.spi.indexstatemanagement.model.ManagedIndexMetaData
+import org.opensearch.indexmanagement.spi.indexstatemanagement.model.StepContext
 import org.opensearch.indexmanagement.spi.indexstatemanagement.model.StepMetaData
 import org.opensearch.rest.RestStatus
 import org.opensearch.transport.RemoteTransportException
@@ -104,6 +106,10 @@ class AttemptCallForceMergeStep(private val action: ForceMergeAction) : Step(nam
     }
 
     override fun isIdempotent() = false
+    override suspend fun isTransientFailure(client: Client, stepContext: StepContext, managedIndexMetaData: ManagedIndexMetaData): Boolean {
+        // TODO implement logic for detecting transient failure in attempt call force merge step
+        return false
+    }
 
     companion object {
         const val name = "attempt_call_force_merge"

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/notification/AttemptNotificationStep.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/notification/AttemptNotificationStep.kt
@@ -6,12 +6,14 @@
 package org.opensearch.indexmanagement.indexstatemanagement.step.notification
 
 import org.apache.logging.log4j.LogManager
+import org.opensearch.client.Client
 import org.opensearch.indexmanagement.indexstatemanagement.action.NotificationAction
 import org.opensearch.indexmanagement.indexstatemanagement.util.publishLegacyNotification
 import org.opensearch.indexmanagement.indexstatemanagement.util.sendNotification
 import org.opensearch.indexmanagement.opensearchapi.convertToMap
 import org.opensearch.indexmanagement.spi.indexstatemanagement.Step
 import org.opensearch.indexmanagement.spi.indexstatemanagement.model.ManagedIndexMetaData
+import org.opensearch.indexmanagement.spi.indexstatemanagement.model.StepContext
 import org.opensearch.indexmanagement.spi.indexstatemanagement.model.StepMetaData
 import org.opensearch.script.Script
 import org.opensearch.script.ScriptService
@@ -66,6 +68,10 @@ class AttemptNotificationStep(private val action: NotificationAction) : Step(nam
     }
 
     override fun isIdempotent(): Boolean = false
+    override suspend fun isTransientFailure(client: Client, stepContext: StepContext, managedIndexMetaData: ManagedIndexMetaData): Boolean {
+        // TODO implement logic for detecting transient failure in attempt notification step
+        return false
+    }
 
     companion object {
         const val name = "attempt_notification"

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/shrink/AttemptShrinkStep.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/shrink/AttemptShrinkStep.kt
@@ -12,6 +12,7 @@ import org.opensearch.action.admin.indices.shrink.ResizeResponse
 import org.opensearch.action.admin.indices.stats.IndicesStatsRequest
 import org.opensearch.action.admin.indices.stats.IndicesStatsResponse
 import org.opensearch.action.support.master.AcknowledgedResponse
+import org.opensearch.client.Client
 import org.opensearch.cluster.metadata.IndexMetadata
 import org.opensearch.common.settings.Settings
 import org.opensearch.indexmanagement.indexstatemanagement.action.ShrinkAction
@@ -135,6 +136,10 @@ class AttemptShrinkStep(private val action: ShrinkAction) : ShrinkStep(name, tru
     }
 
     override fun isIdempotent() = false
+    override suspend fun isTransientFailure(client: Client, stepContext: StepContext, managedIndexMetaData: ManagedIndexMetaData): Boolean {
+        // TODO implement logic for detecting transient failure in attempt shrink step
+        return false
+    }
 
     companion object {
         const val name = "attempt_shrink_step"

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/snapshot/AttemptSnapshotStep.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/snapshot/AttemptSnapshotStep.kt
@@ -9,6 +9,7 @@ import org.apache.logging.log4j.LogManager
 import org.opensearch.ExceptionsHelper
 import org.opensearch.action.admin.cluster.snapshots.create.CreateSnapshotRequest
 import org.opensearch.action.admin.cluster.snapshots.create.CreateSnapshotResponse
+import org.opensearch.client.Client
 import org.opensearch.common.regex.Regex
 import org.opensearch.indexmanagement.indexstatemanagement.action.SnapshotAction
 import org.opensearch.indexmanagement.indexstatemanagement.settings.ManagedIndexSettings.Companion.SNAPSHOT_DENY_LIST
@@ -17,6 +18,7 @@ import org.opensearch.indexmanagement.opensearchapi.suspendUntil
 import org.opensearch.indexmanagement.spi.indexstatemanagement.Step
 import org.opensearch.indexmanagement.spi.indexstatemanagement.model.ActionProperties
 import org.opensearch.indexmanagement.spi.indexstatemanagement.model.ManagedIndexMetaData
+import org.opensearch.indexmanagement.spi.indexstatemanagement.model.StepContext
 import org.opensearch.indexmanagement.spi.indexstatemanagement.model.StepMetaData
 import org.opensearch.rest.RestStatus
 import org.opensearch.script.Script
@@ -155,6 +157,10 @@ class AttemptSnapshotStep(private val action: SnapshotAction) : Step(name) {
     }
 
     override fun isIdempotent(): Boolean = false
+    override suspend fun isTransientFailure(client: Client, stepContext: StepContext, managedIndexMetaData: ManagedIndexMetaData): Boolean {
+        // TODO implement logic for detecting transient failure in attempt snapshot step
+        return false
+    }
 
     companion object {
         val validTopContextFields = setOf("index", "indexUuid")

--- a/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/action/RolloverActionIT.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/action/RolloverActionIT.kt
@@ -689,7 +689,7 @@ class RolloverActionIT : IndexStateManagementRestTestCase() {
         updateManagedIndexConfigStartTime(managedIndexConfig)
         waitFor {
             val stepStatus = getExplainManagedIndexMetaData(firstIndex).stepMetaData?.stepStatus
-            assertEquals("Index did not rollover.", Step.StepStatus.COMPLETED, stepStatus)
+            assertEquals("rollover step did not continue executing after detecting the transient failure.", Step.StepStatus.COMPLETED, stepStatus)
         }
     }
 }

--- a/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/action/RolloverActionIT.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/action/RolloverActionIT.kt
@@ -688,8 +688,9 @@ class RolloverActionIT : IndexStateManagementRestTestCase() {
         // Execute again to see if the metadata will update
         updateManagedIndexConfigStartTime(managedIndexConfig)
         waitFor {
-            val stepStatus = getExplainManagedIndexMetaData(firstIndex).stepMetaData?.stepStatus
-            assertEquals("rollover step did not continue executing after detecting the transient failure.", Step.StepStatus.COMPLETED, stepStatus)
+            val stepMetaData = getExplainManagedIndexMetaData(firstIndex).stepMetaData
+            assertEquals("executed the wrong step: ${stepMetaData?.name} instead of attempt rollover", "attempt_rollover", stepMetaData?.name)
+            assertEquals("rollover step did not continue executing after detecting the transient failure.", Step.StepStatus.COMPLETED, stepMetaData?.stepStatus)
         }
     }
 }

--- a/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/action/RolloverActionIT.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/action/RolloverActionIT.kt
@@ -632,4 +632,56 @@ class RolloverActionIT : IndexStateManagementRestTestCase() {
         }
         assertTrue("New rollover index does not exist.", indexExists("$indexNameBase-000002"))
     }
+    fun `test rollover detects transient failure and continues executing`() {
+        val aliasName = "${testIndexName}_alias"
+        val indexNameBase = "${testIndexName}_index"
+        val firstIndex = "$indexNameBase-1"
+        val policyID = "${testIndexName}_testPolicyName_1"
+        val actionConfig = RolloverAction(null, 0, null, null, 0)
+        val states = listOf(State(name = "RolloverAction", actions = listOf(actionConfig), transitions = listOf()))
+        val policy = Policy(
+            id = policyID,
+            description = "$testIndexName description",
+            schemaVersion = 1L,
+            lastUpdatedTime = Instant.now().truncatedTo(ChronoUnit.MILLIS),
+            errorNotification = randomErrorNotification(),
+            defaultState = states[0].name,
+            states = states
+        )
+
+        createPolicy(policy, policyID)
+        // create index defaults
+        createIndex(firstIndex, policyID, aliasName)
+
+        val managedIndexConfig = getExistingManagedIndexConfig(firstIndex)
+
+        // Change the start time so the job will trigger in 2 seconds, this will trigger the first initialization of the policy
+        updateManagedIndexConfigStartTime(managedIndexConfig)
+        waitFor { assertEquals(policyID, getExplainManagedIndexMetaData(firstIndex).policyID) }
+
+        // Need to speed up to second execution where it will trigger the attempt rollover step
+        updateManagedIndexConfigStartTime(managedIndexConfig)
+        waitFor {
+            val info = getExplainManagedIndexMetaData(firstIndex).info as Map<String, Any?>
+            assertEquals("Index did not rollover.", AttemptRolloverStep.getSuccessMessage(firstIndex), info["message"])
+        }
+        // Manually produce transient failure
+        waitFor {
+            val response = client().makeRequest(
+                "POST", ".opendistro-ism-config/_update/${managedIndexConfig.id}%23metadata",
+                StringEntity(
+                    "{\"script\":{\"managed_index\": \"ctx._source.managed_index_metadata.step.step_status = params.step_status\"," +
+                        "\"lang\": \"painless\", \"params\": {\"step_status\": \"starting\"}}}",
+                    ContentType.APPLICATION_JSON
+                )
+            )
+            assertEquals("Request failed", RestStatus.OK, response.restStatus())
+        }
+        // Execute again to see if the metadata will update
+        updateManagedIndexConfigStartTime(managedIndexConfig)
+        waitFor {
+            val stepStatus = getExplainManagedIndexMetaData(firstIndex).stepMetaData?.stepStatus
+            assertEquals("Index did not rollover.", Step.StepStatus.COMPLETED, stepStatus)
+        }
+    }
 }

--- a/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/AttemptCallForceMergeStepTests.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/AttemptCallForceMergeStepTests.kt
@@ -1,0 +1,64 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.indexmanagement.indexstatemanagement.step
+
+import com.nhaarman.mockitokotlin2.any
+import com.nhaarman.mockitokotlin2.doAnswer
+import com.nhaarman.mockitokotlin2.doReturn
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.whenever
+import org.junit.Assert
+import org.opensearch.action.ActionListener
+import org.opensearch.action.admin.cluster.snapshots.create.CreateSnapshotResponse
+import org.opensearch.client.AdminClient
+import org.opensearch.client.Client
+import org.opensearch.client.ClusterAdminClient
+import org.opensearch.cluster.service.ClusterService
+import org.opensearch.common.settings.Settings
+import org.opensearch.indexmanagement.indexstatemanagement.randomForceMergeActionConfig
+import org.opensearch.indexmanagement.indexstatemanagement.step.forcemerge.AttemptCallForceMergeStep
+import org.opensearch.indexmanagement.spi.indexstatemanagement.model.ActionMetaData
+import org.opensearch.indexmanagement.spi.indexstatemanagement.model.ActionProperties
+import org.opensearch.indexmanagement.spi.indexstatemanagement.model.ManagedIndexMetaData
+import org.opensearch.indexmanagement.spi.indexstatemanagement.model.StepContext
+import org.opensearch.jobscheduler.spi.utils.LockService
+import org.opensearch.script.ScriptService
+import org.opensearch.test.OpenSearchTestCase
+
+class AttemptCallForceMergeStepTests {
+    private val clusterService: ClusterService = mock()
+    private val scriptService: ScriptService = mock()
+    private val settings: Settings = Settings.EMPTY
+    private val forceMergeAction = randomForceMergeActionConfig()
+    private val metadata = ManagedIndexMetaData(
+        "test", "indexUuid", "policy_id", null, null, null, null, null, null, null,
+        ActionMetaData(AttemptCallForceMergeStep.name, 1, 0, false, 0, null, ActionProperties()), null, null, null
+    )
+    private val lockService: LockService = LockService(mock(), clusterService)
+
+    suspend fun `test detect transient failure`() {
+        // TODO adjust this test after implementing isTransientFailure method
+        val step = AttemptCallForceMergeStep(forceMergeAction)
+        val client = getClient(getAdminClient(getClusterAdminClient(null, null)))
+        val stepContext = StepContext(metadata, clusterService, client, null, null, scriptService, settings, lockService)
+        Assert.assertEquals("Cannot detect transient failure", false, step.isTransientFailure(client, stepContext, metadata))
+    }
+    private fun getClient(adminClient: AdminClient): Client = mock { on { admin() } doReturn adminClient }
+    private fun getAdminClient(clusterAdminClient: ClusterAdminClient): AdminClient = mock { on { cluster() } doReturn clusterAdminClient }
+    private fun getClusterAdminClient(createSnapshotRequest: CreateSnapshotResponse?, exception: Exception?): ClusterAdminClient {
+        OpenSearchTestCase.assertTrue(
+            "Must provide one and only one response or exception",
+            (createSnapshotRequest != null).xor(exception != null)
+        )
+        return mock {
+            doAnswer { invocationOnMock ->
+                val listener = invocationOnMock.getArgument<ActionListener<CreateSnapshotResponse>>(1)
+                if (createSnapshotRequest != null) listener.onResponse(createSnapshotRequest)
+                else listener.onFailure(exception)
+            }.whenever(this.mock).createSnapshot(any(), any())
+        }
+    }
+}

--- a/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/AttemptCallForceMergeStepTests.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/AttemptCallForceMergeStepTests.kt
@@ -28,7 +28,7 @@ import org.opensearch.jobscheduler.spi.utils.LockService
 import org.opensearch.script.ScriptService
 import org.opensearch.test.OpenSearchTestCase
 
-class AttemptCallForceMergeStepTests {
+class AttemptCallForceMergeStepTests : OpenSearchTestCase() {
     private val clusterService: ClusterService = mock()
     private val scriptService: ScriptService = mock()
     private val settings: Settings = Settings.EMPTY

--- a/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/AttemptNotificationStepTests.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/AttemptNotificationStepTests.kt
@@ -1,0 +1,64 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.indexmanagement.indexstatemanagement.step
+
+import com.nhaarman.mockitokotlin2.any
+import com.nhaarman.mockitokotlin2.doAnswer
+import com.nhaarman.mockitokotlin2.doReturn
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.whenever
+import org.junit.Assert
+import org.opensearch.action.ActionListener
+import org.opensearch.action.admin.cluster.snapshots.create.CreateSnapshotResponse
+import org.opensearch.client.AdminClient
+import org.opensearch.client.Client
+import org.opensearch.client.ClusterAdminClient
+import org.opensearch.cluster.service.ClusterService
+import org.opensearch.common.settings.Settings
+import org.opensearch.indexmanagement.indexstatemanagement.randomNotificationActionConfig
+import org.opensearch.indexmanagement.indexstatemanagement.step.notification.AttemptNotificationStep
+import org.opensearch.indexmanagement.spi.indexstatemanagement.model.ActionMetaData
+import org.opensearch.indexmanagement.spi.indexstatemanagement.model.ActionProperties
+import org.opensearch.indexmanagement.spi.indexstatemanagement.model.ManagedIndexMetaData
+import org.opensearch.indexmanagement.spi.indexstatemanagement.model.StepContext
+import org.opensearch.jobscheduler.spi.utils.LockService
+import org.opensearch.script.ScriptService
+import org.opensearch.test.OpenSearchTestCase
+
+class AttemptNotificationStepTests {
+    private val clusterService: ClusterService = mock()
+    private val scriptService: ScriptService = mock()
+    private val settings: Settings = Settings.EMPTY
+    private val notificationAction = randomNotificationActionConfig()
+    private val metadata = ManagedIndexMetaData(
+        "test", "indexUuid", "policy_id", null, null, null, null, null, null, null,
+        ActionMetaData(AttemptNotificationStep.name, 1, 0, false, 0, null, ActionProperties()), null, null, null
+    )
+    private val lockService: LockService = LockService(mock(), clusterService)
+
+    suspend fun `test detect transient failure`() {
+        // TODO adjust this test after implementing isTransientFailure method
+        val step = AttemptNotificationStep(notificationAction)
+        val client = getClient(getAdminClient(getClusterAdminClient(null, null)))
+        val stepContext = StepContext(metadata, clusterService, client, null, null, scriptService, settings, lockService)
+        Assert.assertEquals("Cannot detect transient failure", false, step.isTransientFailure(client, stepContext, metadata))
+    }
+    private fun getClient(adminClient: AdminClient): Client = mock { on { admin() } doReturn adminClient }
+    private fun getAdminClient(clusterAdminClient: ClusterAdminClient): AdminClient = mock { on { cluster() } doReturn clusterAdminClient }
+    private fun getClusterAdminClient(createSnapshotRequest: CreateSnapshotResponse?, exception: Exception?): ClusterAdminClient {
+        OpenSearchTestCase.assertTrue(
+            "Must provide one and only one response or exception",
+            (createSnapshotRequest != null).xor(exception != null)
+        )
+        return mock {
+            doAnswer { invocationOnMock ->
+                val listener = invocationOnMock.getArgument<ActionListener<CreateSnapshotResponse>>(1)
+                if (createSnapshotRequest != null) listener.onResponse(createSnapshotRequest)
+                else listener.onFailure(exception)
+            }.whenever(this.mock).createSnapshot(any(), any())
+        }
+    }
+}

--- a/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/AttemptNotificationStepTests.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/AttemptNotificationStepTests.kt
@@ -28,7 +28,7 @@ import org.opensearch.jobscheduler.spi.utils.LockService
 import org.opensearch.script.ScriptService
 import org.opensearch.test.OpenSearchTestCase
 
-class AttemptNotificationStepTests {
+class AttemptNotificationStepTests : OpenSearchTestCase() {
     private val clusterService: ClusterService = mock()
     private val scriptService: ScriptService = mock()
     private val settings: Settings = Settings.EMPTY

--- a/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/AttemptRolloverStepTests.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/AttemptRolloverStepTests.kt
@@ -1,0 +1,62 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.indexmanagement.indexstatemanagement.step
+
+import com.nhaarman.mockitokotlin2.any
+import com.nhaarman.mockitokotlin2.doAnswer
+import com.nhaarman.mockitokotlin2.doReturn
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.whenever
+import org.junit.Assert
+import org.opensearch.action.ActionListener
+import org.opensearch.action.admin.cluster.snapshots.create.CreateSnapshotResponse
+import org.opensearch.client.AdminClient
+import org.opensearch.client.Client
+import org.opensearch.client.ClusterAdminClient
+import org.opensearch.cluster.service.ClusterService
+import org.opensearch.common.settings.Settings
+import org.opensearch.indexmanagement.indexstatemanagement.randomRolloverActionConfig
+import org.opensearch.indexmanagement.indexstatemanagement.step.rollover.AttemptRolloverStep
+import org.opensearch.indexmanagement.spi.indexstatemanagement.model.ActionMetaData
+import org.opensearch.indexmanagement.spi.indexstatemanagement.model.ActionProperties
+import org.opensearch.indexmanagement.spi.indexstatemanagement.model.ManagedIndexMetaData
+import org.opensearch.indexmanagement.spi.indexstatemanagement.model.StepContext
+import org.opensearch.jobscheduler.spi.utils.LockService
+import org.opensearch.script.ScriptService
+import org.opensearch.test.OpenSearchTestCase
+
+class AttemptRolloverStepTests : OpenSearchTestCase() {
+    private val clusterService: ClusterService = mock()
+    private val scriptService: ScriptService = mock()
+    private val settings: Settings = Settings.EMPTY
+    private val rolloverAction = randomRolloverActionConfig()
+    private val metadata = ManagedIndexMetaData(
+        "test", "indexUuid", "policy_id", null, null, null, null, null, null, null,
+        ActionMetaData(AttemptRolloverStep.name, 1, 0, false, 0, null, ActionProperties()), null, null, null
+    )
+    private val lockService: LockService = LockService(mock(), clusterService)
+
+    suspend fun `test detect transient failure`() {
+        // TODO adjust this test after implementing isTransientFailure method
+        val step = AttemptRolloverStep(rolloverAction)
+        val client = getClient(getAdminClient(getClusterAdminClient(null, null)))
+        val stepContext = StepContext(metadata, clusterService, client, null, null, scriptService, settings, lockService)
+        // Rollover has not happened yet, should not be able to find an alias attached to index
+        Assert.assertEquals("Incorrectly found alias attached to index", false, step.isTransientFailure(client, stepContext, metadata))
+    }
+    private fun getClient(adminClient: AdminClient): Client = mock { on { admin() } doReturn adminClient }
+    private fun getAdminClient(clusterAdminClient: ClusterAdminClient): AdminClient = mock { on { cluster() } doReturn clusterAdminClient }
+    private fun getClusterAdminClient(createSnapshotRequest: CreateSnapshotResponse?, exception: Exception?): ClusterAdminClient {
+        assertTrue("Must provide one and only one response or exception", (createSnapshotRequest != null).xor(exception != null))
+        return mock {
+            doAnswer { invocationOnMock ->
+                val listener = invocationOnMock.getArgument<ActionListener<CreateSnapshotResponse>>(1)
+                if (createSnapshotRequest != null) listener.onResponse(createSnapshotRequest)
+                else listener.onFailure(exception)
+            }.whenever(this.mock).createSnapshot(any(), any())
+        }
+    }
+}

--- a/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/AttemptShrinkStepTests.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/AttemptShrinkStepTests.kt
@@ -1,0 +1,65 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.indexmanagement.indexstatemanagement.step
+
+import com.nhaarman.mockitokotlin2.any
+import com.nhaarman.mockitokotlin2.doAnswer
+import com.nhaarman.mockitokotlin2.doReturn
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.whenever
+import org.junit.Assert
+import org.opensearch.action.ActionListener
+import org.opensearch.action.admin.cluster.snapshots.create.CreateSnapshotResponse
+import org.opensearch.client.AdminClient
+import org.opensearch.client.Client
+import org.opensearch.client.ClusterAdminClient
+import org.opensearch.cluster.service.ClusterService
+import org.opensearch.common.settings.Settings
+import org.opensearch.indexmanagement.indexstatemanagement.randomShrinkAction
+import org.opensearch.indexmanagement.indexstatemanagement.step.notification.AttemptNotificationStep
+import org.opensearch.indexmanagement.indexstatemanagement.step.shrink.AttemptShrinkStep
+import org.opensearch.indexmanagement.spi.indexstatemanagement.model.ActionMetaData
+import org.opensearch.indexmanagement.spi.indexstatemanagement.model.ActionProperties
+import org.opensearch.indexmanagement.spi.indexstatemanagement.model.ManagedIndexMetaData
+import org.opensearch.indexmanagement.spi.indexstatemanagement.model.StepContext
+import org.opensearch.jobscheduler.spi.utils.LockService
+import org.opensearch.script.ScriptService
+import org.opensearch.test.OpenSearchTestCase
+
+class AttemptShrinkStepTests {
+    private val clusterService: ClusterService = mock()
+    private val scriptService: ScriptService = mock()
+    private val settings: Settings = Settings.EMPTY
+    private val shrinkAction = randomShrinkAction()
+    private val metadata = ManagedIndexMetaData(
+        "test", "indexUuid", "policy_id", null, null, null, null, null, null, null,
+        ActionMetaData(AttemptNotificationStep.name, 1, 0, false, 0, null, ActionProperties()), null, null, null
+    )
+    private val lockService: LockService = LockService(mock(), clusterService)
+
+    suspend fun `test detect transient failure`() {
+        // TODO adjust this test after implementing isTransientFailure method
+        val step = AttemptShrinkStep(shrinkAction)
+        val client = getClient(getAdminClient(getClusterAdminClient(null, null)))
+        val stepContext = StepContext(metadata, clusterService, client, null, null, scriptService, settings, lockService)
+        Assert.assertEquals("Cannot detect transient failure", false, step.isTransientFailure(client, stepContext, metadata))
+    }
+    private fun getClient(adminClient: AdminClient): Client = mock { on { admin() } doReturn adminClient }
+    private fun getAdminClient(clusterAdminClient: ClusterAdminClient): AdminClient = mock { on { cluster() } doReturn clusterAdminClient }
+    private fun getClusterAdminClient(createSnapshotRequest: CreateSnapshotResponse?, exception: Exception?): ClusterAdminClient {
+        OpenSearchTestCase.assertTrue(
+            "Must provide one and only one response or exception",
+            (createSnapshotRequest != null).xor(exception != null)
+        )
+        return mock {
+            doAnswer { invocationOnMock ->
+                val listener = invocationOnMock.getArgument<ActionListener<CreateSnapshotResponse>>(1)
+                if (createSnapshotRequest != null) listener.onResponse(createSnapshotRequest)
+                else listener.onFailure(exception)
+            }.whenever(this.mock).createSnapshot(any(), any())
+        }
+    }
+}

--- a/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/AttemptShrinkStepTests.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/AttemptShrinkStepTests.kt
@@ -29,7 +29,7 @@ import org.opensearch.jobscheduler.spi.utils.LockService
 import org.opensearch.script.ScriptService
 import org.opensearch.test.OpenSearchTestCase
 
-class AttemptShrinkStepTests {
+class AttemptShrinkStepTests : OpenSearchTestCase() {
     private val clusterService: ClusterService = mock()
     private val scriptService: ScriptService = mock()
     private val settings: Settings = Settings.EMPTY

--- a/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/AttemptSnapshotStepTests.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/AttemptSnapshotStepTests.kt
@@ -12,6 +12,7 @@ import com.nhaarman.mockitokotlin2.eq
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.whenever
 import kotlinx.coroutines.runBlocking
+import org.junit.Assert
 import org.junit.Before
 import org.opensearch.action.ActionListener
 import org.opensearch.action.admin.cluster.snapshots.create.CreateSnapshotResponse
@@ -135,6 +136,14 @@ class AttemptSnapshotStepTests : OpenSearchTestCase() {
             assertEquals("Step status is not FAILED", Step.StepStatus.FAILED, updatedManagedIndexMetaData.stepMetaData?.stepStatus)
             assertEquals("Did not get cause from nested exception", "some error", updatedManagedIndexMetaData.info!!["cause"])
         }
+    }
+
+    suspend fun `test detect transient failure`() {
+        // TODO adjust this test after implementing isTransientFailure method
+        val step = AttemptSnapshotStep(snapshotAction)
+        val client = getClient(getAdminClient(getClusterAdminClient(null, null)))
+        val stepContext = StepContext(metadata, clusterService, client, null, null, scriptService, settings, lockService)
+        Assert.assertEquals("Cannot detect transient failure", false, step.isTransientFailure(client, stepContext, metadata))
     }
 
     private fun getClient(adminClient: AdminClient): Client = mock { on { admin() } doReturn adminClient }


### PR DESCRIPTION
Issue 33

Description of changes:
•Abstracted logic to handle nonidempotent failures that could cause inapropriate error log "Previous action was not able to update IndexMetaData."
•Detects transient failure for rollover step with testing

CheckList:

[ x] Commits are signed per the DCO using --signoff
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/index-management/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
