### PR TITLE
Add vikas as code owner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*   @bowenlan-amzn @getsaurabh02 @lezzago @praveensameneni @xluo-aws @gaobinlong @Hailong-am @amsiglan @sbcd90 @eirsep @AWSHurneyt @jowg-amazon @r1walz
+*   @bowenlan-amzn @getsaurabh02 @lezzago @praveensameneni @xluo-aws @gaobinlong @Hailong-am @amsiglan @sbcd90 @eirsep @AWSHurneyt @jowg-amazon @r1walz @vikasvb90

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -19,3 +19,4 @@ This document contains a list of maintainers in this repo. See [opensearch-proje
 | Thomas Hurney         | [AWSHurneyt](https://github.com/AWSHurneyt)           | Amazon      |
 | Joanne Wang           | [jowg-amazon](https://github.com/jowg-amazon)         | Amazon      |
 | Rohit Ashiwal         | [r1walz](https://github.com/r1walz)                   | Amazon      |
+| Vikas Bansal          | [vikasvb90](https://github.com/vikasvb90)             | Amazon      |


### PR DESCRIPTION
Description of changes:

Adding Vikas as a maintainer

*CheckList:*
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/index-management/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
