### PR TITLE
Support copy alias in rollover

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -613,32 +613,44 @@ task integTestRemote(type: RestIntegTestTask) {
 
 // === Set up BWC tests ===
 
-String bwcMinVersion = "1.13.2.0"
-String bwcJobSchedulerVersion = "1.13.0.0"
+String bwcMinVersion = "2.6.0.0"
 String bwcBundleVersion = "1.3.2.0"
 Boolean bwcBundleTest = (project.findProperty('customDistributionDownloadType') != null &&
         project.properties['customDistributionDownloadType'] == "bundle");
 String bwcVersion = bwcBundleTest ? bwcBundleVersion : bwcMinVersion
 String bwcCurrentVersion = opensearch_version.replace("-SNAPSHOT", "")
 String baseName = "indexmanagementBwcCluster"
-String bwcFilePath = "src/test/resources/bwc/"
-String bwc_js_resource_location = bwcFilePath + "job-scheduler/" + bwcJobSchedulerVersion
-String bwc_im_resource_location = bwcFilePath + "indexmanagement/" + bwcVersion
 
-// Downloads the bwc job scheduler version
-String bwc_js_download_url = "https://github.com/opendistro-for-elasticsearch/job-scheduler/releases/download/v" +
-        bwcJobSchedulerVersion + "/job-scheduler-artifacts.zip"
-
-// Downloads the bwc index management version
-String bwc_im_download_url = "https://github.com/opendistro-for-elasticsearch/index-management/releases/download/v" +
-        bwcMinVersion + "/index-management-artifacts.zip"
-getPluginResource(bwc_im_resource_location, bwc_im_download_url)
-
+configurations {
+    bwcZip
+}
+dependencies {
+    bwcZip "org.opensearch.plugin:opensearch-job-scheduler:${bwcMinVersion}-SNAPSHOT@zip"
+    bwcZip "org.opensearch.plugin:opensearch-index-management:${bwcMinVersion}-SNAPSHOT@zip"
+}
+ext.resolvebwcZipFile = { pluginId ->
+    return new Callable<RegularFile>() {
+        @Override
+        RegularFile call() throws Exception {
+            return new RegularFile() {
+                @Override
+                File getAsFile() {
+                    return configurations.bwcZip.resolvedConfiguration.resolvedArtifacts
+                            .find { ResolvedArtifact f ->
+                                f.name.startsWith(pluginId)
+                            }
+                            .file
+                }
+            }
+        }
+    }
+}
+Integer bwcNumNodes = 3
 2.times {i ->
     testClusters {
         "${baseName}$i"{
             testDistribution = "ARCHIVE"
-            numberOfNodes = 3
+            numberOfNodes = bwcNumNodes
             if (bwcBundleTest) {
                 versions = [
                         "1.3.2", bwcCurrentVersion
@@ -686,31 +698,10 @@ getPluginResource(bwc_im_resource_location, bwc_im_download_url)
                 }
             } else {
                 versions = [
-                        "7.10.2", opensearch_version
+                        "2.6.0-SNAPSHOT", opensearch_version
                 ]
-                plugin(provider(new Callable<RegularFile>(){
-                    @Override
-                    RegularFile call() throws Exception {
-                        return new RegularFile() {
-                            @Override
-                            File getAsFile() {
-                                return getPluginResource(bwc_js_resource_location, bwc_js_download_url)
-                            }
-                        }
-                    }
-                }))
-
-                plugin(provider(new Callable<RegularFile>(){
-                    @Override
-                    RegularFile call() throws Exception {
-                        return new RegularFile() {
-                            @Override
-                            File getAsFile() {
-                                return getPluginResource(bwc_im_resource_location, bwc_im_download_url)
-                            }
-                        }
-                    }
-                }))
+                plugin(provider(resolvebwcZipFile("opensearch-job-scheduler")))
+                plugin(provider(resolvebwcZipFile("opensearch-index-management")))
             }
 
             setting 'path.repo',
@@ -748,6 +739,7 @@ task prepareBwcTests {
         nonInputProperties.systemProperty('tests.rest.cluster', "${-> testClusters."${baseName}$i".allHttpSocketURI.join(",")}")
         nonInputProperties.systemProperty('tests.clustername', "${-> testClusters."${baseName}$i".getName()}")
         systemProperty 'tests.security.manager', 'false'
+        systemProperty 'cluster.number_of_nodes', "${bwcNumNodes}"
     }
 }
 
@@ -772,6 +764,7 @@ task "${baseName}#oneThirdsUpgradeCluster"(type: StandaloneRestIntegTestTask) {
     nonInputProperties.systemProperty('tests.rest.cluster', "${-> testClusters."${baseName}0".allHttpSocketURI.join(",")}")
     nonInputProperties.systemProperty('tests.clustername', "${-> testClusters."${baseName}0".getName()}")
     systemProperty 'tests.security.manager', 'false'
+    systemProperty 'cluster.number_of_nodes', "${bwcNumNodes}"
 }
 
 // Upgrade the second node to new OpenSearch version with upgraded plugin version after the first node is upgraded.
@@ -792,6 +785,7 @@ task "${baseName}#twoThirdsUpgradedClusterTask"(type: StandaloneRestIntegTestTas
     nonInputProperties.systemProperty('tests.rest.cluster', "${-> testClusters."${baseName}0".allHttpSocketURI.join(",")}")
     nonInputProperties.systemProperty('tests.clustername', "${-> testClusters."${baseName}0".getName()}")
     systemProperty 'tests.security.manager', 'false'
+    systemProperty 'cluster.number_of_nodes', "${bwcNumNodes}"
 }
 
 // Upgrade the third node to new OpenSearch version with upgraded plugin version after the second node is upgraded.
@@ -812,6 +806,7 @@ task "${baseName}#rollingUpgradeClusterTask"(type: StandaloneRestIntegTestTask) 
     nonInputProperties.systemProperty('tests.rest.cluster', "${-> testClusters."${baseName}0".allHttpSocketURI.join(",")}")
     nonInputProperties.systemProperty('tests.clustername', "${-> testClusters."${baseName}0".getName()}")
     systemProperty 'tests.security.manager', 'false'
+    systemProperty 'cluster.number_of_nodes', "${bwcNumNodes}"
 }
 
 // Upgrade all the nodes of the old cluster to new OpenSearch version with upgraded plugin version
@@ -830,6 +825,7 @@ task "${baseName}#fullRestartClusterTask"(type: StandaloneRestIntegTestTask) {
     nonInputProperties.systemProperty('tests.rest.cluster', "${-> testClusters."${baseName}1".allHttpSocketURI.join(",")}")
     nonInputProperties.systemProperty('tests.clustername', "${-> testClusters."${baseName}1".getName()}")
     systemProperty 'tests.security.manager', 'false'
+    systemProperty 'cluster.number_of_nodes', "${bwcNumNodes}"
 }
 
 // A bwc test suite which runs all the bwc tasks combined
@@ -837,7 +833,7 @@ task bwcTestSuite(type: StandaloneRestIntegTestTask) {
     exclude '**/*Test*'
     exclude '**/*IT*'
     // TODO refactor bwc test #677
-    // dependsOn tasks.named("${baseName}#rollingUpgradeClusterTask")
+    dependsOn tasks.named("${baseName}#rollingUpgradeClusterTask")
     dependsOn tasks.named("${baseName}#fullRestartClusterTask")
 }
 

--- a/spi/src/main/kotlin/org.opensearch.indexmanagement.spi/indexstatemanagement/model/ManagedIndexMetaData.kt
+++ b/spi/src/main/kotlin/org.opensearch.indexmanagement.spi/indexstatemanagement/model/ManagedIndexMetaData.kt
@@ -38,7 +38,8 @@ data class ManagedIndexMetaData(
     val info: Map<String, Any>?,
     val id: String = NO_ID,
     val seqNo: Long = SequenceNumbers.UNASSIGNED_SEQ_NO,
-    val primaryTerm: Long = SequenceNumbers.UNASSIGNED_PRIMARY_TERM
+    val primaryTerm: Long = SequenceNumbers.UNASSIGNED_PRIMARY_TERM,
+    val rolledOverIndexName: String? = null,
 ) : Writeable, ToXContentFragment {
 
     @Suppress("ComplexMethod")
@@ -51,6 +52,7 @@ data class ManagedIndexMetaData(
         if (policyPrimaryTerm != null) resultMap[POLICY_PRIMARY_TERM] = policyPrimaryTerm.toString()
         if (policyCompleted != null) resultMap[POLICY_COMPLETED] = policyCompleted.toString()
         if (rolledOver != null) resultMap[ROLLED_OVER] = rolledOver.toString()
+        if (rolledOverIndexName != null) resultMap[ROLLED_OVER_INDEX_NAME] = rolledOverIndexName
         if (indexCreationDate != null) resultMap[INDEX_CREATION_DATE] = indexCreationDate.toString()
         if (transitionTo != null) resultMap[TRANSITION_TO] = transitionTo
         if (stateMetaData != null) resultMap[StateMetaData.STATE] = stateMetaData.getMapValueString()
@@ -76,6 +78,7 @@ data class ManagedIndexMetaData(
             .field(POLICY_PRIMARY_TERM, policyPrimaryTerm)
             .field(POLICY_COMPLETED, policyCompleted)
             .field(ROLLED_OVER, rolledOver)
+            .field(ROLLED_OVER_INDEX_NAME, rolledOverIndexName)
             .field(INDEX_CREATION_DATE, indexCreationDate)
             .field(TRANSITION_TO, transitionTo)
             .addObject(StateMetaData.STATE, stateMetaData, params, true)
@@ -110,6 +113,7 @@ data class ManagedIndexMetaData(
         // Only show rolled_over if we have rolled over or we are in the rollover action
         if (rolledOver == true || (actionMetaData != null && actionMetaData.name == "rollover")) {
             builder.field(ROLLED_OVER, rolledOver)
+            if (rolledOverIndexName != null) builder.field(ROLLED_OVER_INDEX_NAME, rolledOverIndexName)
         }
 
         if (indexCreationDate != null) builder.field(INDEX_CREATION_DATE, indexCreationDate)
@@ -142,6 +146,7 @@ data class ManagedIndexMetaData(
         streamOutput.writeOptionalLong(policyPrimaryTerm)
         streamOutput.writeOptionalBoolean(policyCompleted)
         streamOutput.writeOptionalBoolean(rolledOver)
+        streamOutput.writeOptionalString(rolledOverIndexName)
         streamOutput.writeOptionalLong(indexCreationDate)
         streamOutput.writeOptionalString(transitionTo)
 
@@ -172,6 +177,7 @@ data class ManagedIndexMetaData(
         const val POLICY_PRIMARY_TERM = "policy_primary_term"
         const val POLICY_COMPLETED = "policy_completed"
         const val ROLLED_OVER = "rolled_over"
+        const val ROLLED_OVER_INDEX_NAME = "rolled_over_index_name"
         const val INDEX_CREATION_DATE = "index_creation_date"
         const val TRANSITION_TO = "transition_to"
         const val INFO = "info"
@@ -185,6 +191,7 @@ data class ManagedIndexMetaData(
             val policyPrimaryTerm: Long? = si.readOptionalLong()
             val policyCompleted: Boolean? = si.readOptionalBoolean()
             val rolledOver: Boolean? = si.readOptionalBoolean()
+            val rolledOverIndexName: String? = si.readOptionalString()
             val indexCreationDate: Long? = si.readOptionalLong()
             val transitionTo: String? = si.readOptionalString()
 
@@ -207,6 +214,7 @@ data class ManagedIndexMetaData(
                 policyPrimaryTerm = policyPrimaryTerm,
                 policyCompleted = policyCompleted,
                 rolledOver = rolledOver,
+                rolledOverIndexName = rolledOverIndexName,
                 indexCreationDate = indexCreationDate,
                 transitionTo = transitionTo,
                 stateMetaData = state,
@@ -234,6 +242,7 @@ data class ManagedIndexMetaData(
             var policyPrimaryTerm: Long? = null
             var policyCompleted: Boolean? = null
             var rolledOver: Boolean? = null
+            var rolledOverIndexName: String? = null
             var indexCreationDate: Long? = null
             var transitionTo: String? = null
 
@@ -256,6 +265,7 @@ data class ManagedIndexMetaData(
                     POLICY_PRIMARY_TERM -> policyPrimaryTerm = if (xcp.currentToken() == XContentParser.Token.VALUE_NULL) null else xcp.longValue()
                     POLICY_COMPLETED -> policyCompleted = if (xcp.currentToken() == XContentParser.Token.VALUE_NULL) null else xcp.booleanValue()
                     ROLLED_OVER -> rolledOver = if (xcp.currentToken() == XContentParser.Token.VALUE_NULL) null else xcp.booleanValue()
+                    ROLLED_OVER_INDEX_NAME -> rolledOverIndexName = if (xcp.currentToken() == XContentParser.Token.VALUE_NULL) null else xcp.text()
                     INDEX_CREATION_DATE -> indexCreationDate = if (xcp.currentToken() == XContentParser.Token.VALUE_NULL) null else xcp.longValue()
                     TRANSITION_TO -> transitionTo = if (xcp.currentToken() == XContentParser.Token.VALUE_NULL) null else xcp.text()
                     StateMetaData.STATE -> {
@@ -277,23 +287,24 @@ data class ManagedIndexMetaData(
             }
 
             return ManagedIndexMetaData(
-                requireNotNull(index) { "$INDEX is null" },
-                requireNotNull(indexUuid) { "$INDEX_UUID is null" },
-                requireNotNull(policyID) { "$POLICY_ID is null" },
-                policySeqNo,
-                policyPrimaryTerm,
-                policyCompleted,
-                rolledOver,
-                indexCreationDate,
-                transitionTo,
-                state,
-                action,
-                step,
-                retryInfo,
-                info,
-                id,
-                seqNo,
-                primaryTerm
+                index = requireNotNull(index) { "$INDEX is null" },
+                indexUuid = requireNotNull(indexUuid) { "$INDEX_UUID is null" },
+                policyID = requireNotNull(policyID) { "$POLICY_ID is null" },
+                policySeqNo = policySeqNo,
+                policyPrimaryTerm = policyPrimaryTerm,
+                policyCompleted = policyCompleted,
+                rolledOver = rolledOver,
+                rolledOverIndexName = rolledOverIndexName,
+                indexCreationDate = indexCreationDate,
+                transitionTo = transitionTo,
+                stateMetaData = state,
+                actionMetaData = action,
+                stepMetaData = step,
+                policyRetryInfo = retryInfo,
+                info = info,
+                id = id,
+                seqNo = seqNo,
+                primaryTerm = primaryTerm,
             )
         }
 
@@ -323,6 +334,7 @@ data class ManagedIndexMetaData(
                 policyPrimaryTerm = map[POLICY_PRIMARY_TERM]?.toLong(),
                 policyCompleted = map[POLICY_COMPLETED]?.toBoolean(),
                 rolledOver = map[ROLLED_OVER]?.toBoolean(),
+                rolledOverIndexName = map[ROLLED_OVER_INDEX_NAME],
                 indexCreationDate = map[INDEX_CREATION_DATE]?.toLong(),
                 transitionTo = map[TRANSITION_TO],
                 stateMetaData = StateMetaData.fromManagedIndexMetaDataMap(map),

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/action/RolloverAction.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/action/RolloverAction.kt
@@ -20,6 +20,7 @@ class RolloverAction(
     val minDocs: Long?,
     val minAge: TimeValue?,
     val minPrimaryShardSize: ByteSizeValue?,
+    val copyAlias: Boolean = false,
     index: Int
 ) : Action(name, index) {
 
@@ -47,6 +48,7 @@ class RolloverAction(
         if (minDocs != null) builder.field(MIN_DOC_COUNT_FIELD, minDocs)
         if (minAge != null) builder.field(MIN_INDEX_AGE_FIELD, minAge.stringRep)
         if (minPrimaryShardSize != null) builder.field(MIN_PRIMARY_SHARD_SIZE_FIELD, minPrimaryShardSize.stringRep)
+        builder.field(COPY_ALIAS_FIELD, copyAlias)
         builder.endObject()
     }
 
@@ -55,6 +57,7 @@ class RolloverAction(
         out.writeOptionalLong(minDocs)
         out.writeOptionalTimeValue(minAge)
         out.writeOptionalWriteable(minPrimaryShardSize)
+        out.writeBoolean(copyAlias)
         out.writeInt(actionIndex)
     }
 
@@ -64,5 +67,6 @@ class RolloverAction(
         const val MIN_DOC_COUNT_FIELD = "min_doc_count"
         const val MIN_INDEX_AGE_FIELD = "min_index_age"
         const val MIN_PRIMARY_SHARD_SIZE_FIELD = "min_primary_shard_size"
+        const val COPY_ALIAS_FIELD = "copy_alias"
     }
 }

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/action/RolloverActionParser.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/action/RolloverActionParser.kt
@@ -19,9 +19,10 @@ class RolloverActionParser : ActionParser() {
         val minDocs = sin.readOptionalLong()
         val minAge = sin.readOptionalTimeValue()
         val minPrimaryShardSize = sin.readOptionalWriteable(::ByteSizeValue)
+        val copyAlias = sin.readBoolean()
         val index = sin.readInt()
 
-        return RolloverAction(minSize, minDocs, minAge, minPrimaryShardSize, index)
+        return RolloverAction(minSize, minDocs, minAge, minPrimaryShardSize, copyAlias, index)
     }
 
     override fun fromXContent(xcp: XContentParser, index: Int): Action {
@@ -29,6 +30,7 @@ class RolloverActionParser : ActionParser() {
         var minDocs: Long? = null
         var minAge: TimeValue? = null
         var minPrimaryShardSize: ByteSizeValue? = null
+        var copyAlias = false
 
         ensureExpectedToken(XContentParser.Token.START_OBJECT, xcp.currentToken(), xcp)
         while (xcp.nextToken() != XContentParser.Token.END_OBJECT) {
@@ -44,11 +46,12 @@ class RolloverActionParser : ActionParser() {
                     RolloverAction
                         .MIN_PRIMARY_SHARD_SIZE_FIELD
                 )
+                RolloverAction.COPY_ALIAS_FIELD -> copyAlias = xcp.booleanValue()
                 else -> throw IllegalArgumentException("Invalid field: [$fieldName] found in RolloverAction.")
             }
         }
 
-        return RolloverAction(minSize, minDocs, minAge, minPrimaryShardSize, index)
+        return RolloverAction(minSize, minDocs, minAge, minPrimaryShardSize, copyAlias, index)
     }
 
     override fun getActionType(): String {

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/rollover/AttemptRolloverStep.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/rollover/AttemptRolloverStep.kt
@@ -330,7 +330,7 @@ class AttemptRolloverStep(private val action: RolloverAction) : Step(name) {
             } else {
                 stepStatus = StepStatus.FAILED
                 info = listOfNotNull(
-                    "message" to getFailedCopyAliasMessage(indexName, rolledOverIndexName),
+                    "message" to getCopyAliasNotAckMessage(indexName, rolledOverIndexName),
                     if (conditions != null) "conditions" to conditions else null
                 ).toMap()
             }
@@ -389,6 +389,8 @@ class AttemptRolloverStep(private val action: RolloverAction) : Step(name) {
             "Successfully rolled over and copied alias from [index=$index] to [index=$newIndex]"
         fun getFailedCopyAliasMessage(index: String, newIndex: String) =
             "Successfully rolled over but failed to copied alias from [index=$index] to [index=$newIndex]"
+        fun getCopyAliasNotAckMessage(index: String, newIndex: String) =
+            "Successfully rolled over but copy alias from [index=$index] to [index=$newIndex] is not acknowledged"
         fun getCopyAliasIndexNotFoundMessage(newIndex: String?) =
             "Successfully rolled over but new index [index=$newIndex] not found during copy alias"
         fun getCopyAliasRolledOverIndexNotFoundMessage(index: String?) =

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/rollover/AttemptRolloverStep.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/rollover/AttemptRolloverStep.kt
@@ -291,7 +291,7 @@ class AttemptRolloverStep(private val action: RolloverAction) : Step(name) {
         if (rolledOverIndexName == null) {
             // Only in rare case when the program shut down unexpectedly before rolledOverIndexName is set or metadata corrupted
             // ISM cannot auto recover from this case, so the status is COMPLETED
-            logger.error("Cannot find rolled over index to copy aliases to")
+            logger.error("$indexName rolled over but cannot find the rolledOverIndexName to copy aliases to")
             stepStatus = StepStatus.COMPLETED
             info = listOfNotNull(
                 "message" to getCopyAliasRolledOverIndexNotFoundMessage(indexName),

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/util/ManagedIndexUtils.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/util/ManagedIndexUtils.kt
@@ -367,6 +367,7 @@ fun ManagedIndexMetaData.getCompletedManagedIndexMetaData(
     return this.copy(
         policyCompleted = updatedStepMetaData.policyCompleted,
         rolledOver = updatedStepMetaData.rolledOver,
+        rolledOverIndexName = updatedStepMetaData.rolledOverIndexName,
         actionMetaData = updatedActionMetaData,
         stepMetaData = updatedStepMetaData.stepMetaData,
         transitionTo = updatedStepMetaData.transitionTo,

--- a/src/main/resources/mappings/opendistro-ism-config.json
+++ b/src/main/resources/mappings/opendistro-ism-config.json
@@ -1,6 +1,6 @@
 {
   "_meta" : {
-    "schema_version": 18
+    "schema_version": 19
   },
   "dynamic": "strict",
   "properties": {
@@ -229,6 +229,9 @@
                     },
                     "min_primary_shard_size": {
                       "type": "keyword"
+                    },
+                    "copy_alias": {
+                      "type": "boolean"
                     }
                   }
                 },
@@ -707,6 +710,9 @@
         },
         "rolled_over": {
           "type": "boolean"
+        },
+        "rolled_over_index_name": {
+          "type": "keyword"
         },
         "index_creation_date": {
           "type": "date",

--- a/src/main/resources/mappings/opendistro-ism-history.json
+++ b/src/main/resources/mappings/opendistro-ism-history.json
@@ -1,6 +1,6 @@
 {
   "_meta" : {
-    "schema_version": 5
+    "schema_version": 6
   },
   "dynamic": "strict",
   "properties": {
@@ -36,6 +36,9 @@
         },
         "rolled_over": {
           "type": "boolean"
+        },
+        "rolled_over_index_name": {
+          "type": "keyword"
         },
         "index_creation_date": {
           "type": "date",

--- a/src/test/kotlin/org/opensearch/indexmanagement/IndexManagementRestTestCase.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/IndexManagementRestTestCase.kt
@@ -37,7 +37,7 @@ import kotlin.collections.HashSet
 
 abstract class IndexManagementRestTestCase : ODFERestTestCase() {
 
-    val configSchemaVersion = 18
+    val configSchemaVersion = 19
     val historySchemaVersion = 5
 
     // Having issues with tests leaking into other tests and mappings being incorrect and they are not caught by any pending task wait check as

--- a/src/test/kotlin/org/opensearch/indexmanagement/IndexManagementRestTestCase.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/IndexManagementRestTestCase.kt
@@ -37,7 +37,7 @@ import javax.management.remote.JMXServiceURL
 abstract class IndexManagementRestTestCase : ODFERestTestCase() {
 
     val configSchemaVersion = 19
-    val historySchemaVersion = 5
+    val historySchemaVersion = 6
 
     // Having issues with tests leaking into other tests and mappings being incorrect and they are not caught by any pending task wait check as
     // they do not go through the pending task queue. Ideally this should probably be written in a way to wait for the
@@ -168,7 +168,6 @@ abstract class IndexManagementRestTestCase : ODFERestTestCase() {
 
     override fun preserveIndicesUponCompletion(): Boolean = true
     companion object {
-        private val logger = LogManager.getLogger(IndexManagementRestTestCase::class.java)
         val isMultiNode = System.getProperty("cluster.number_of_nodes", "1").toInt() > 1
         val isBWCTest = System.getProperty("tests.plugin_bwc_version", "0") != "0"
         protected val defaultKeepIndexSet = setOf(".opendistro_security")
@@ -177,6 +176,7 @@ abstract class IndexManagementRestTestCase : ODFERestTestCase() {
          * Meant to be used in @After or @AfterClass of your feature test suite
          */
         fun wipeAllIndices(client: RestClient = adminClient(), keepIndex: Set<String> = defaultKeepIndexSet, skip: Boolean = false) {
+            val logger = LogManager.getLogger(IndexManagementRestTestCase::class.java)
             if (skip) {
                 logger.info("Skipping wipeAllIndices...")
                 return

--- a/src/test/kotlin/org/opensearch/indexmanagement/bwc/ISMBackwardsCompatibilityIT.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/bwc/ISMBackwardsCompatibilityIT.kt
@@ -1,0 +1,218 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.indexmanagement.bwc
+
+import org.junit.Assert
+import org.opensearch.common.settings.Settings
+import org.opensearch.common.unit.TimeValue
+import org.opensearch.indexmanagement.indexstatemanagement.IndexStateManagementRestTestCase
+import org.opensearch.indexmanagement.indexstatemanagement.action.RolloverAction
+import org.opensearch.indexmanagement.indexstatemanagement.model.Policy
+import org.opensearch.indexmanagement.indexstatemanagement.model.State
+import org.opensearch.indexmanagement.indexstatemanagement.randomErrorNotification
+import org.opensearch.indexmanagement.indexstatemanagement.step.rollover.AttemptRolloverStep
+import org.opensearch.indexmanagement.waitFor
+import java.time.Instant
+import java.time.temporal.ChronoUnit
+import java.util.Locale
+
+class ISMBackwardsCompatibilityIT : IndexStateManagementRestTestCase() {
+
+    private val testIndexName = javaClass.simpleName.lowercase(Locale.ROOT)
+
+    private enum class ClusterType {
+        OLD,
+        MIXED,
+        UPGRADED;
+
+        companion object {
+            fun parse(value: String): ClusterType {
+                return when (value) {
+                    "old_cluster" -> OLD
+                    "mixed_cluster" -> MIXED
+                    "upgraded_cluster" -> UPGRADED
+                    else -> throw AssertionError("Unknown cluster type: $value")
+                }
+            }
+        }
+    }
+
+    private fun getPluginUri(): String {
+        return when (CLUSTER_TYPE) {
+            ClusterType.OLD -> "_nodes/$CLUSTER_NAME-0/plugins"
+            ClusterType.MIXED -> {
+                when (System.getProperty("tests.rest.bwcsuite_round")) {
+                    "second" -> "_nodes/$CLUSTER_NAME-1/plugins"
+                    "third" -> "_nodes/$CLUSTER_NAME-2/plugins"
+                    else -> "_nodes/$CLUSTER_NAME-0/plugins"
+                }
+            }
+            ClusterType.UPGRADED -> "_nodes/plugins"
+        }
+    }
+
+    companion object {
+        private val CLUSTER_TYPE = ClusterType.parse(System.getProperty("tests.rest.bwcsuite"))
+        private val CLUSTER_NAME = System.getProperty("tests.clustername")
+    }
+
+    override fun preserveIndicesUponCompletion(): Boolean = true
+
+    override fun preserveReposUponCompletion(): Boolean = true
+
+    override fun preserveTemplatesUponCompletion(): Boolean = true
+
+    override fun restClientSettings(): Settings {
+        return Settings.builder()
+            .put(super.restClientSettings())
+            // increase the timeout here to 90 seconds to handle long waits for a green
+            // cluster health. the waits for green need to be longer than a minute to
+            // account for delayed shards
+            .put(CLIENT_SOCKET_TIMEOUT, "90s")
+            .build()
+    }
+
+    private val indexNameBase = "${testIndexName}_index_doc"
+    private val firstIndex = "$indexNameBase-1"
+    private val aliasName = "${testIndexName}_doc_alias"
+    private val policyID = "${testIndexName}_testPolicyName_doc_1"
+
+    @Throws(Exception::class)
+    @Suppress("UNCHECKED_CAST")
+    fun `test policy backwards compatibility`() {
+        val uri = getPluginUri()
+        val responseMap = getAsMap(uri)["nodes"] as Map<String, Map<String, Any>>
+        for (response in responseMap.values) {
+            val plugins = response["plugins"] as List<Map<String, Any>>
+            val pluginNames = plugins.map { plugin -> plugin ["name"] }.toSet()
+            when (CLUSTER_TYPE) {
+                ClusterType.OLD -> {
+                    assertTrue(pluginNames.contains("opendistro-index-management") || pluginNames.contains("opensearch-index-management"))
+                    createRolloverPolicy()
+
+                    val managedIndexConfig = getExistingManagedIndexConfig(firstIndex)
+                    // Change the start time so the job will trigger in 2 seconds, this will trigger the first initialization of the policy
+                    updateManagedIndexConfigStartTime(managedIndexConfig)
+                    waitFor { assertEquals(policyID, getExplainManagedIndexMetaData(firstIndex).policyID) }
+
+                    // Need to speed up to second execution where it will trigger the first execution of the action
+                    updateManagedIndexConfigStartTime(managedIndexConfig)
+                    waitFor {
+                        val info = getExplainManagedIndexMetaData(firstIndex).info as Map<String, Any?>
+                        assertEquals(
+                            "Index rollover before it met the condition.",
+                            AttemptRolloverStep.getPendingMessage(firstIndex), info["message"]
+                        )
+                        val conditions = info["conditions"] as Map<String, Any?>
+                        assertEquals(
+                            "Did not have exclusively min age and min doc count conditions",
+                            setOf(RolloverAction.MIN_INDEX_AGE_FIELD, RolloverAction.MIN_DOC_COUNT_FIELD), conditions.keys
+                        )
+                        val minAge = conditions[RolloverAction.MIN_INDEX_AGE_FIELD] as Map<String, Any?>
+                        val minDocCount = conditions[RolloverAction.MIN_DOC_COUNT_FIELD] as Map<String, Any?>
+                        assertEquals("Did not have min age condition", "2d", minAge["condition"])
+                        assertTrue("Did not have min age current", minAge["current"] is String)
+                        assertEquals("Did not have min doc count condition", 3, minDocCount["condition"])
+                        assertEquals("Did not have min doc count current", 0, minDocCount["current"])
+                    }
+                }
+                ClusterType.MIXED -> {
+                    assertTrue(pluginNames.contains("opensearch-index-management"))
+
+                    val managedIndexConfig = getExistingManagedIndexConfig(firstIndex)
+                    // Need to speed up to second execution where it will trigger the first execution of the action
+                    updateManagedIndexConfigStartTime(managedIndexConfig)
+                    waitFor {
+                        val info = getExplainManagedIndexMetaData(firstIndex).info as Map<String, Any?>
+                        assertEquals(
+                            "Index rollover before it met the condition.",
+                            AttemptRolloverStep.getPendingMessage(firstIndex), info["message"]
+                        )
+                        val conditions = info["conditions"] as Map<String, Any?>
+                        assertEquals(
+                            "Did not have exclusively min age and min doc count conditions",
+                            setOf(RolloverAction.MIN_INDEX_AGE_FIELD, RolloverAction.MIN_DOC_COUNT_FIELD), conditions.keys
+                        )
+                        val minAge = conditions[RolloverAction.MIN_INDEX_AGE_FIELD] as Map<String, Any?>
+                        val minDocCount = conditions[RolloverAction.MIN_DOC_COUNT_FIELD] as Map<String, Any?>
+                        assertEquals("Did not have min age condition", "2d", minAge["condition"])
+                        assertTrue("Did not have min age current", minAge["current"] is String)
+                        assertEquals("Did not have min doc count condition", 3, minDocCount["condition"])
+                        assertEquals("Did not have min doc count current", 0, minDocCount["current"])
+                    }
+                }
+                ClusterType.UPGRADED -> {
+                    assertTrue(pluginNames.contains("opensearch-index-management"))
+
+                    val managedIndexConfig = getExistingManagedIndexConfig(firstIndex)
+                    // Need to speed up to second execution where it will trigger the first execution of the action
+                    updateManagedIndexConfigStartTime(managedIndexConfig)
+                    waitFor {
+                        val info = getExplainManagedIndexMetaData(firstIndex).info as Map<String, Any?>
+                        assertEquals(
+                            "Index rollover before it met the condition.",
+                            AttemptRolloverStep.getPendingMessage(firstIndex), info["message"]
+                        )
+                        val conditions = info["conditions"] as Map<String, Any?>
+                        assertEquals(
+                            "Did not have exclusively min age and min doc count conditions",
+                            setOf(RolloverAction.MIN_INDEX_AGE_FIELD, RolloverAction.MIN_DOC_COUNT_FIELD), conditions.keys
+                        )
+                        val minAge = conditions[RolloverAction.MIN_INDEX_AGE_FIELD] as Map<String, Any?>
+                        val minDocCount = conditions[RolloverAction.MIN_DOC_COUNT_FIELD] as Map<String, Any?>
+                        assertEquals("Did not have min age condition", "2d", minAge["condition"])
+                        assertTrue("Did not have min age current", minAge["current"] is String)
+                        assertEquals("Did not have min doc count condition", 3, minDocCount["condition"])
+                        assertEquals("Did not have min doc count current", 0, minDocCount["current"])
+                    }
+
+                    insertSampleData(index = firstIndex, docCount = 5, delay = 0)
+
+                    // Need to speed up to second execution where it will trigger the first execution of the action
+                    updateManagedIndexConfigStartTime(managedIndexConfig)
+                    val newIndex = "$indexNameBase-000002"
+                    waitFor {
+                        val metadata = getExplainManagedIndexMetaData(firstIndex)
+                        val info = metadata.info as Map<String, Any?>
+                        assertEquals("Index did not rollover", AttemptRolloverStep.getSuccessCopyAliasMessage(firstIndex, newIndex), info["message"])
+                        val conditions = info["conditions"] as Map<String, Any?>
+                        assertEquals(
+                            "Did not have exclusively min age and min doc count conditions",
+                            setOf(RolloverAction.MIN_INDEX_AGE_FIELD, RolloverAction.MIN_DOC_COUNT_FIELD), conditions.keys
+                        )
+                        val minAge = conditions[RolloverAction.MIN_INDEX_AGE_FIELD] as Map<String, Any?>
+                        val minDocCount = conditions[RolloverAction.MIN_DOC_COUNT_FIELD] as Map<String, Any?>
+                        assertEquals("Did not have min age condition", "2d", minAge["condition"])
+                        assertTrue("Did not have min age current", minAge["current"] is String)
+                        assertEquals("Did not have min doc count condition", 3, minDocCount["condition"])
+                        assertEquals("Did not have min doc count current", 5, minDocCount["current"])
+                        assertEquals("Did not have rolled over index name", metadata.rolledOverIndexName, newIndex)
+                    }
+                    Assert.assertTrue("New rollover index does not exist.", indexExists(newIndex))
+                }
+            }
+            break
+        }
+    }
+
+    private fun createRolloverPolicy() {
+        val actionConfig = RolloverAction(null, 3, TimeValue.timeValueDays(2), null, true, 0)
+        val states = listOf(State(name = "RolloverAction", actions = listOf(actionConfig), transitions = listOf()))
+        val policy = Policy(
+            id = policyID,
+            description = "$testIndexName description",
+            schemaVersion = 1L,
+            lastUpdatedTime = Instant.now().truncatedTo(ChronoUnit.MILLIS),
+            errorNotification = randomErrorNotification(),
+            defaultState = states[0].name,
+            states = states
+        )
+
+        createPolicy(policy, policyID)
+        // create index defaults
+        createIndex(firstIndex, policyID, aliasName)
+    }
+}

--- a/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/IndexStateManagementRestTestCase.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/IndexStateManagementRestTestCase.kt
@@ -78,7 +78,7 @@ abstract class IndexStateManagementRestTestCase : IndexManagementRestTestCase() 
 
     @After
     fun clearIndicesAfterEachTest() {
-        wipeAllIndices()
+        wipeAllIndices(skip = isBWCTest)
     }
 
     val explainResponseOpendistroPolicyIdSetting = "index.opendistro.index_state_management.policy_id"
@@ -90,13 +90,11 @@ abstract class IndexStateManagementRestTestCase : IndexManagementRestTestCase() 
         updateIndexStateManagementJitterSetting(0.0)
     }
 
-    @Before
-    protected fun disableValidationService() {
+    protected open fun disableValidationService() {
         updateValidationServiceSetting(false)
     }
 
-    @Before
-    protected fun enableValidationService() {
+    protected open fun enableValidationService() {
         updateValidationServiceSetting(true)
     }
 

--- a/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/IndexStateManagementRestTestCase.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/IndexStateManagementRestTestCase.kt
@@ -24,9 +24,9 @@ import org.opensearch.common.settings.Settings
 import org.opensearch.common.unit.TimeValue
 import org.opensearch.core.xcontent.DeprecationHandler
 import org.opensearch.common.xcontent.LoggingDeprecationHandler
+import org.opensearch.common.xcontent.XContentParserUtils.ensureExpectedToken
 import org.opensearch.core.xcontent.NamedXContentRegistry
 import org.opensearch.core.xcontent.XContentParser.Token
-import org.opensearch.common.xcontent.XContentParserUtils.ensureExpectedToken
 import org.opensearch.common.xcontent.XContentType
 import org.opensearch.common.xcontent.json.JsonXContent.jsonXContent
 import org.opensearch.index.seqno.SequenceNumbers
@@ -67,6 +67,7 @@ import org.opensearch.indexmanagement.waitFor
 import org.opensearch.jobscheduler.spi.schedule.IntervalSchedule
 import org.opensearch.rest.RestRequest
 import org.opensearch.rest.RestStatus
+import org.opensearch.indexmanagement.rollup.randomTermQuery
 import org.opensearch.test.OpenSearchTestCase
 import java.io.IOException
 import java.time.Duration
@@ -238,16 +239,28 @@ abstract class IndexStateManagementRestTestCase : IndexManagementRestTestCase() 
         index: String,
         alias: String,
         action: String = "remove",
-        isWriteIndex: Boolean = false
+        isWriteIndex: Boolean = false,
+        routing: Int? = null,
+        searchRouting: Int = randomInt(),
+        indexRouting: Int = randomInt(),
+        filter: String = randomTermQuery().toString(),
+        isHidden: Boolean = randomBoolean()
     ) {
         val isWriteIndexField = if (isWriteIndex) "\",\"is_write_index\": \"$isWriteIndex" else ""
+        val params = if (action == "add" && routing != null) """
+            ,"routing": $routing,
+            "search_routing": $searchRouting,
+            "index_routing": $indexRouting,
+            "filter": $filter,
+            "is_hidden": $isHidden
+        """.trimIndent() else ""
         val body = """
             {
               "actions": [
                 {
                   "$action": {
                     "index": "$index",
-                    "alias": "$alias$isWriteIndexField"
+                    "alias": "$alias$isWriteIndexField"$params
                   }
                 }
               ]

--- a/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/action/RolloverActionIT.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/action/RolloverActionIT.kt
@@ -495,6 +495,9 @@ class RolloverActionIT : IndexStateManagementRestTestCase() {
         managedIndexConfig = getExistingManagedIndexConfig(secondIndexName)
         updateManagedIndexConfigStartTime(managedIndexConfig)
         waitFor { assertEquals(policyID, getExplainManagedIndexMetaData(secondIndexName).policyID) }
+
+        val metadata = getExplainManagedIndexMetaData(firstIndexName)
+        assertEquals(metadata.rolledOverIndexName, secondIndexName)
     }
 
     @Suppress("UNCHECKED_CAST")
@@ -588,6 +591,9 @@ class RolloverActionIT : IndexStateManagementRestTestCase() {
 
         val secondIndexName = DataStream.getDefaultBackingIndexName(dataStreamName, 2L)
         Assert.assertTrue("New rollover index does not exist.", indexExists(secondIndexName))
+
+        val metadata = getExplainManagedIndexMetaData(firstIndexName)
+        assertEquals(metadata.rolledOverIndexName, secondIndexName)
     }
 
     fun `test rollover from outside ISM doesn't fail ISM job`() {

--- a/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/AttemptRolloverStepTests.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/AttemptRolloverStepTests.kt
@@ -40,8 +40,8 @@ class AttemptRolloverStepTests : OpenSearchTestCase() {
     private val scriptService: ScriptService = mock()
     private val settings: Settings = Settings.EMPTY
     private val lockService: LockService = LockService(mock(), clusterService)
-    val oldIndexName = "old_index"
-    val newIndexName = "new_index"
+    private val oldIndexName = "old_index"
+    private val newIndexName = "new_index"
     val alias = "alias"
 
     @Before
@@ -85,6 +85,7 @@ class AttemptRolloverStepTests : OpenSearchTestCase() {
             attemptRolloverStep.preExecute(logger, context).execute()
             val updatedManagedIndexMetaData = attemptRolloverStep.getUpdatedManagedIndexMetadata(managedIndexMetaData)
             assertEquals("Step status is not FAILED", Step.StepStatus.FAILED, updatedManagedIndexMetaData.stepMetaData?.stepStatus)
+            assertEquals("message info is not matched", AttemptRolloverStep.getFailedCopyAliasMessage(oldIndexName, newIndexName), updatedManagedIndexMetaData.info?.get("message"))
         }
     }
 
@@ -108,6 +109,7 @@ class AttemptRolloverStepTests : OpenSearchTestCase() {
             attemptRolloverStep.preExecute(logger, context).execute()
             val updatedManagedIndexMetaData = attemptRolloverStep.getUpdatedManagedIndexMetadata(managedIndexMetaData)
             assertEquals("Step status is not FAILED", Step.StepStatus.FAILED, updatedManagedIndexMetaData.stepMetaData?.stepStatus)
+            assertEquals("message info is not matched", AttemptRolloverStep.getCopyAliasIndexNotFoundMessage(newIndexName), updatedManagedIndexMetaData.info?.get("message"))
         }
     }
 
@@ -131,6 +133,7 @@ class AttemptRolloverStepTests : OpenSearchTestCase() {
             attemptRolloverStep.preExecute(logger, context).execute()
             val updatedManagedIndexMetaData = attemptRolloverStep.getUpdatedManagedIndexMetadata(managedIndexMetaData)
             assertEquals("Step status is not COMPLETED", Step.StepStatus.COMPLETED, updatedManagedIndexMetaData.stepMetaData?.stepStatus)
+            assertEquals("message info is not matched", AttemptRolloverStep.getCopyAliasRolledOverIndexNotFoundMessage(oldIndexName), updatedManagedIndexMetaData.info?.get("message"))
         }
     }
 

--- a/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/AttemptRolloverStepTests.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/AttemptRolloverStepTests.kt
@@ -1,0 +1,167 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.indexmanagement.indexstatemanagement.step
+
+import com.nhaarman.mockitokotlin2.any
+import com.nhaarman.mockitokotlin2.doAnswer
+import com.nhaarman.mockitokotlin2.doReturn
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.whenever
+import kotlinx.coroutines.runBlocking
+import org.junit.Before
+import org.opensearch.action.ActionListener
+import org.opensearch.action.admin.indices.rollover.RolloverResponse
+import org.opensearch.action.support.master.AcknowledgedResponse
+import org.opensearch.client.AdminClient
+import org.opensearch.client.Client
+import org.opensearch.client.IndicesAdminClient
+import org.opensearch.cluster.ClusterState
+import org.opensearch.cluster.metadata.IndexMetadata
+import org.opensearch.cluster.service.ClusterService
+import org.opensearch.common.settings.Settings
+import org.opensearch.indexmanagement.indexstatemanagement.action.RolloverAction
+import org.opensearch.indexmanagement.indexstatemanagement.step.rollover.AttemptRolloverStep
+import org.opensearch.indexmanagement.spi.indexstatemanagement.Step
+import org.opensearch.indexmanagement.spi.indexstatemanagement.model.ManagedIndexMetaData
+import org.opensearch.indexmanagement.spi.indexstatemanagement.model.StepContext
+import org.opensearch.jobscheduler.spi.utils.LockService
+import org.opensearch.script.ScriptService
+import org.opensearch.test.OpenSearchTestCase
+import org.opensearch.cluster.metadata.Metadata
+import org.opensearch.index.IndexNotFoundException
+import org.opensearch.indexmanagement.indexstatemanagement.settings.ManagedIndexSettings
+
+class AttemptRolloverStepTests : OpenSearchTestCase() {
+
+    private val clusterService: ClusterService = mock()
+    private val scriptService: ScriptService = mock()
+    private val settings: Settings = Settings.EMPTY
+    private val lockService: LockService = LockService(mock(), clusterService)
+    val oldIndexName = "old_index"
+    val newIndexName = "new_index"
+    val alias = "alias"
+
+    @Before
+    fun setup() {
+        // mock rollover target
+        val clusterState: ClusterState = mock()
+        val metadata: Metadata = mock()
+        val indexMetadata: IndexMetadata = mock()
+        val settings = Settings.builder()
+            .put(ManagedIndexSettings.ROLLOVER_ALIAS.key, alias)
+            .put(ManagedIndexSettings.ROLLOVER_SKIP.key, false)
+            .build()
+        whenever(clusterService.state()).thenReturn(clusterState)
+        whenever(clusterState.metadata()).thenReturn(metadata)
+        whenever(clusterState.metadata).thenReturn(metadata)
+        whenever(metadata.index(oldIndexName)).thenReturn(indexMetadata)
+        whenever(metadata.indicesLookup).thenReturn(sortedMapOf())
+        whenever(indexMetadata.settings).thenReturn(settings)
+
+        // mock rolloverInfos
+        whenever(metadata.index(oldIndexName).rolloverInfos).thenReturn(mapOf(alias to mock()))
+    }
+
+    fun `test copy alias in rollover step failed`() {
+        val rolloverResponse = RolloverResponse(oldIndexName, newIndexName, mapOf(), false, true, true, true)
+        // val aliasResponse = AcknowledgedResponse(true)
+        val exception = Exception("test exception")
+        val client = getClient(getAdminClient(getIndicesAdminClient(rolloverResponse, null, null, exception)))
+
+        runBlocking {
+            val rolloverAction = RolloverAction(null, null, null, null, true, 0)
+            val managedIndexMetaData = ManagedIndexMetaData(
+                oldIndexName, "indexUuid", "policy_id",
+                null, null, null,
+                null, null, null,
+                null, null, null,
+                null, null, rolledOverIndexName = newIndexName
+            )
+            val attemptRolloverStep = AttemptRolloverStep(rolloverAction)
+            val context = StepContext(managedIndexMetaData, clusterService, client, null, null, scriptService, settings, lockService)
+            attemptRolloverStep.preExecute(logger, context).execute()
+            val updatedManagedIndexMetaData = attemptRolloverStep.getUpdatedManagedIndexMetadata(managedIndexMetaData)
+            assertEquals("Step status is not FAILED", Step.StepStatus.FAILED, updatedManagedIndexMetaData.stepMetaData?.stepStatus)
+        }
+    }
+
+    fun `test copy alias in rollover step failed with index not found exception`() {
+        val rolloverResponse = RolloverResponse(oldIndexName, newIndexName, mapOf(), false, true, true, true)
+        // val aliasResponse = AcknowledgedResponse(true)
+        val exception = IndexNotFoundException("test exception")
+        val client = getClient(getAdminClient(getIndicesAdminClient(rolloverResponse, null, null, exception)))
+
+        runBlocking {
+            val rolloverAction = RolloverAction(null, null, null, null, true, 0)
+            val managedIndexMetaData = ManagedIndexMetaData(
+                oldIndexName, "indexUuid", "policy_id",
+                null, null, null,
+                null, null, null,
+                null, null, null,
+                null, null, rolledOverIndexName = newIndexName
+            )
+            val attemptRolloverStep = AttemptRolloverStep(rolloverAction)
+            val context = StepContext(managedIndexMetaData, clusterService, client, null, null, scriptService, settings, lockService)
+            attemptRolloverStep.preExecute(logger, context).execute()
+            val updatedManagedIndexMetaData = attemptRolloverStep.getUpdatedManagedIndexMetadata(managedIndexMetaData)
+            assertEquals("Step status is not FAILED", Step.StepStatus.FAILED, updatedManagedIndexMetaData.stepMetaData?.stepStatus)
+        }
+    }
+
+    fun `test copy alias in rollover step but no rollodOverIndexName`() {
+        val rolloverResponse = RolloverResponse(oldIndexName, newIndexName, mapOf(), false, true, true, true)
+        val aliasResponse = AcknowledgedResponse(true)
+        // val exception = IndexNotFoundException("test exception")
+        val client = getClient(getAdminClient(getIndicesAdminClient(rolloverResponse, aliasResponse, null, null)))
+
+        runBlocking {
+            val rolloverAction = RolloverAction(null, null, null, null, true, 0)
+            val managedIndexMetaData = ManagedIndexMetaData(
+                oldIndexName, "indexUuid", "policy_id",
+                null, null, null,
+                null, null, null,
+                null, null, null,
+                null, null, rolledOverIndexName = null
+            )
+            val attemptRolloverStep = AttemptRolloverStep(rolloverAction)
+            val context = StepContext(managedIndexMetaData, clusterService, client, null, null, scriptService, settings, lockService)
+            attemptRolloverStep.preExecute(logger, context).execute()
+            val updatedManagedIndexMetaData = attemptRolloverStep.getUpdatedManagedIndexMetadata(managedIndexMetaData)
+            assertEquals("Step status is not COMPLETED", Step.StepStatus.COMPLETED, updatedManagedIndexMetaData.stepMetaData?.stepStatus)
+        }
+    }
+
+    private fun getClient(adminClient: AdminClient): Client = mock { on { admin() } doReturn adminClient }
+    private fun getAdminClient(indicesAdminClient: IndicesAdminClient): AdminClient = mock { on { indices() } doReturn indicesAdminClient }
+    private fun getIndicesAdminClient(
+        rolloverResponse: RolloverResponse?,
+        aliasResponse: AcknowledgedResponse?,
+        rolloverException: Exception?,
+        aliasException: Exception?,
+    ): IndicesAdminClient {
+        assertTrue(
+            "Must provide one and only one response or exception",
+            (rolloverResponse != null).xor(rolloverException != null)
+        )
+        assertTrue(
+            "Must provide one and only one response or exception",
+            (aliasResponse != null).xor(aliasException != null)
+        )
+        return mock {
+            doAnswer { invocationOnMock ->
+                val listener = invocationOnMock.getArgument<ActionListener<AcknowledgedResponse>>(1)
+                if (rolloverResponse != null) listener.onResponse(rolloverResponse)
+                else listener.onFailure(rolloverException)
+            }.whenever(this.mock).rolloverIndex(any(), any())
+
+            doAnswer { invocationOnMock ->
+                val listener = invocationOnMock.getArgument<ActionListener<AcknowledgedResponse>>(1)
+                if (aliasResponse != null) listener.onResponse(aliasResponse)
+                else listener.onFailure(aliasException)
+            }.whenever(this.mock).aliases(any(), any())
+        }
+    }
+}

--- a/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/validation/ValidateRolloverIT.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/validation/ValidateRolloverIT.kt
@@ -32,7 +32,7 @@ class ValidateRolloverIT : IndexStateManagementRestTestCase() {
         val index1 = "index-1"
         val alias1 = "x"
         val policyID = "${testIndexName}_precheck"
-        val actionConfig = RolloverAction(null, 3, TimeValue.timeValueDays(2), null, 0)
+        val actionConfig = RolloverAction(null, 3, TimeValue.timeValueDays(2), null, false, 0)
         actionConfig.configRetry = ActionRetry(0)
         val states = listOf(State(name = "RolloverAction", actions = listOf(actionConfig), transitions = listOf()))
         val policy = Policy(
@@ -84,7 +84,7 @@ class ValidateRolloverIT : IndexStateManagementRestTestCase() {
         val indexNameBase = "${testIndexName}_index"
         val index1 = "$indexNameBase-1"
         val policyID = "${testIndexName}_testPolicyName_1"
-        val actionConfig = RolloverAction(null, null, null, null, 0)
+        val actionConfig = RolloverAction(null, null, null, null, false, 0)
         val states = listOf(State(name = "RolloverAction", actions = listOf(actionConfig), transitions = listOf()))
         val policy = Policy(
             id = policyID,
@@ -131,7 +131,7 @@ class ValidateRolloverIT : IndexStateManagementRestTestCase() {
         val index1 = "index-1"
         val index2 = "index-2"
         val policyID = "${testIndexName}_precheck"
-        val actionConfig = RolloverAction(null, 3, TimeValue.timeValueDays(2), null, 0)
+        val actionConfig = RolloverAction(null, 3, TimeValue.timeValueDays(2), null, false, 0)
         actionConfig.configRetry = ActionRetry(0)
         val states = listOf(State(name = "RolloverAction", actions = listOf(actionConfig), transitions = listOf()))
         val policy = Policy(
@@ -175,7 +175,7 @@ class ValidateRolloverIT : IndexStateManagementRestTestCase() {
         val index2 = "index-2"
         val alias1 = "x"
         val policyID = "${testIndexName}_precheck"
-        val actionConfig = RolloverAction(null, 3, TimeValue.timeValueDays(2), null, 0)
+        val actionConfig = RolloverAction(null, 3, TimeValue.timeValueDays(2), null, false, 0)
         actionConfig.configRetry = ActionRetry(0)
         val states = listOf(State(name = "RolloverAction", actions = listOf(actionConfig), transitions = listOf()))
         val policy = Policy(

--- a/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/validation/ValidateRolloverTests.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/validation/ValidateRolloverTests.kt
@@ -40,7 +40,7 @@ class ValidateRolloverTests : OpenSearchTestCase() {
         ("rollover", 1, 0, false, 0, null, null),
         null, null, null
     )
-    val actionConfig = RolloverAction(null, 3, TimeValue.timeValueDays(2), null, 0)
+    val actionConfig = RolloverAction(null, 3, TimeValue.timeValueDays(2), null, false, 0)
     private val client: Client = mock()
     private val lockService: LockService = LockService(mock(), clusterService)
     private val validate = ValidateRollover(settings, clusterService, jvmService)

--- a/src/test/resources/mappings/cached-opendistro-ism-config.json
+++ b/src/test/resources/mappings/cached-opendistro-ism-config.json
@@ -1,6 +1,6 @@
 {
   "_meta" : {
-    "schema_version": 18
+    "schema_version": 19
   },
   "dynamic": "strict",
   "properties": {
@@ -229,6 +229,9 @@
                     },
                     "min_primary_shard_size": {
                       "type": "keyword"
+                    },
+                    "copy_alias": {
+                      "type": "boolean"
                     }
                   }
                 },
@@ -707,6 +710,9 @@
         },
         "rolled_over": {
           "type": "boolean"
+        },
+        "rolled_over_index_name": {
+          "type": "keyword"
         },
         "index_creation_date": {
           "type": "date",

--- a/src/test/resources/mappings/cached-opendistro-ism-history.json
+++ b/src/test/resources/mappings/cached-opendistro-ism-history.json
@@ -1,6 +1,6 @@
 {
   "_meta" : {
-    "schema_version": 5
+    "schema_version": 6
   },
   "dynamic": "strict",
   "properties": {
@@ -36,6 +36,9 @@
         },
         "rolled_over": {
           "type": "boolean"
+        },
+        "rolled_over_index_name": {
+          "type": "keyword"
         },
         "index_creation_date": {
           "type": "date",


### PR DESCRIPTION
*Issue #, if available:*
#734 

*Description of changes:*

- Introduce a new parameter `copy_alias` under rollover action, that can let user choose whether to copy the alias from old index to new index during rollover. 
  - This param is default to false because rollover API by default doesn't copy over alias.
- If enabled, copy alias will only be performed after rollover succeeded. 
- If copy alias failed, it can be retried base on the `rolled_over_index_name` saved in metadata. `rolled_over_index_name` is saved after rollover succeeded
- New fields `copy_alias`, `rolled_over_index_name` are added to the ISM config index mapping, making sure it won't be added by dynamic mapping and causes mapping conflict regression
  - `copy_alias` in policy.action will be handled during create/update policy path. The policy field in managed_index is of object type so no problem there.
  - `rolled_over_index_name` in metadata will be handled during updateMetadata in Runner, the mapping will first be updated then the metadata document will be saved.
- Add BWC to make sure it won't cause rollover job from old versions to fail. 
1. Start cluster using the old ISM, create a rollover job
2. Upgrade the cluster using the new ISM, trigger the rollover, double check the managed_index and metadata content

*CheckList:*
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/index-management/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
