### PR TITLE
start_time npe fix for Rollup and Transform jobs

### DIFF
--- a/src/main/kotlin/org/opensearch/indexmanagement/rollup/model/Rollup.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/rollup/model/Rollup.kt
@@ -340,7 +340,7 @@ data class Rollup(
             // TODO: Make startTime public in Job Scheduler so we can just directly check the value
             if (seqNo == SequenceNumbers.UNASSIGNED_SEQ_NO || primaryTerm == SequenceNumbers.UNASSIGNED_PRIMARY_TERM) {
                 if (schedule is IntervalSchedule) {
-                    schedule = IntervalSchedule(schedule.startTime, schedule.interval, schedule.unit, schedule.delay ?: 0)
+                    schedule = IntervalSchedule(schedule.startTime ?: Instant.now(), schedule.interval, schedule.unit, schedule.delay ?: 0)
                 }
             }
             return Rollup(

--- a/src/main/kotlin/org/opensearch/indexmanagement/rollup/model/Rollup.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/rollup/model/Rollup.kt
@@ -343,6 +343,7 @@ data class Rollup(
                     schedule = IntervalSchedule(schedule.startTime ?: Instant.now(), schedule.interval, schedule.unit, schedule.delay ?: 0)
                 }
             }
+
             return Rollup(
                 id = id,
                 seqNo = seqNo,

--- a/src/main/kotlin/org/opensearch/indexmanagement/transform/model/Transform.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/transform/model/Transform.kt
@@ -397,7 +397,7 @@ data class Transform(
             if (seqNo == SequenceNumbers.UNASSIGNED_SEQ_NO || primaryTerm == SequenceNumbers.UNASSIGNED_PRIMARY_TERM) {
                 // we instantiate the start time
                 if (schedule is IntervalSchedule) {
-                    schedule = IntervalSchedule(schedule.startTime, schedule.interval, schedule.unit)
+                    schedule = IntervalSchedule(schedule.startTime ?: Instant.now(), schedule.interval, schedule.unit)
                 }
 
                 // we clear out metadata if its a new job


### PR DESCRIPTION
if start_time not pecified explicitly assign current time to start_time

*Issue #1161*

*Description of changes:*
if start_time not pecified explicitly assign current time to start_time to prevent the NPE and avoid a braking change

*CheckList:*
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/index-management/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
