### PR TITLE
[Backport 2.12] Fixes password assignment for integTest when using remote cluster (#1091)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -527,7 +527,8 @@ integTest {
     systemProperty "https", System.getProperty("https")
     systemProperty "security", System.getProperty("security")
     systemProperty "user", System.getProperty("user", "admin")
-    systemProperty "password", System.getProperty("password", "admin")
+    // a remote cluster requires a custom password to be passed. This password must be a custom password.
+    systemProperty "password", usingRemoteCluster ? System.getProperty("password", "myStrongPassword123!") : "admin" // defaulting to admin since security plugin's demo config tool is not used
     // Tell the test JVM if the cluster JVM is running under a debugger so that tests can use longer timeouts for
     // requests. The 'doFirst' delays reading the debug setting on the cluster till execution time.
     doFirst {


### PR DESCRIPTION
Backports #1091
(cherry picked from commit 027509e3c7ca25fd3f910d48dbd3456597d0a9e1)


*CheckList:*
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/index-management/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
