### PR TITLE
Execute PluginVersionSweepCoordinator on GENERIC threadpool

### DIFF
--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/PluginVersionSweepCoordinator.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/PluginVersionSweepCoordinator.kt
@@ -58,8 +58,10 @@ class PluginVersionSweepCoordinator(
 
     override fun clusterChanged(event: ClusterChangedEvent) {
         if (event.nodesChanged() || event.isNewCluster) {
-            skipExecution.sweepISMPluginVersion()
-            initBackgroundSweepISMPluginVersionExecution()
+            threadPool.generic().execute {
+                skipExecution.sweepISMPluginVersion()
+                initBackgroundSweepISMPluginVersionExecution()
+            }
         }
     }
 
@@ -85,7 +87,7 @@ class PluginVersionSweepCoordinator(
                 }
             }
         scheduledSkipExecution =
-            threadPool.scheduleWithFixedDelay(scheduledJob, sweepSkipPeriod, ThreadPool.Names.MANAGEMENT)
+            threadPool.scheduleWithFixedDelay(scheduledJob, sweepSkipPeriod, ThreadPool.Names.GENERIC)
     }
 
     private fun isIndexStateManagementEnabled(): Boolean = indexStateManagementEnabled == true


### PR DESCRIPTION
*Issue #, if available:* #1075

*Description of changes:*

Change threadpool to generic to avoid blocking `clusterApplierService#updateTask` thread.
*CheckList:*
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/index-management/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
