### PR TITLE
Can query on live data and rolled up data if there is no overlap

### DIFF
--- a/src/main/kotlin/org/opensearch/indexmanagement/IndexManagementPlugin.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/IndexManagementPlugin.kt
@@ -390,7 +390,7 @@ class IndexManagementPlugin : JobSchedulerExtension, NetworkPlugin, ActionPlugin
             namedWriteableRegistry,
             environment
         )
-        rollupInterceptor = RollupInterceptor(clusterService, settings, indexNameExpressionResolver)
+        rollupInterceptor = RollupInterceptor(clusterService, settings, indexNameExpressionResolver, client)
         val jvmService = JvmService(environment.settings())
         val transformRunner = TransformRunner.initialize(
             client,

--- a/worksheets/rollups/secured/nyc.http
+++ b/worksheets/rollups/secured/nyc.http
@@ -1,5 +1,5 @@
 ### Create these mappings first if you want to have the date mapping correctly created for datetime fields
-PUT https://localhost:9200/nyc-taxi-data
+PUT localhost:9200/nyc-taxi-data
 Authorization: Basic admin admin
 Content-Type: application/json
 
@@ -10,16 +10,16 @@ Content-Type: application/json
 }
 
 ###
-POST https://localhost:9200/nyc-taxi-data/_bulk?pretty
+POST localhost:9200/nyc-taxi-data/_bulk?pretty
 Authorization: Basic admin admin
 Content-Type: application/x-ndjson
 
 < ../../src/test/resources/data/nyc_5000.ndjson
 
 ###
-DELETE https://localhost:9200/nyc-taxi-data/
+DELETE localhost:9200/nyc-taxi-data/
 Authorization: Basic admin admin
 
 ###
-GET https://localhost:9200/nyc-taxi-data/_mapping
+GET localhost:9200/nyc-taxi-data/_mapping
 Authorization: Basic admin admin


### PR DESCRIPTION
POC: query from both historical rollup data and live data if there is no overlap

Follow the [ES syntax](https://www.elastic.co/guide/en/elasticsearch/reference/7.10/rollup-search.html#_searching_both_historical_rollup_and_non_rollup_data) of a comma separate search query. Rollup index first followed by the live data indices.

*Description of changes:*

- Refactored the Rollup Interceptor logic to only rewrite the agg request if the index is a rollup index. Live index requests executes as normal
- Only "validate" rollup indices so there is no longer an "Not all indices have rollup job" exception thrown

*CheckList:*
- [ x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/index-management/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
