### PR TITLE
Set the rollover action to idempotent

### DIFF
--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/rollover/AttemptRolloverStep.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/rollover/AttemptRolloverStep.kt
@@ -366,7 +366,7 @@ class AttemptRolloverStep(private val action: RolloverAction) : Step(name) {
         info = mutableInfo.toMap()
     }
 
-    override fun isIdempotent(): Boolean = false
+    override fun isIdempotent(): Boolean = true
 
     @Suppress("TooManyFunctions")
     companion object {

--- a/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/action/RolloverActionIT.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/action/RolloverActionIT.kt
@@ -27,6 +27,7 @@ import org.opensearch.indexmanagement.spi.indexstatemanagement.model.ActionRetry
 import org.opensearch.indexmanagement.waitFor
 import org.opensearch.rest.RestRequest
 import org.opensearch.core.rest.RestStatus
+import org.opensearch.indexmanagement.IndexManagementPlugin.Companion.INDEX_MANAGEMENT_INDEX
 import org.opensearch.test.OpenSearchTestCase
 import java.time.Instant
 import java.time.temporal.ChronoUnit
@@ -732,5 +733,66 @@ class RolloverActionIT : IndexStateManagementRestTestCase() {
         }
         Assert.assertEquals(alias.containsKey("test_alias2"), true)
         Assert.assertEquals(alias.containsKey("test_alias3"), true)
+    }
+
+    fun `test rollover detects transient failure and continues executing`() {
+        val aliasName = "${testIndexName}_alias"
+        val indexNameBase = "${testIndexName}_index"
+        val firstIndex = "$indexNameBase-1"
+        val policyID = "${testIndexName}_testPolicyName_1"
+        val actionConfig = RolloverAction(null, 1, null, null, false, 0)
+        val states = listOf(State(name = "RolloverAction", actions = listOf(actionConfig), transitions = listOf()))
+        val policy = Policy(
+            id = policyID,
+            description = "$testIndexName description",
+            schemaVersion = 1L,
+            lastUpdatedTime = Instant.now().truncatedTo(ChronoUnit.MILLIS),
+            errorNotification = randomErrorNotification(),
+            defaultState = states[0].name,
+            states = states
+        )
+
+        createPolicy(policy, policyID)
+        createIndex(firstIndex, policyID, aliasName)
+
+        val managedIndexConfig = getExistingManagedIndexConfig(firstIndex)
+
+        // Change the start time so the job will trigger in 2 seconds, this will trigger the first initialization of the policy
+        updateManagedIndexConfigStartTime(managedIndexConfig)
+        waitFor { assertEquals(policyID, getExplainManagedIndexMetaData(firstIndex).policyID) }
+
+        // Insert data to trigger rollover
+        insertSampleData(index = firstIndex, docCount = 5, delay = 0)
+        // Need to speed up to second execution where it will trigger the attempt rollover step
+        updateManagedIndexConfigStartTime(managedIndexConfig)
+        waitFor {
+            val info = getExplainManagedIndexMetaData(firstIndex).info as Map<String, Any?>
+            assertEquals("Index did not rollover.", AttemptRolloverStep.getSuccessMessage(firstIndex), info["message"])
+        }
+        // Manually produce transaction failure
+        val response = client().makeRequest(
+            "POST", "$INDEX_MANAGEMENT_INDEX/_update/${managedIndexConfig.id}%23metadata",
+            StringEntity(
+                "{\n" +
+                    "    \"script\": {\n" +
+                    "        \"source\": \"ctx._source.managed_index_metadata.step.step_status = params.step_status\",\n" +
+                    "        \"lang\": \"painless\",\n" +
+                    "        \"params\": {\n" +
+                    "            \"step_status\": \"starting\"\n" +
+                    "    }\n" +
+                    "  }\n" +
+                    "}",
+                ContentType.APPLICATION_JSON
+            )
+        )
+        assertEquals("Request failed", RestStatus.OK, response.restStatus())
+
+        // Execute again to see the transaction failure
+        updateManagedIndexConfigStartTime(managedIndexConfig)
+        waitFor {
+            val metadata = getExplainManagedIndexMetaData(firstIndex)
+            assertEquals("Executing the wrong step", "attempt_rollover", metadata.stepMetaData?.name)
+            assertEquals("rollover step did not continue executing after detecting the transient failure.", Step.StepStatus.COMPLETED, metadata.stepMetaData?.stepStatus)
+        }
     }
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

The rollover action could fail with message `Previous action was not able to update IndexMetaData`. 
This failure was because ISM failed to save metadata at the end of a transaction run. 

### Background
ISM manages each index by using a background job running in certain frequency. For each background job run, ISM makes it transactional by setting the metadata to `STARTING` status before executing the action, and resets the `STARTING` status after execution. If the reset failed to be saved into ISM system index and the action to be executed is not idempotent, then at next run, ISM detected this as a transaction failure and disabled/stopped the background job for this managed index. After this point, users need to use ISM retry API to continue the ISM running after confirming whether the action has been executed or not. Rollover is currently treated as a non-idempotent action because calling rollover multiple times could create multiple new indexes.

### Why change rollover to idempotent
We are looking at the situation when ISM cannot figure out what's the result of previous run. For rollover, there are 2 possibilities.
1. rollover succeed
2. rollover failed or didn't happen
For case 1, the rolloverInfo would be saved in cluster state, while it wouldn't be saved for case 2.
And since we already have the logic to check the rolloverInfo, the attempt rollover step already can decide what to do depending on that. That makes this step idempotent. 
https://github.com/opensearch-project/index-management/blob/bc3c3f3b7280536238f236931fa3bb2460f8c295/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/rollover/AttemptRolloverStep.kt#L60-L67

### Testing
Add one IT that re-produce the transaction failure state, and see ISM can continue the rollover action without failing.

*CheckList:*
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/index-management/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
