### PR TITLE
Set preference to _primary when searching control-center index

### DIFF
--- a/src/main/kotlin/org/opensearch/indexmanagement/controlcenter/notification/action/get/TransportGetLRONConfigAction.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/controlcenter/notification/action/get/TransportGetLRONConfigAction.kt
@@ -94,7 +94,7 @@ class TransportGetLRONConfigAction @Inject constructor(
             val searchRequest = SearchRequest()
                 .source(searchSourceBuilder)
                 .indices(IndexManagementPlugin.CONTROL_CENTER_INDEX)
-                .preference(Preference.PRIMARY.type())
+                .preference(Preference.PRIMARY_FIRST.type())
 
             client.search(
                 searchRequest,

--- a/src/main/kotlin/org/opensearch/indexmanagement/controlcenter/notification/action/get/TransportGetLRONConfigAction.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/controlcenter/notification/action/get/TransportGetLRONConfigAction.kt
@@ -13,6 +13,7 @@ import org.opensearch.action.search.SearchResponse
 import org.opensearch.action.support.ActionFilters
 import org.opensearch.action.support.HandledTransportAction
 import org.opensearch.client.node.NodeClient
+import org.opensearch.cluster.routing.Preference
 import org.opensearch.common.inject.Inject
 import org.opensearch.common.xcontent.LoggingDeprecationHandler
 import org.opensearch.common.xcontent.XContentHelper
@@ -93,6 +94,7 @@ class TransportGetLRONConfigAction @Inject constructor(
             val searchRequest = SearchRequest()
                 .source(searchSourceBuilder)
                 .indices(IndexManagementPlugin.CONTROL_CENTER_INDEX)
+                .preference(Preference.PRIMARY.type())
 
             client.search(
                 searchRequest,


### PR DESCRIPTION
*Issue *
https://github.com/opensearch-project/index-management/issues/833

*Description of changes:*
This change is to set the query parameter `preference` to `_primary` when searching control-center index, because when indexing new documents in this index, we use RefreshPolicy.IMMEDIATE to force a refresh after the document is indexed which aims to make the new document visible immediately, but if segment replication is enabled in the control-center index, read-after-write is not guaranteed, so we need to search the primary shard only to make the document can be seen as soon as possible.

The search load on the control-center index is pretty low, it will not have some performance issue if we only search the primary shard.

*CheckList:*
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/index-management/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
