### PR TITLE
Add publish in spi build.gradle

### DIFF
--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -33,3 +33,4 @@ jobs:
           echo "::add-mask::$SONATYPE_USERNAME"
           echo "::add-mask::$SONATYPE_PASSWORD"
           ./gradlew publishPluginZipPublicationToSnapshotsRepository
+          ./gradlew publishShadowPublicationToSnapshotsRepository

--- a/build.gradle
+++ b/build.gradle
@@ -271,6 +271,8 @@ publishing {
     }
 }
 
+tasks.generatePomFileForPluginZipPublication.dependsOn publishNebulaPublicationToMavenLocal
+
 plugins.withId('java') {
     sourceCompatibility = targetCompatibility = JavaVersion.VERSION_11
 }

--- a/spi/build.gradle
+++ b/spi/build.gradle
@@ -16,6 +16,7 @@ apply plugin: 'kotlin'
 apply plugin: 'org.jetbrains.kotlin.jvm'
 apply plugin: 'org.jetbrains.kotlin.plugin.allopen'
 apply plugin: 'idea'
+apply plugin: 'maven-publish'
 
 ext {
     projectSubstitutions = [:]
@@ -83,6 +84,11 @@ tasks.register("sourcesJar", Jar) {
     from sourceSets.main.allSource
 }
 
+task javadocJar(type: Jar) {
+    archiveClassifier = 'javadoc'
+    from javadoc.destinationDir
+}
+
 test {
     doFirst {
         test.classpath -= project.files(project.tasks.named('shadowJar'))
@@ -102,4 +108,58 @@ check.dependsOn integTest
 
 testClusters.javaRestTest {
     testDistribution = 'INTEG_TEST'
+}
+
+publishing {
+    repositories {
+        maven {
+            name = 'staging'
+            url = "${rootProject.buildDir}/local-staging-repo"
+        }
+        maven {
+            name = "Snapshots"
+            url = "https://aws.oss.sonatype.org/content/repositories/snapshots"
+            credentials {
+                username "$System.env.SONATYPE_USERNAME"
+                password "$System.env.SONATYPE_PASSWORD"
+            }
+        }
+    }
+    publications {
+        shadow(MavenPublication) {
+            project.shadow.component(it)
+            groupId = 'org.opensearch.opensearch-index-management'
+            artifactId = 'opensearch-index-management-spi'
+
+            artifact sourcesJar
+            artifact javadocJar
+
+            pom {
+                name = "OpenSearch Index Management SPI"
+                packaging = "jar"
+                url = "https://github.com/opensearch-project/index-management"
+                description = "OpenSearch Index Management SPI"
+                scm {
+                    connection = "scm:git@github.com:opensearch-project/index-management.git"
+                    developerConnection = "scm:git@github.com:opensearch-project/index-management.git"
+                    url = "git@github.com:opensearch-project/index-management.git"
+                }
+                licenses {
+                    license {
+                        name = "The Apache License, Version 2.0"
+                        url = "http://www.apache.org/licenses/LICENSE-2.0.txt"
+                    }
+                }
+                developers {
+                    developer {
+                        name = "OpenSearch"
+                        url = "https://github.com/opensearch-project/index-management"
+                    }
+                }
+            }
+        }
+    }
+
+    gradle.startParameter.setShowStacktrace(ShowStacktrace.ALWAYS)
+    gradle.startParameter.setLogLevel(LogLevel.DEBUG)
 }

--- a/spi/build.gradle
+++ b/spi/build.gradle
@@ -128,8 +128,6 @@ publishing {
     publications {
         shadow(MavenPublication) {
             project.shadow.component(it)
-            groupId = 'org.opensearch.opensearch-index-management'
-            artifactId = 'opensearch-index-management-spi'
 
             artifact sourcesJar
             artifact javadocJar


### PR DESCRIPTION
### Description

Publish the spi to maven

Can be consumed as `compileOnly "org.opensearch:opensearch-index-management-spi:${opensearch_version}"`

Example commit of extend ISM https://github.com/opensearch-project/cross-cluster-replication/commit/3853901d77da71e772a71ea623ed1e721ded5d37

#### Test

Test locally by running `./gradlew publishShadowPublicationToStagingRepository`

![image](https://github.com/user-attachments/assets/fbcfbc04-9619-4171-9717-129cd031dac5)

Reference
https://github.com/opensearch-project/alerting/pull/1562
https://github.com/opensearch-project/alerting/pull/1604
https://github.com/opensearch-project/opensearch-plugins/blob/main/BUILDING.md#include-checksums-in-maven-publications

### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
- [x] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/index-management/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
