### PR TITLE
Fix auto managed index always have -2 seqNo bug

### DIFF
--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/ManagedIndexCoordinator.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/ManagedIndexCoordinator.kt
@@ -425,7 +425,7 @@ class ManagedIndexCoordinator(
             .source(
                 SearchSourceBuilder().query(
                     QueryBuilders.existsQuery(ISM_TEMPLATE_FIELD)
-                ).size(MAX_HITS)
+                ).size(MAX_HITS).seqNoAndPrimaryTerm(true)
             )
             .indices(INDEX_MANAGEMENT_INDEX)
             .preference(Preference.PRIMARY_FIRST.type())

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/transport/action/indexpolicy/TransportIndexPolicyAction.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/transport/action/indexpolicy/TransportIndexPolicyAction.kt
@@ -178,7 +178,7 @@ class TransportIndexPolicyAction @Inject constructor(
                 .source(
                     SearchSourceBuilder().query(
                         QueryBuilders.existsQuery(ISM_TEMPLATE_FIELD)
-                    ).size(MAX_HITS)
+                    ).size(MAX_HITS).seqNoAndPrimaryTerm(true)
                 )
                 .indices(IndexManagementPlugin.INDEX_MANAGEMENT_INDEX)
                 .preference(Preference.PRIMARY_FIRST.type())

--- a/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/coordinator/ManagedIndexCoordinatorIT.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/coordinator/ManagedIndexCoordinatorIT.kt
@@ -36,6 +36,8 @@ class ManagedIndexCoordinatorIT : IndexStateManagementRestTestCase() {
             assertEquals("Has incorrect policy_id", policyID, managedIndexConfig!!.policyID)
             assertEquals("Has incorrect index", index, managedIndexConfig.index)
             assertEquals("Has incorrect name", index, managedIndexConfig.name)
+            assertEquals("Has incorrect seq no", policy.seqNo, managedIndexConfig.policySeqNo)
+            assertEquals("Has incorrect primary term", policy.primaryTerm, managedIndexConfig.policyPrimaryTerm)
         }
     }
 

--- a/worksheets/ism/delete.http
+++ b/worksheets/ism/delete.http
@@ -18,16 +18,53 @@ Content-Type: application/json
       }
     ],
     "ism_template": {
-      "index_patterns": ["testdelete"],
+      "index_patterns": ["testdelete2"],
       "priority": 100
     }
   }
 }
 
-### delete index
+###
+DELETE localhost:9200/_opendistro/_ism/policies/exampledelete
+
+###
 PUT http://localhost:9200/testdelete
 Content-Type: application/json
+
+###
+DELETE http://localhost:9200/testdelete
+Content-Type: application/json
+
+### add policy api call
+POST localhost:9200/_plugins/_ism/add/testdelete
+Content-Type: application/json
+
+{
+  "policy_id": "exampledelete"
+}
 
 ### explain api call
 GET localhost:9200/_plugins/_ism/explain/testdelete?validate_action=true
 Accept: application/json
+
+### get policy call
+GET localhost:9200/.opendistro-ism-config/_doc/exampledelete
+
+### get managed index call
+GET localhost:9200/.opendistro-ism-config/_search
+Content-Type: application/json
+
+{
+  "seq_no_primary_term": true,
+  "query": {
+    "term": {
+      "managed_index.index": {
+        "value": "testdelete2"
+      }
+    }
+  }
+}
+
+###
+PUT http://localhost:9200/testdelete2
+Content-Type: application/json


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

ISM has a function to auto manage the newly created index, however, we found in this path, the managed index created is always having policy seqNo set as -2, this is because the policy search request doesn't require seqNo back so it's always default to -2. This PR adds it back

*CheckList:*
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/index-management/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
