### PR TITLE
Fixing the flaky in rollup API test

### DIFF
--- a/src/test/kotlin/org/opensearch/indexmanagement/rollup/resthandler/RestDeleteRollupActionIT.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/rollup/resthandler/RestDeleteRollupActionIT.kt
@@ -6,16 +6,14 @@
 package org.opensearch.indexmanagement.rollup.resthandler
 
 import org.opensearch.client.ResponseException
-import org.opensearch.indexmanagement.IndexManagementPlugin.Companion.INDEX_MANAGEMENT_INDEX
 import org.opensearch.indexmanagement.IndexManagementPlugin.Companion.ROLLUP_JOBS_BASE_URI
 import org.opensearch.indexmanagement.makeRequest
-import org.opensearch.indexmanagement.rollup.RollupRestTestCase
 import org.opensearch.core.rest.RestStatus
+import org.opensearch.indexmanagement.indexstatemanagement.wait
 import org.opensearch.test.junit.annotations.TestLogging
 
 @TestLogging(value = "level:DEBUG", reason = "Debugging tests")
-@Suppress("UNCHECKED_CAST")
-class RestDeleteRollupActionIT : RollupRestTestCase() {
+class RestDeleteRollupActionIT : RollupRestAPITestCase() {
 
     @Throws(Exception::class)
     fun `test deleting a rollup`() {
@@ -30,19 +28,21 @@ class RestDeleteRollupActionIT : RollupRestTestCase() {
 
     @Throws(Exception::class)
     fun `test deleting a rollup that doesn't exist in existing config index`() {
-        try {
-            createRandomRollup()
-            client().makeRequest("DELETE", "$ROLLUP_JOBS_BASE_URI/foobarbaz")
-            fail("expected 404 ResponseException")
-        } catch (e: ResponseException) {
-            assertEquals(RestStatus.NOT_FOUND, e.response.restStatus())
+        createRandomRollup()
+        wait {
+            try {
+                client().makeRequest("DELETE", "$ROLLUP_JOBS_BASE_URI/foobarbaz")
+                fail("expected 404 ResponseException")
+            } catch (e: ResponseException) {
+                assertEquals(RestStatus.NOT_FOUND, e.response.restStatus())
+            }
         }
     }
 
     @Throws(Exception::class)
     fun `test deleting a rollup that doesn't exist and config index doesnt exist`() {
         try {
-            deleteIndex(INDEX_MANAGEMENT_INDEX)
+            wipeAllIndices()
             client().makeRequest("DELETE", "$ROLLUP_JOBS_BASE_URI/foobarbaz")
             fail("expected 404 ResponseException")
         } catch (e: ResponseException) {

--- a/src/test/kotlin/org/opensearch/indexmanagement/rollup/resthandler/RestExplainRollupActionIT.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/rollup/resthandler/RestExplainRollupActionIT.kt
@@ -8,7 +8,6 @@ package org.opensearch.indexmanagement.rollup.resthandler
 import org.opensearch.client.ResponseException
 import org.opensearch.indexmanagement.IndexManagementPlugin.Companion.ROLLUP_JOBS_BASE_URI
 import org.opensearch.indexmanagement.makeRequest
-import org.opensearch.indexmanagement.rollup.RollupRestTestCase
 import org.opensearch.indexmanagement.rollup.model.RollupMetadata
 import org.opensearch.indexmanagement.rollup.randomRollup
 import org.opensearch.indexmanagement.waitFor
@@ -20,7 +19,7 @@ import java.time.temporal.ChronoUnit
 
 @TestLogging(value = "level:DEBUG", reason = "Debugging tests")
 @Suppress("UNCHECKED_CAST")
-class RestExplainRollupActionIT : RollupRestTestCase() {
+class RestExplainRollupActionIT : RollupRestAPITestCase() {
 
     @Throws(Exception::class)
     fun `test explain rollup`() {

--- a/src/test/kotlin/org/opensearch/indexmanagement/rollup/resthandler/RestGetRollupActionIT.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/rollup/resthandler/RestGetRollupActionIT.kt
@@ -8,7 +8,6 @@ package org.opensearch.indexmanagement.rollup.resthandler
 import org.opensearch.client.ResponseException
 import org.opensearch.indexmanagement.IndexManagementPlugin.Companion.ROLLUP_JOBS_BASE_URI
 import org.opensearch.indexmanagement.makeRequest
-import org.opensearch.indexmanagement.rollup.RollupRestTestCase
 import org.opensearch.indexmanagement.rollup.action.get.GetRollupsRequest.Companion.DEFAULT_SIZE
 import org.opensearch.indexmanagement.rollup.randomRollup
 import org.opensearch.core.rest.RestStatus
@@ -17,7 +16,7 @@ import java.util.Locale
 
 @TestLogging(value = "level:DEBUG", reason = "Debugging tests")
 @Suppress("UNCHECKED_CAST")
-class RestGetRollupActionIT : RollupRestTestCase() {
+class RestGetRollupActionIT : RollupRestAPITestCase() {
 
     private val testName = javaClass.simpleName.lowercase(Locale.ROOT)
 

--- a/src/test/kotlin/org/opensearch/indexmanagement/rollup/resthandler/RestIndexRollupActionIT.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/rollup/resthandler/RestIndexRollupActionIT.kt
@@ -14,7 +14,6 @@ import org.opensearch.indexmanagement.common.model.dimension.Dimension
 import org.opensearch.indexmanagement.common.model.dimension.Histogram
 import org.opensearch.indexmanagement.common.model.dimension.Terms
 import org.opensearch.indexmanagement.makeRequest
-import org.opensearch.indexmanagement.rollup.RollupRestTestCase
 import org.opensearch.indexmanagement.rollup.model.RollupMetrics
 import org.opensearch.indexmanagement.rollup.model.metric.Average
 import org.opensearch.indexmanagement.rollup.model.metric.Max
@@ -35,7 +34,7 @@ import java.util.Locale
 
 @TestLogging(value = "level:DEBUG", reason = "Debugging tests")
 @Suppress("UNCHECKED_CAST")
-class RestIndexRollupActionIT : RollupRestTestCase() {
+class RestIndexRollupActionIT : RollupRestAPITestCase() {
 
     private val testName = javaClass.simpleName.lowercase(Locale.ROOT)
 

--- a/src/test/kotlin/org/opensearch/indexmanagement/rollup/resthandler/RestStartRollupActionIT.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/rollup/resthandler/RestStartRollupActionIT.kt
@@ -14,7 +14,6 @@ import org.opensearch.indexmanagement.common.model.dimension.DateHistogram
 import org.opensearch.indexmanagement.indexstatemanagement.util.INDEX_HIDDEN
 import org.opensearch.indexmanagement.indexstatemanagement.util.INDEX_NUMBER_OF_SHARDS
 import org.opensearch.indexmanagement.makeRequest
-import org.opensearch.indexmanagement.rollup.RollupRestTestCase
 import org.opensearch.indexmanagement.rollup.model.Rollup
 import org.opensearch.indexmanagement.rollup.model.RollupMetadata
 import org.opensearch.indexmanagement.rollup.randomRollup
@@ -25,7 +24,7 @@ import java.time.Instant
 import java.time.temporal.ChronoUnit
 import java.util.Locale
 
-class RestStartRollupActionIT : RollupRestTestCase() {
+class RestStartRollupActionIT : RollupRestAPITestCase() {
 
     private val testName = javaClass.simpleName.lowercase(Locale.ROOT)
 

--- a/src/test/kotlin/org/opensearch/indexmanagement/rollup/resthandler/RestStopRollupActionIT.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/rollup/resthandler/RestStopRollupActionIT.kt
@@ -5,7 +5,6 @@
 
 package org.opensearch.indexmanagement.rollup.resthandler
 
-import org.junit.After
 import org.opensearch.client.ResponseException
 import org.opensearch.common.settings.Settings
 import org.opensearch.indexmanagement.IndexManagementIndices
@@ -17,7 +16,6 @@ import org.opensearch.indexmanagement.indexstatemanagement.util.INDEX_HIDDEN
 import org.opensearch.indexmanagement.indexstatemanagement.util.INDEX_NUMBER_OF_SHARDS
 import org.opensearch.indexmanagement.makeRequest
 import org.opensearch.indexmanagement.randomInstant
-import org.opensearch.indexmanagement.rollup.RollupRestTestCase
 import org.opensearch.indexmanagement.rollup.model.Rollup
 import org.opensearch.indexmanagement.rollup.model.RollupMetadata
 import org.opensearch.indexmanagement.rollup.randomRollup
@@ -28,17 +26,9 @@ import java.time.Instant
 import java.time.temporal.ChronoUnit
 import java.util.Locale
 
-class RestStopRollupActionIT : RollupRestTestCase() {
+class RestStopRollupActionIT : RollupRestAPITestCase() {
 
     private val testName = javaClass.simpleName.lowercase(Locale.ROOT)
-
-    @After
-    fun clearIndicesAfterEachTest() {
-        // Flaky could happen if config index not deleted
-        // metadata creation could cause the mapping to be auto set to
-        //  a wrong type, namely, [rollup_metadata.continuous.next_window_end_time] to long
-        wipeAllIndices()
-    }
 
     @Throws(Exception::class)
     fun `test stopping a started rollup`() {

--- a/src/test/kotlin/org/opensearch/indexmanagement/rollup/resthandler/RollupRestAPITestCase.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/rollup/resthandler/RollupRestAPITestCase.kt
@@ -1,0 +1,19 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.indexmanagement.rollup.resthandler
+
+import org.junit.After
+import org.opensearch.indexmanagement.rollup.RollupRestTestCase
+
+abstract class RollupRestAPITestCase : RollupRestTestCase() {
+    @After
+    fun clearIndicesAfterEachTest() {
+        // For API tests, flaky could happen if config index not deleted
+        // metadata creation could cause the mapping to be auto set to
+        //  a wrong type, namely, [rollup_metadata.continuous.next_window_end_time] to long
+        wipeAllIndices()
+    }
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Rollup API tests have flaky because the rollup created is not cleaned before the next test starts, and when the next test starts, it cannot create rollup since previous rollup updates with wrong mapping.

*CheckList:*
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/index-management/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
