### PR TITLE
Support switch aliases in shrink action.

### DIFF
--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/action/ShrinkAction.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/action/ShrinkAction.kt
@@ -28,6 +28,7 @@ class ShrinkAction(
     val percentageOfSourceShards: Double?,
     val targetIndexTemplate: Script?,
     val aliases: List<Alias>?,
+    val switchAliases: Boolean = false,
     val forceUnsafe: Boolean?,
     index: Int
 ) : Action(name, index) {
@@ -104,6 +105,7 @@ class ShrinkAction(
         if (percentageOfSourceShards != null) builder.field(PERCENTAGE_OF_SOURCE_SHARDS_FIELD, percentageOfSourceShards)
         if (targetIndexTemplate != null) builder.field(TARGET_INDEX_TEMPLATE_FIELD, targetIndexTemplate)
         if (aliases != null) { builder.aliasesField(aliases) }
+        builder.field(SWITCH_ALIASES, switchAliases)
         if (forceUnsafe != null) builder.field(FORCE_UNSAFE_FIELD, forceUnsafe)
         builder.endObject()
     }
@@ -120,6 +122,7 @@ class ShrinkAction(
         } else {
             out.writeBoolean(false)
         }
+        out.writeBoolean(switchAliases)
         out.writeOptionalBoolean(forceUnsafe)
         out.writeInt(actionIndex)
     }
@@ -131,6 +134,7 @@ class ShrinkAction(
         const val MAX_SHARD_SIZE_FIELD = "max_shard_size"
         const val TARGET_INDEX_TEMPLATE_FIELD = "target_index_name_template"
         const val ALIASES_FIELD = "aliases"
+        const val SWITCH_ALIASES = "switch_aliases"
         const val FORCE_UNSAFE_FIELD = "force_unsafe"
         const val LOCK_SOURCE_JOB_ID = "shrink-node_name"
         fun getSecurityFailureMessage(failure: String) = "Shrink action failed because of missing permissions: $failure"

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/shrink/WaitForShrinkStep.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/shrink/WaitForShrinkStep.kt
@@ -5,6 +5,8 @@
 
 package org.opensearch.indexmanagement.indexstatemanagement.step.shrink
 
+import org.opensearch.action.admin.indices.alias.IndicesAliasesRequest
+import org.opensearch.action.admin.indices.alias.IndicesAliasesRequest.AliasActions
 import org.opensearch.action.admin.indices.stats.IndicesStatsRequest
 import org.opensearch.action.admin.indices.stats.IndicesStatsResponse
 import org.opensearch.action.support.master.AcknowledgedResponse
@@ -12,13 +14,14 @@ import org.opensearch.client.Client
 import org.opensearch.cluster.service.ClusterService
 import org.opensearch.common.settings.Settings
 import org.opensearch.indexmanagement.indexstatemanagement.action.ShrinkAction
-import org.opensearch.indexmanagement.indexstatemanagement.util.resetReadOnlyAndRouting
 import org.opensearch.indexmanagement.indexstatemanagement.util.deleteShrinkLock
 import org.opensearch.indexmanagement.indexstatemanagement.util.getActionStartTime
 import org.opensearch.indexmanagement.indexstatemanagement.util.issueUpdateSettingsRequest
+import org.opensearch.indexmanagement.indexstatemanagement.util.resetReadOnlyAndRouting
 import org.opensearch.indexmanagement.opensearchapi.suspendUntil
 import org.opensearch.indexmanagement.spi.indexstatemanagement.model.ActionProperties
 import org.opensearch.indexmanagement.spi.indexstatemanagement.model.ManagedIndexMetaData
+import org.opensearch.indexmanagement.spi.indexstatemanagement.model.ShrinkActionProperties
 import org.opensearch.indexmanagement.spi.indexstatemanagement.model.StepContext
 import org.opensearch.indexmanagement.spi.indexstatemanagement.model.StepMetaData
 import java.time.Duration
@@ -45,8 +48,15 @@ class WaitForShrinkStep(private val action: ShrinkAction) : ShrinkStep(name, tru
         if (!deleteShrinkLock(localShrinkActionProperties, context.lockService, logger)) {
             logger.error("Failed to delete Shrink action lock on node [${localShrinkActionProperties.nodeName}]")
         }
-        stepStatus = StepStatus.COMPLETED
-        info = mapOf("message" to SUCCESS_MESSAGE)
+
+        if (switchAliases(context, localShrinkActionProperties)) {
+            stepStatus = StepStatus.COMPLETED
+            info = mapOf("message" to SUCCESS_MESSAGE)
+        } else {
+            stepStatus = StepStatus.FAILED
+            info = mapOf("message" to "Shrink failed due to aliases switch failure.")
+        }
+
         return this
     }
 
@@ -88,6 +98,64 @@ class WaitForShrinkStep(private val action: ShrinkAction) : ShrinkStep(name, tru
         } else {
             info = mapOf("message" to getDelayedMessage(targetIndex))
             stepStatus = StepStatus.CONDITION_NOT_MET
+        }
+    }
+
+    private suspend fun switchAliases(context: StepContext, shrinkActionProperties: ShrinkActionProperties): Boolean {
+
+        val sourceIndexName = context.metadata.index
+        val targetIndexName = shrinkActionProperties.targetIndexName
+
+        if (!action.switchAliases) {
+            logger.info("Switch aliases disabled from [$sourceIndexName] to [$targetIndexName].")
+            return true
+        }
+
+        logger.info("Switching aliases from [$sourceIndexName] to [$targetIndexName].")
+
+        val targetIndexAliasesNames = context
+            .clusterService
+            .state()
+            .metadata()
+            .index(targetIndexName)
+            .aliases
+            .keys
+        val sourceIndexAliases = context
+            .clusterService
+            .state()
+            .metadata()
+            .index(sourceIndexName)
+            .aliases
+            .values
+
+        val req = IndicesAliasesRequest()
+        sourceIndexAliases.map { it.alias }.forEach { req.addAliasAction(AliasActions(AliasActions.Type.REMOVE).index(sourceIndexName).alias(it)) }
+
+        sourceIndexAliases
+            .filterNot { targetIndexAliasesNames.contains(it.alias) }
+            .map {
+                AliasActions(AliasActions.Type.ADD)
+                    .index(targetIndexName)
+                    .alias(it.alias)
+                    .filter(it.filter?.string())
+                    .indexRouting(it.indexRouting)
+                    .searchRouting(it.searchRouting)
+                    .isHidden(it.isHidden)
+                    .writeIndex(it.writeIndex())
+            }
+            .forEach { req.addAliasAction(it) }
+
+        return try {
+            val response: AcknowledgedResponse = context.client.admin().indices().suspendUntil { aliases(req, it) }
+            if (response.isAcknowledged) {
+                logger.info("Aliases switched successfully from [$sourceIndexName] to [$targetIndexName].")
+            } else {
+                logger.error("Switching aliases from [$sourceIndexName] to [$targetIndexName] failed.")
+            }
+            response.isAcknowledged
+        } catch (e: Exception) {
+            logger.error("Switching aliases from [$sourceIndexName] to [$targetIndexName] failed due to exception.", e)
+            false
         }
     }
 

--- a/src/main/resources/mappings/opendistro-ism-config.json
+++ b/src/main/resources/mappings/opendistro-ism-config.json
@@ -1,6 +1,6 @@
 {
   "_meta" : {
-    "schema_version": 20
+    "schema_version": 21
   },
   "dynamic": "strict",
   "properties": {
@@ -550,6 +550,9 @@
                     "aliases": {
                       "type": "object",
                       "enabled": false
+                    },
+                    "switch_aliases": {
+                      "type": "boolean"
                     },
                     "force_unsafe": {
                       "type": "boolean"

--- a/src/test/kotlin/org/opensearch/indexmanagement/IndexManagementRestTestCase.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/IndexManagementRestTestCase.kt
@@ -42,7 +42,7 @@ import javax.management.remote.JMXServiceURL
 
 abstract class IndexManagementRestTestCase : ODFERestTestCase() {
 
-    val configSchemaVersion = 20
+    val configSchemaVersion = 21
     val historySchemaVersion = 7
 
     // Having issues with tests leaking into other tests and mappings being incorrect and they are not caught by any pending task wait check as

--- a/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/TestHelpers.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/TestHelpers.kt
@@ -152,16 +152,17 @@ fun randomShrinkAction(
     percentageOfSourceShards: Double? = null,
     targetIndexTemplate: Script? = if (randomBoolean()) randomTemplateScript(randomAlphaOfLength(10)) else null,
     aliases: List<Alias>? = if (randomBoolean()) randomList(10) { randomAlias() } else null,
+    switchAliases: Boolean = randomBoolean(),
     forceUnsafe: Boolean? = if (randomBoolean()) randomBoolean() else null
 ): ShrinkAction {
     if (numNewShards == null && maxShardSize == null && percentageOfSourceShards == null) {
         when (randomInt(2)) {
-            0 -> return ShrinkAction(abs(randomInt()) + 1, null, null, targetIndexTemplate, aliases, forceUnsafe, 0)
-            1 -> return ShrinkAction(null, randomByteSizeValue(), null, targetIndexTemplate, aliases, forceUnsafe, 0)
-            2 -> return ShrinkAction(null, null, randomDoubleBetween(0.0, 1.0, true), targetIndexTemplate, aliases, forceUnsafe, 0)
+            0 -> return ShrinkAction(abs(randomInt()) + 1, null, null, targetIndexTemplate, aliases, switchAliases, forceUnsafe, 0)
+            1 -> return ShrinkAction(null, randomByteSizeValue(), null, targetIndexTemplate, aliases, switchAliases, forceUnsafe, 0)
+            2 -> return ShrinkAction(null, null, randomDoubleBetween(0.0, 1.0, true), targetIndexTemplate, aliases, switchAliases, forceUnsafe, 0)
         }
     }
-    return ShrinkAction(numNewShards, maxShardSize, percentageOfSourceShards, targetIndexTemplate, aliases, forceUnsafe, 0)
+    return ShrinkAction(numNewShards, maxShardSize, percentageOfSourceShards, targetIndexTemplate, aliases, switchAliases, forceUnsafe, 0)
 }
 
 fun randomReadOnlyActionConfig(): ReadOnlyAction {

--- a/src/test/resources/mappings/cached-opendistro-ism-config.json
+++ b/src/test/resources/mappings/cached-opendistro-ism-config.json
@@ -1,6 +1,6 @@
 {
   "_meta" : {
-    "schema_version": 20
+    "schema_version": 21
   },
   "dynamic": "strict",
   "properties": {
@@ -550,6 +550,9 @@
                     "aliases": {
                       "type": "object",
                       "enabled": false
+                    },
+                    "switch_aliases": {
+                      "type": "boolean"
                     },
                     "force_unsafe": {
                       "type": "boolean"


### PR DESCRIPTION
*Issue #676 *

*Description of changes:*
During shrink action aliases from sources will be switched (i.e. copied/moved) to the target index.
To control the above(i.e. enable/disable), a dedicated boolean property [swithc_aliases] was added to the shrink action.
Switch aliases will only happen if the [swithc_aliases] flag is set to [true]. The default is set to [false].

In policy in shrink action, a user may also specify aliases to be added to the target index. 
If there is a coincidence between the source-index-alias and the shrink-action-alias, precedence is given to the shrink-action-alias, and the target index will gain the alias from the shrink action.

*CheckList:*
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/index-management/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
