### PR TITLE
Accepts https as a property to set securityEnabled flag

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -328,7 +328,7 @@ ext.getPluginResource = { download_to_folder, download_from_src ->
 
 // === Setup security test ===
 // This flag indicates the existence of security plugin
-def securityEnabled = System.getProperty("security", "false") == "true"
+def securityEnabled = System.getProperty("security", "false") == "true" || System.getProperty("https", "false") == "true"
 afterEvaluate {
     testClusters.integTest.nodes.each { node ->
         def plugins = node.plugins


### PR DESCRIPTION

- Related to https://github.com/opensearch-project/index-management/issues/1086

- The error:
```zsh
Build file '/local/home/dchanp/codebase/index-management/build.gradle' line: 441

* What went wrong:
Execution failed for task ':integTest'.
> `cluster{::integTest}` failed to wait for cluster health yellow after 40 SECONDS
    Unexpected end of file from server
```

Upon investigation I discovered that the integration tests triggered by opensearch-build do not pass `security` as an inline argument, instead they pass `https` ([code-line](https://github.com/opensearch-project/opensearch-build/blob/fc2040fe19059b60a8eee67c45b63615c40a1c2c/scripts/default/integtest.sh#L105)). This cause the index-management tests in RC builds run `with-security` to fail with `Not a valid SSL/TLS record: NotSslRecordException ` which translates to mismatch between `http` vs `https`. The protocol is set [here](https://github.com/opensearch-project/index-management/blob/bc10724d39ced73e9f05ab94a554033d338784ce/build.gradle#L514) conditionally to https via `securityEnabled` flag via https://github.com/opensearch-project/index-management/blob/bc10724d39ced73e9f05ab94a554033d338784ce/build.gradle#L514

- The culprit:
https://github.com/opensearch-project/index-management/blob/bc10724d39ced73e9f05ab94a554033d338784ce/build.gradle#L331

This PR adds an additional check to toggle securityEnabled flag by checking if `https` was passed.

- The fix:
```groovy
def securityEnabled = System.getProperty("security", "false") == "true" || System.getProperty("https", "false") == "true"
```

*CheckList:*
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/index-management/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
