### PR TITLE
Addition of Optional Parameter - allow_Red_cluster to bypass ISM to run on a Red Opensearch Cluster

### DIFF
--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/model/State.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/model/State.kt
@@ -31,10 +31,10 @@ data class State(
 ) : ToXContentObject, Writeable {
 
     constructor(
-            name: String,
-            actions: List<Action>,
-            transitions: List<Transition>,
-    ) : this(name, false, actions, transitions
+        name: String,
+        actions: List<Action>,
+        transitions: List<Transition>,
+    ) : this(name, false, actions, transitions)
 
     init {
         require(name.isNotBlank()) { "State must contain a valid name" }

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/model/State.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/model/State.kt
@@ -29,6 +29,13 @@ data class State(
     val actions: List<Action>,
     val transitions: List<Transition>,
 ) : ToXContentObject, Writeable {
+
+    constructor(
+            name: String,
+            actions: List<Action>,
+            transitions: List<Transition>,
+    ) : this(name, false, actions, transitions
+
     init {
         require(name.isNotBlank()) { "State must contain a valid name" }
         var hasDelete = false

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/model/State.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/model/State.kt
@@ -24,10 +24,10 @@ import org.opensearch.indexmanagement.spi.indexstatemanagement.model.ManagedInde
 import java.io.IOException
 
 data class State(
-        val name: String,
-        val allowRedCluster: Boolean,
-        val actions: List<Action>,
-        val transitions: List<Transition>,
+    val name: String,
+    val allowRedCluster: Boolean,
+    val actions: List<Action>,
+    val transitions: List<Transition>,
 ) : ToXContentObject, Writeable {
     init {
         require(name.isNotBlank()) { "State must contain a valid name" }
@@ -44,35 +44,36 @@ data class State(
 
     override fun toXContent(builder: XContentBuilder, params: ToXContent.Params): XContentBuilder {
         builder
-                .startObject()
-                .field(NAME_FIELD, name)
-                .field(ALLOW_RED_CLUSTER, allowRedCluster)
-                .startArray(ACTIONS_FIELD)
-                .also { actions.forEach { action -> action.toXContent(it, params) } }
-                .endArray()
-                .field(TRANSITIONS_FIELD, transitions.toTypedArray())
-                .endObject()
+            .startObject()
+            .field(NAME_FIELD, name)
+            .field(ALLOW_RED_CLUSTER, allowRedCluster)
+            .startArray(ACTIONS_FIELD)
+            .also { actions.forEach { action -> action.toXContent(it, params) } }
+            .endArray()
+            .field(TRANSITIONS_FIELD, transitions.toTypedArray())
+            .endObject()
         return builder
     }
 
     @Throws(IOException::class)
     constructor(sin: StreamInput) : this(
-            sin.readString(),
-            sin.readBoolean(),
-            sin.readList { ISMActionsParser.instance.fromStreamInput(it) },
-            sin.readList(::Transition),
+        sin.readString(),
+        sin.readBoolean(),
+        sin.readList { ISMActionsParser.instance.fromStreamInput(it) },
+        sin.readList(::Transition),
     )
 
     @Throws(IOException::class)
     override fun writeTo(out: StreamOutput) {
         out.writeString(name)
+        out.writeBoolean(allowRedCluster)
         out.writeList(actions)
         out.writeList(transitions)
     }
 
     fun getActionToExecute(
-            managedIndexMetaData: ManagedIndexMetaData,
-            indexMetadataProvider: IndexMetadataProvider,
+        managedIndexMetaData: ManagedIndexMetaData,
+        indexMetadataProvider: IndexMetadataProvider,
     ): Action? {
         var actionConfig: Action?
         val actionMetaData = managedIndexMetaData.actionMetaData
@@ -86,9 +87,9 @@ data class State(
         } else {
             // Get the current actionConfig that is in the ManagedIndexMetaData
             actionConfig =
-                    this.actions.filterIndexed { index, config ->
-                        index == actionMetaData.index && config.type == actionMetaData.name
-                    }.firstOrNull()
+                this.actions.filterIndexed { index, config ->
+                    index == actionMetaData.index && config.type == actionMetaData.name
+                }.firstOrNull()
             if (actionConfig == null) return null
 
             val stepMetaData = managedIndexMetaData.stepMetaData
@@ -144,10 +145,10 @@ data class State(
             }
 
             return State(
-                    name = requireNotNull(name) { "State name is null" },
-                    allowRedCluster = allowRedCluster,
-                    actions = actions.toList(),
-                    transitions = transitions.toList(),
+                name = requireNotNull(name) { "State name is null" },
+                allowRedCluster = allowRedCluster,
+                actions = actions.toList(),
+                transitions = transitions.toList(),
             )
         }
     }

--- a/src/main/resources/mappings/opendistro-ism-config.json
+++ b/src/main/resources/mappings/opendistro-ism-config.json
@@ -140,6 +140,9 @@
             "name": {
               "type": "keyword"
             },
+            "allow_red_cluster": {
+              "type": "boolean"
+            },
             "actions": {
               "type": "nested",
               "properties": {

--- a/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/IndexStateManagementRestTestCase.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/IndexStateManagementRestTestCase.kt
@@ -941,6 +941,12 @@ abstract class IndexStateManagementRestTestCase : IndexManagementRestTestCase() 
         assertEquals("Unable to delete snapshot", RestStatus.OK, response.restStatus())
     }
 
+    protected fun isClusterGreen(timeout: String) {
+        val endpoint = "_cluster/health?wait_for_status=yellow&timeout=$timeout"
+        val response = client().makeRequest("GET", endpoint)
+        assertEquals("Cluster status check timed out", RestStatus.OK, response.restStatus())
+    }
+
     @Suppress("UNCHECKED_CAST")
     protected fun assertSnapshotExists(
         repository: String,


### PR DESCRIPTION
*Issue #, if available:*

https://github.com/opensearch-project/index-management/issues/1127

*Description of changes:*

This PR involves the provision for ISM to run on a red opensearch cluster. 

**Behaviour before:** 

- The current implementation of the managedIndexRunner job prohibits any calls to the cluster when the cluster is red. 
  https://github.com/opensearch-project/index-management/blob/a049fdb423efcb02fb08a10f3b984fe392d09bab/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/ManagedIndexRunner.kt#L254
  
- In case if the cluster goes to red state due to resource crunch, ISM cannot delete any indices due to the above constraint. 

- Consider each index is of size 1 GB and the persistent volume of the opensearch cluster is 10GB. 

_ISM on a Green/Yellow Opensearch Cluster:_ 

![ISM](https://github.com/opensearch-project/index-management/assets/93825455/e8803e50-69e6-4a1b-b3b1-b726d005a940)

- When the cluster volume reaches 95% of the available volume, the cluster goes to red state. 

_ISM on a Red Opensearch Cluster:_

![ISM-Red](https://github.com/opensearch-project/index-management/assets/93825455/1490919b-824a-4168-8213-82bbd60c3e1e)

**Behaviour Post the Changes:** 

- The user has the option to set "allow_red_cluster" for each state where all the operations on that state can run on a red cluster if the "allow_red_cluster" is set to true. This parameter is optional. 

- If the User sets the parameter to "true", the ISM job will be bypassed to run on the particular state on a red Cluster. Any transitions, Actions under that state will be executed. 

- By default, the value of "allow_red_cluster" is false. Hence, the current behaviour of the API is also unchanged if the user doesnt want to bypass ISM to be run on a red cluster. 

_ISM on a Green/Yellow Opensearch Cluster:_ 

![ISM-GY-WITH PARAM](https://github.com/opensearch-project/index-management/assets/93825455/a3f3e9b3-2cd1-40fd-bd3b-dae83dddaa52)
****

_ISM on a Red Opensearch Cluster with the optional parameter:_

![ISM - 1](https://github.com/opensearch-project/index-management/assets/93825455/badb090a-8f12-4dc0-9d6f-db649d866a92)

- In case if the cluster goes to red state due to the volume getting consumed more than 95%, the ISM will still execute the delete action because of the param allowRedCluster being set true, which will delete the index which is of size 1 GB. This would help us to get the cluster back to yellow/green state and the ISM will continue to run successfully for the previous stages. 
 
*CheckList:*
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/index-management/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
