### PR TITLE
Fixes password assignment for integTest when using remote cluster

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -527,7 +527,8 @@ integTest {
     systemProperty "https", System.getProperty("https")
     systemProperty "security", System.getProperty("security")
     systemProperty "user", System.getProperty("user", "admin")
-    systemProperty "password", "admin" // defaulting to admin since security plugin's demo config tool is not used
+    // a remote cluster requires a custom password to be passed. This password must be a custom password.
+    systemProperty "password", usingRemoteCluster ? System.getProperty("password", "myStrongPassword123!") : "admin" // defaulting to admin since security plugin's demo config tool is not used
     // Tell the test JVM if the cluster JVM is running under a debugger so that tests can use longer timeouts for
     // requests. The 'doFirst' delays reading the debug setting on the cluster till execution time.
     doFirst {
@@ -574,8 +575,6 @@ integTest {
     // remove from running with remote cluster
     if (usingRemoteCluster) {
         exclude 'org/opensearch/indexmanagement/controlcenter/notification/filter/NotificationActionListenerIT.class'
-        // a remote cluster requires a custom password to be passed. This password must be a custom password.
-        systemProperty "password", System.getProperty("password", "myStrongPassword123!") 
     }
 
     if (project.hasProperty('includeTests')) {


### PR DESCRIPTION
- Related to https://github.com/opensearch-project/index-management/issues/1073

Since the password system property was already set the value of admin, this wouldn't be changed later. This was a flaw in https://github.com/opensearch-project/index-management/pull/1088. This PR fixes that by doing conditional assignment at 1 place. 

*CheckList:*
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/index-management/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
