### PR TITLE
added type check for pipeline aggregator types in Transform initializ…

### DIFF
--- a/src/main/kotlin/org/opensearch/indexmanagement/transform/model/Transform.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/transform/model/Transform.kt
@@ -77,6 +77,9 @@ data class Transform(
         aggregations.aggregatorFactories.forEach {
             require(supportedAggregations.contains(it.type)) { "Unsupported aggregation [${it.type}]" }
         }
+        aggregations.pipelineAggregatorFactories.forEach {
+            require(supportedAggregations.contains(it.type)) { "Unsupported aggregation [${it.type}]" }
+        }
         when (jobSchedule) {
             is CronSchedule -> {
                 // Job scheduler already correctly throws errors for this


### PR DESCRIPTION
…ation

*Issue #, if available:*
#671

*Description of changes:*
Error being fixed: the init block of ``Transform.kt`` did not check for pipeline type aggregator factories, which meant it was possible for unsupported aggregation types to be passed in for a transform job without raising an exception.

Changes made: Added a new require statement that checks aggregations.pipelineAggregatorFactories for unsupported types.

*CheckList:*
- [ x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/index-management/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
