### PR TITLE
Upload docker test cluster log

### DIFF
--- a/.github/workflows/docker-security-test-workflow.yml
+++ b/.github/workflows/docker-security-test-workflow.yml
@@ -2,13 +2,13 @@ name: Docker Security Test Workflow
 on:
   pull_request:
     branches:
-      - "*"
+      - "**"
   push:
     branches:
-      - "*"
+      - "**"
 
 jobs:
-  test:
+  docker-test:
     # This job runs on Linux
     runs-on: ubuntu-latest
     steps:
@@ -83,3 +83,17 @@ jobs:
         with:
           name: logs
           path: build/testclusters/integTest-*/logs/*
+      - name: Collect docker logs on failure
+        if: failure()
+        uses: jwalton/gh-docker-logs@v2
+        with:
+          dest: './logs'
+      - name: Tar logs
+        if: failure()
+        run: tar cvzf ./logs.tgz ./logs
+      - name: Upload logs to GitHub
+        if: failure()
+        uses: actions/upload-artifact@v2
+        with:
+          name: logs.tgz
+          path: ./logs.tgz

--- a/.github/workflows/docker-security-test-workflow.yml
+++ b/.github/workflows/docker-security-test-workflow.yml
@@ -84,15 +84,12 @@ jobs:
           name: logs
           path: build/testclusters/integTest-*/logs/*
       - name: Collect docker logs on failure
-        if: failure()
         uses: jwalton/gh-docker-logs@v2
         with:
           dest: './logs'
       - name: Tar logs
-        if: failure()
         run: tar cvzf ./logs.tgz ./logs
       - name: Upload logs to GitHub
-        if: failure()
         uses: actions/upload-artifact@v2
         with:
           name: logs.tgz

--- a/.github/workflows/docker-security-test-workflow.yml
+++ b/.github/workflows/docker-security-test-workflow.yml
@@ -91,6 +91,7 @@ jobs:
         run: tar cvzf ./logs.tgz ./logs
       - name: Upload logs to GitHub
         uses: actions/upload-artifact@v2
+        if: failure()
         with:
           name: logs.tgz
           path: ./logs.tgz

--- a/.github/workflows/multi-node-test-workflow.yml
+++ b/.github/workflows/multi-node-test-workflow.yml
@@ -3,13 +3,13 @@ name: Multi node test workflow
 on:
   pull_request:
     branches:
-      - "*"
+      - "**"
   push:
     branches:
-      - "*"
+      - "**"
 
 jobs:
-  test:
+  multi-node-test:
     # This job runs on Linux
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/security-test-workflow.yml
+++ b/.github/workflows/security-test-workflow.yml
@@ -3,13 +3,13 @@ name: Security test workflow
 on:
   pull_request:
     branches:
-      - "*"
+      - "**"
   push:
     branches:
-      - "*"
+      - "**"
 
 jobs:
-  test:
+  security-test:
     # This job runs on Linux
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/test-and-build-workflow.yml
+++ b/.github/workflows/test-and-build-workflow.yml
@@ -2,13 +2,13 @@ name: Test and Build Workflow
 on:
   pull_request:
     branches:
-      - "*"
+      - "**"
   push:
     branches:
-      - "*"
+      - "**"
 
 jobs:
-  build:
+  test-and-build:
     env:
       BUILD_ARGS: ${{ matrix.os_build_args }}
       WORKING_DIR: ${{ matrix.working_directory }}.


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Docker test cannot upload the cluster log which is the docker log if failed. Now it can. Check this result https://github.com/opensearch-project/index-management/actions/runs/6366907682/job/17285043559?pr=964

*CheckList:*
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/index-management/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
