### PR TITLE
Step Metadata Update on Index Rollover Timeout

### DIFF
--- a/spi/src/main/kotlin/org.opensearch.indexmanagement.spi/indexstatemanagement/Step.kt
+++ b/spi/src/main/kotlin/org.opensearch.indexmanagement.spi/indexstatemanagement/Step.kt
@@ -56,6 +56,7 @@ abstract class Step(val name: String, val isSafeToDisableOn: Boolean = true) {
         CONDITION_NOT_MET("condition_not_met"),
         FAILED("failed"),
         COMPLETED("completed"),
+        TIMED_OUT("timed_out"),
         ;
 
         override fun toString(): String {

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/ManagedIndexRunner.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/ManagedIndexRunner.kt
@@ -332,17 +332,17 @@ object ManagedIndexRunner :
             val info = mapOf("message" to "Action timed out")
             logger.error("Action=${action.type} has timed out")
 
-            val updatedMetaData = managedIndexMetaData.copy(
+            val updatedIndexMetaData = managedIndexMetaData.copy(
                 actionMetaData = currentActionMetaData?.copy(failed = true),
                 stepMetaData = step?.let { StepMetaData(it.name, System.currentTimeMillis(), Step.StepStatus.TIMED_OUT) },
                 info = info,
             )
 
-            val updated = updateManagedIndexMetaData(updatedMetaData)
+            val updated = updateManagedIndexMetaData(updatedIndexMetaData)
 
             if (updated.metadataSaved) {
                 disableManagedIndexConfig(managedIndexConfig)
-                publishErrorNotification(policy, updatedMetaData)
+                publishErrorNotification(policy, updatedIndexMetaData)
             }
             return
         }

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/ManagedIndexRunner.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/ManagedIndexRunner.kt
@@ -91,6 +91,7 @@ import org.opensearch.indexmanagement.spi.indexstatemanagement.model.ManagedInde
 import org.opensearch.indexmanagement.spi.indexstatemanagement.model.PolicyRetryInfoMetaData
 import org.opensearch.indexmanagement.spi.indexstatemanagement.model.StateMetaData
 import org.opensearch.indexmanagement.spi.indexstatemanagement.model.StepContext
+import org.opensearch.indexmanagement.spi.indexstatemanagement.model.StepMetaData
 import org.opensearch.jobscheduler.spi.JobExecutionContext
 import org.opensearch.jobscheduler.spi.LockModel
 import org.opensearch.jobscheduler.spi.ScheduledJobParameter
@@ -330,14 +331,18 @@ object ManagedIndexRunner :
         if (action?.hasTimedOut(currentActionMetaData) == true) {
             val info = mapOf("message" to "Action timed out")
             logger.error("Action=${action.type} has timed out")
-            val updated =
-                updateManagedIndexMetaData(
-                    managedIndexMetaData
-                        .copy(actionMetaData = currentActionMetaData?.copy(failed = true), info = info),
-                )
+
+            val updatedMetaData = managedIndexMetaData.copy(
+                actionMetaData = currentActionMetaData?.copy(failed = true),
+                stepMetaData = step?.let { StepMetaData(it.name, System.currentTimeMillis(), Step.StepStatus.TIMED_OUT) },
+                info = info,
+            )
+
+            val updated = updateManagedIndexMetaData(updatedMetaData)
+
             if (updated.metadataSaved) {
                 disableManagedIndexConfig(managedIndexConfig)
-                publishErrorNotification(policy, managedIndexMetaData)
+                publishErrorNotification(policy, updatedMetaData)
             }
             return
         }


### PR DESCRIPTION
*Issue #1132* : 

*Issue Description:*

This pull request addresses a bug in the Index Management plugin where the step metadata fields within IndexActionMetadata are not updated when a rollover action times out. Currently, only the info.message field is updated to indicate a timeout, which can be misleading if the previous run did not meet the rollover conditions.

*Expected Behaviour:*

Upon a timeout during the rollover action, the step.status and step.name fields within IndexActionMetadata should be updated to reflect the timeout event. This provides a clearer picture of the action's execution and avoids confusion regarding successful completion.

*CheckList:*
- [x] Commits are signed per the DCO using --signoff

*Proposed Changes:*

* The code has been modified to handle timeouts appropriately.
    * The logic checks if an action has timed out using the hasTimedOut function.
    * If a timeout occurs, a new IndexActionMetadata object is created with the following updates:
        * step.status is set to Step.StepStatus.TIMED_OUT.
        * step.name retains its original value (e.g., "attempt_rollover").
        * info.message is set to "Action timed out".
* The updated metadata is then persisted using the updateManagedIndexMetaData function.

*Testing:*

* Unit tests have been updated in the ActionTimeoutIT class to verify that the step metadata is correctly populated with the TIMED_OUT status upon a timeout.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/index-management/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
