### PR TITLE
Updates integTest behavior to run against local and remote cluster

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -527,7 +527,7 @@ integTest {
     systemProperty "https", System.getProperty("https")
     systemProperty "security", System.getProperty("security")
     systemProperty "user", System.getProperty("user", "admin")
-    systemProperty "password", System.getProperty("password", "admin")
+    systemProperty "password", "admin" // defaulting to admin since security plugin's demo config tool is not used
     // Tell the test JVM if the cluster JVM is running under a debugger so that tests can use longer timeouts for
     // requests. The 'doFirst' delays reading the debug setting on the cluster till execution time.
     doFirst {
@@ -574,6 +574,8 @@ integTest {
     // remove from running with remote cluster
     if (usingRemoteCluster) {
         exclude 'org/opensearch/indexmanagement/controlcenter/notification/filter/NotificationActionListenerIT.class'
+        // a remote cluster requires a custom password to be passed. This password must be a custom password.
+        systemProperty "password", System.getProperty("password", "myStrongPassword123!") 
     }
 
     if (project.hasProperty('includeTests')) {


### PR DESCRIPTION
- related to: https://github.com/opensearch-project/index-management/issues/1086#issuecomment-1927084271

Recent [CI build](https://build.ci.opensearch.org/blue/rest/organizations/jenkins/pipelines/integ-test/runs/7595/nodes/98/steps/578/log/?start=0) failed with:
```

* Where:
Build file '/tmp/tmp19lh39y9/index-management/build.gradle' line: 441

* What went wrong:
Execution failed for task ':integTest'.
> `cluster{::integTest}` failed to wait for cluster health yellow after 40 SECONDS
    Unexpected end of file from server

* Try:
> Run with --stacktrace option to get the stack trace.
> Run with --info or --debug option to get more log output.
> Run with --scan to get full insights.
> Get more help at https://help.gradle.org.

BUILD FAILED in 6m 23s

```

This is because the previous PR: https://github.com/opensearch-project/index-management/pull/1076/ assumed that the password will always be `admin` for `integTest` task since a custom configuration is applied for setup. However, that is not the case when `integTest` is triggered via opensearch-build as it uses a remote-cluster.
Hence, this PR defaults `integTest` task user password to `admin` for local cluster and conditionally accepts the password if running against remote cluster.


*CheckList:*
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/index-management/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
