### PR TITLE
Interval schedule should take start time from the request, should not…

### DIFF
--- a/src/main/kotlin/org/opensearch/indexmanagement/rollup/model/Rollup.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/rollup/model/Rollup.kt
@@ -330,7 +330,7 @@ data class Rollup(
             // TODO: Make startTime public in Job Scheduler so we can just directly check the value
             if (seqNo == SequenceNumbers.UNASSIGNED_SEQ_NO || primaryTerm == SequenceNumbers.UNASSIGNED_PRIMARY_TERM) {
                 if (schedule is IntervalSchedule) {
-                    schedule = IntervalSchedule(schedule.startTime, schedule.interval, schedule.unit, schedule.delay ?: 0)
+                    schedule = IntervalSchedule(schedule.startTime?: Instant.now(), schedule.interval, schedule.unit, schedule.delay ?: 0)
                 }
             }
             return Rollup(

--- a/src/main/kotlin/org/opensearch/indexmanagement/rollup/model/Rollup.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/rollup/model/Rollup.kt
@@ -330,7 +330,7 @@ data class Rollup(
             // TODO: Make startTime public in Job Scheduler so we can just directly check the value
             if (seqNo == SequenceNumbers.UNASSIGNED_SEQ_NO || primaryTerm == SequenceNumbers.UNASSIGNED_PRIMARY_TERM) {
                 if (schedule is IntervalSchedule) {
-                    schedule = IntervalSchedule(schedule.startTime ?: Instant.now(), schedule.interval, schedule.unit, schedule.delay ?: 0)
+                    schedule = IntervalSchedule(schedule.startTime, schedule.interval, schedule.unit, schedule.delay ?: 0)
                 }
             }
             return Rollup(

--- a/src/main/kotlin/org/opensearch/indexmanagement/rollup/model/Rollup.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/rollup/model/Rollup.kt
@@ -330,7 +330,7 @@ data class Rollup(
             // TODO: Make startTime public in Job Scheduler so we can just directly check the value
             if (seqNo == SequenceNumbers.UNASSIGNED_SEQ_NO || primaryTerm == SequenceNumbers.UNASSIGNED_PRIMARY_TERM) {
                 if (schedule is IntervalSchedule) {
-                    schedule = IntervalSchedule(schedule.startTime?: Instant.now(), schedule.interval, schedule.unit, schedule.delay ?: 0)
+                    schedule = IntervalSchedule(schedule.startTime ?: Instant.now(), schedule.interval, schedule.unit, schedule.delay ?: 0)
                 }
             }
             return Rollup(

--- a/src/main/kotlin/org/opensearch/indexmanagement/rollup/model/Rollup.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/rollup/model/Rollup.kt
@@ -330,7 +330,7 @@ data class Rollup(
             // TODO: Make startTime public in Job Scheduler so we can just directly check the value
             if (seqNo == SequenceNumbers.UNASSIGNED_SEQ_NO || primaryTerm == SequenceNumbers.UNASSIGNED_PRIMARY_TERM) {
                 if (schedule is IntervalSchedule) {
-                    schedule = IntervalSchedule(Instant.now(), schedule.interval, schedule.unit, schedule.delay ?: 0)
+                    schedule = IntervalSchedule(schedule.startTime, schedule.interval, schedule.unit, schedule.delay ?: 0)
                 }
             }
             return Rollup(

--- a/src/main/kotlin/org/opensearch/indexmanagement/transform/model/Transform.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/transform/model/Transform.kt
@@ -387,7 +387,7 @@ data class Transform(
             if (seqNo == SequenceNumbers.UNASSIGNED_SEQ_NO || primaryTerm == SequenceNumbers.UNASSIGNED_PRIMARY_TERM) {
                 // we instantiate the start time
                 if (schedule is IntervalSchedule) {
-                    schedule = IntervalSchedule(schedule.startTime?: Instant.now(), schedule.interval, schedule.unit)
+                    schedule = IntervalSchedule(schedule.startTime ?: Instant.now(), schedule.interval, schedule.unit)
                 }
 
                 // we clear out metadata if its a new job

--- a/src/main/kotlin/org/opensearch/indexmanagement/transform/model/Transform.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/transform/model/Transform.kt
@@ -387,7 +387,7 @@ data class Transform(
             if (seqNo == SequenceNumbers.UNASSIGNED_SEQ_NO || primaryTerm == SequenceNumbers.UNASSIGNED_PRIMARY_TERM) {
                 // we instantiate the start time
                 if (schedule is IntervalSchedule) {
-                    schedule = IntervalSchedule(schedule.startTime ?: Instant.now(), schedule.interval, schedule.unit)
+                    schedule = IntervalSchedule(schedule.startTime, schedule.interval, schedule.unit)
                 }
 
                 // we clear out metadata if its a new job

--- a/src/main/kotlin/org/opensearch/indexmanagement/transform/model/Transform.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/transform/model/Transform.kt
@@ -387,7 +387,7 @@ data class Transform(
             if (seqNo == SequenceNumbers.UNASSIGNED_SEQ_NO || primaryTerm == SequenceNumbers.UNASSIGNED_PRIMARY_TERM) {
                 // we instantiate the start time
                 if (schedule is IntervalSchedule) {
-                    schedule = IntervalSchedule(schedule.startTime, schedule.interval, schedule.unit)
+                    schedule = IntervalSchedule(schedule.startTime?: Instant.now(), schedule.interval, schedule.unit)
                 }
 
                 // we clear out metadata if its a new job


### PR DESCRIPTION
Interval schedule should take `start_time` from the request, and should not set it to the current time of request execution.

*Issue #1039*

*Description of changes:*
When creating a `Rollup` with interval schedule defined, `schedule.start_time` will be assigned a value defined in the request. Before the fix  `schedule.start_time` was assigned current time of create Rollup request execution.

*CheckList:*
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/index-management/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
