### PR TITLE
Improve security plugin enabling check

### DIFF
--- a/.github/workflows/docker-security-test-workflow.yml
+++ b/.github/workflows/docker-security-test-workflow.yml
@@ -66,9 +66,10 @@ jobs:
       - name: Run Index Management Test for security enabled test cases
         if: env.imagePresent == 'true'
         run: |
-          cluster_running=`curl -XGET https://localhost:9200/_cat/plugins -u admin:admin --insecure`
-          echo $cluster_running
-          security=`curl -XGET https://localhost:9200/_cat/plugins -u admin:admin --insecure |grep opensearch-security|wc -l`
+          container_id=`docker ps -q`
+          plugins=`docker exec $container_id /usr/share/opensearch/bin/opensearch-plugin list`
+          echo "plugins: $plugins"
+          security=`echo $plugins | grep opensearch-security | wc -l`
           echo $security
           if [ $security -gt 0 ]
           then


### PR DESCRIPTION
*Issue #, if available:*


*Description of changes:*

If security plugins is not installed, endpoint https://localhost:9200 is not accessible. In this case, the way we determine security is enabled or not is not valid.
```shell
cluster_running=`curl -XGET https://localhost:9200/_cat/plugins -u admin:admin --insecure`
echo $cluster_running
security=`curl -XGET https://localhost:9200/_cat/plugins -u admin:admin --insecure |grep opensearch-security|wc -l`
echo $security
if [ $security -gt 0 ]
```
change it to below is more reliable
```shell
container_id=`docker ps -q`
security =`docker exec $container_id /usr/share/opensearch/bin/opensearch-plugin list | grep opensearch-security | wc -l`
```

*CheckList:*
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/index-management/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
