### PR TITLE
Skipping Execution based on Cluster Service

### DIFF
--- a/src/main/kotlin/org/opensearch/indexmanagement/IndexManagementPlugin.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/IndexManagementPlugin.kt
@@ -411,7 +411,7 @@ class IndexManagementPlugin : JobSchedulerExtension, NetworkPlugin, ActionPlugin
         fieldCapsFilter = FieldCapsFilter(clusterService, settings, indexNameExpressionResolver)
         this.indexNameExpressionResolver = indexNameExpressionResolver
 
-        val skipFlag = SkipExecution(client)
+        val skipFlag = SkipExecution()
         RollupFieldValueExpressionResolver.registerServices(scriptService, clusterService)
         val rollupRunner =
             RollupRunner

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/PluginVersionSweepCoordinator.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/PluginVersionSweepCoordinator.kt
@@ -25,7 +25,7 @@ class PluginVersionSweepCoordinator(
     private val skipExecution: SkipExecution,
     settings: Settings,
     private val threadPool: ThreadPool,
-    clusterService: ClusterService,
+    var clusterService: ClusterService,
 ) : CoroutineScope by CoroutineScope(SupervisorJob() + Dispatchers.Default + CoroutineName("ISMPluginSweepCoordinator")),
     LifecycleListener(),
     ClusterStateListener {
@@ -58,7 +58,7 @@ class PluginVersionSweepCoordinator(
 
     override fun clusterChanged(event: ClusterChangedEvent) {
         if (event.nodesChanged() || event.isNewCluster) {
-            skipExecution.sweepISMPluginVersion()
+            skipExecution.sweepISMPluginVersion(clusterService)
             initBackgroundSweepISMPluginVersionExecution()
         }
     }
@@ -77,7 +77,7 @@ class PluginVersionSweepCoordinator(
                             logger.info("Canceling sweep ism plugin version job")
                             scheduledSkipExecution?.cancel()
                         } else {
-                            skipExecution.sweepISMPluginVersion()
+                            skipExecution.sweepISMPluginVersion(clusterService)
                         }
                     } catch (e: Exception) {
                         logger.error("Failed to sweep ism plugin version", e)

--- a/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/coordinator/SkipExecutionTests.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/coordinator/SkipExecutionTests.kt
@@ -5,29 +5,88 @@
 
 package org.opensearch.indexmanagement.indexstatemanagement.coordinator
 
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.whenever
 import org.junit.Before
-import org.mockito.Mockito
-import org.opensearch.action.admin.cluster.node.info.NodesInfoAction
-import org.opensearch.client.Client
-import org.opensearch.cluster.ClusterChangedEvent
-import org.opensearch.cluster.OpenSearchAllocationTestCase
+import org.opensearch.Version
+import org.opensearch.cluster.ClusterState
+import org.opensearch.cluster.node.DiscoveryNode
+import org.opensearch.cluster.node.DiscoveryNodes
+import org.opensearch.cluster.service.ClusterService
+import org.opensearch.core.common.transport.TransportAddress
 import org.opensearch.indexmanagement.indexstatemanagement.SkipExecution
+import org.opensearch.test.OpenSearchTestCase
 
-class SkipExecutionTests : OpenSearchAllocationTestCase() {
-    private lateinit var client: Client
+class SkipExecutionTests : OpenSearchTestCase() {
+    private var clusterService: ClusterService = mock()
+    private lateinit var clusterState: ClusterState
     private lateinit var skip: SkipExecution
 
     @Before
-    @Throws(Exception::class)
     fun setup() {
-        client = Mockito.mock(Client::class.java)
-        skip = SkipExecution(client)
+        skip = SkipExecution()
     }
 
-    fun `test cluster change event`() {
-        val event = Mockito.mock(ClusterChangedEvent::class.java)
-        Mockito.`when`(event.nodesChanged()).thenReturn(true)
-        skip.sweepISMPluginVersion()
-        Mockito.verify(client).execute(Mockito.eq(NodesInfoAction.INSTANCE), Mockito.any(), Mockito.any())
+    fun `test sweepISMPluginVersion should set flag to false and hasLegacyPlugin to false when all nodes have the same version`() {
+        val version = Version.CURRENT
+        val node1 = DiscoveryNode("node1", TransportAddress(TransportAddress.META_ADDRESS, 9300), version)
+        val node2 = DiscoveryNode("node2", TransportAddress(TransportAddress.META_ADDRESS, 9301), version)
+        val discoveryNodes = DiscoveryNodes.builder().add(node1).add(node2).build()
+        clusterState = ClusterState.builder(ClusterState.EMPTY_STATE).nodes(discoveryNodes).build()
+        whenever(clusterService.state()).thenReturn(clusterState)
+
+        skip.sweepISMPluginVersion(clusterService)
+
+        assertFalse(skip.flag)
+        assertFalse(skip.hasLegacyPlugin)
+    }
+
+    fun `test sweepISMPluginVersion should set flag to true and hasLegacyPlugin to false when all nodes have the different versions`() {
+        val version1 = Version.CURRENT
+        val version2 = Version.V_2_0_0
+        val node1 = DiscoveryNode("node1", TransportAddress(TransportAddress.META_ADDRESS, 9300), version1)
+        val node2 = DiscoveryNode("node2", TransportAddress(TransportAddress.META_ADDRESS, 9301), version2)
+        val node3 = DiscoveryNode("node3", TransportAddress(TransportAddress.META_ADDRESS, 9302), version2)
+        val discoveryNodes = DiscoveryNodes.builder().add(node1).add(node2).add(node3).build()
+        clusterState = ClusterState.builder(ClusterState.EMPTY_STATE).nodes(discoveryNodes).build()
+        whenever(clusterService.state()).thenReturn(clusterState)
+
+        skip.sweepISMPluginVersion(clusterService)
+
+        assertTrue(skip.flag)
+        assertFalse(skip.hasLegacyPlugin)
+    }
+
+    fun `test sweepISMPluginVersion should set flag to true and hasLegacyPlugin to true when there are different versions including current version`() {
+        val minVersion = Version.fromString("7.10.0")
+        val maxVersion = Version.CURRENT
+        val node1 = DiscoveryNode("node1", TransportAddress(TransportAddress.META_ADDRESS, 9300), minVersion)
+        val node2 = DiscoveryNode("node2", TransportAddress(TransportAddress.META_ADDRESS, 9301), maxVersion)
+        val node3 = DiscoveryNode("node3", TransportAddress(TransportAddress.META_ADDRESS, 9302), maxVersion)
+        val discoveryNodes = DiscoveryNodes.builder().add(node1).add(node2).add(node3).build()
+        clusterState = ClusterState.builder(ClusterState.EMPTY_STATE).nodes(discoveryNodes).build()
+        whenever(clusterService.state()).thenReturn(clusterState)
+
+        skip.sweepISMPluginVersion(clusterService)
+
+        assertTrue(skip.flag)
+        assertTrue(skip.hasLegacyPlugin)
+    }
+
+    fun `test sweepISMPluginVersion should set flag to true and hasLegacyPlugin to true with different versions`() {
+        val minVersion = Version.fromString("7.10.0")
+        val maxVersion = Version.V_2_0_0
+        val node1 = DiscoveryNode("node1", TransportAddress(TransportAddress.META_ADDRESS, 9300), minVersion)
+        val node2 = DiscoveryNode("node2", TransportAddress(TransportAddress.META_ADDRESS, 9301), maxVersion)
+        val node3 = DiscoveryNode("node3", TransportAddress(TransportAddress.META_ADDRESS, 9302), maxVersion)
+
+        val discoveryNodes = DiscoveryNodes.builder().add(node1).add(node2).add(node3).build()
+        clusterState = ClusterState.builder(ClusterState.EMPTY_STATE).nodes(discoveryNodes).build()
+        whenever(clusterService.state()).thenReturn(clusterState)
+
+        skip.sweepISMPluginVersion(clusterService)
+
+        assertTrue(skip.flag)
+        assertTrue(skip.hasLegacyPlugin)
     }
 }


### PR DESCRIPTION
### Description
Currently, we make expensive node infos calls to verify if all the nodes are on the same version or not, before we execute index-management actions.

With this change, we would be able to avoid that broadcast request, and rely on the cluster service to provide us with the min and max versions across the cluster.

### Related Issues
Resolves #1075



### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/index-management/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).


### Testing

**Cluster Configuration:**

1. Data Node: OS v2.12
2. Data Node: OS v2.15



### Case 1: Mixed Cluster

Both nodes with different versions are present in the cluster.


```
[2024-08-17T10:51:04,896][INFO ][o.o.i.i.SkipExecution ] Current max 2.15.0
[2024-08-17T10:51:04,896][INFO ][o.o.i.i.SkipExecution    ] Current min 2.12.0
[2024-08-17T10:51:04,897][INFO ][o.o.i.i.SkipExecution    ] There are multiple versions of Index Management plugins in the cluster: [2.15.0, 2.12.0]
[2024-08-17T10:51:04,900][INFO ][o.o.d.PeerFinder         ] setting findPeersInterval to [1s] as node commission status = [true] for local node [{bcd0743e920a.ant.amazon.com}{mPc9ej1FQ4y9Z4w_yUOqTQ}{hc4kfB-LTr-GdPmU7VMrQQ}{127.0.0.1}{127.0.0.1:9300}{dimr}{shard_indexing_pressure_enabled=true}]
[2024-08-17T10:55:23,670][INFO ][o.o.j.s.JobSweeper       ] Running full sweep
[2024-08-17T10:56:04,921][INFO ][o.o.i.i.SkipExecution    ] Current max 2.15.0
[2024-08-17T10:56:04,922][INFO ][o.o.i.i.SkipExecution    ]  Current min 2.12.0
[2024-08-17T10:56:04,922][INFO ][o.o.i.i.SkipExecution    ] There are multiple versions of Index Management plugins in the cluster: [2.15.0, 2.12.0]
```


It is visible that the skip execution scheduler is able to check the cluster state multiple times to verify that different nodes exist.


**Created a rollover policy with mixed cluster.** 

```
[2024-08-17T11:06:04,912][INFO ][o.o.i.i.SkipExecution ] Current max 2.15.0
[2024-08-17T11:06:04,914][INFO ][o.o.i.i.SkipExecution ] Current min 2.12.0
[2024-08-17T11:06:04,914][INFO ][o.o.i.i.SkipExecution ] There are multiple versions of Index Management plugins in the cluster: [2.15.0, 2.12.0]
[2024-08-17T11:07:23,924][INFO ][o.o.j.s.JobScheduler ] Will delay 30531 miliseconds for next execution of job log-000001
[2024-08-17T11:07:23,929][INFO ][o.o.i.i.ManagedIndexRunner] Cluster still has nodes running old version ISM plugin, skip execution on new nodes until all nodes upgraded

The plugin is delaying the execution of the rollover.
```


### Case 2: Mixed Cluster

*Stopping Data Node: OS v2.12*


Rollover was successful once only one node was present or all the nodes were of the same OS version.

````
╰─ curl --location --request GET 'http://localhost:9201/_plugins/_ism/explain/log-000001?pretty' \
--data-raw ''
{
"log-000001" : {
"index.plugins.index_state_management.policy_id" : "rollover_policy",
"index.opendistro.index_state_management.policy_id" : "rollover_policy",
"index" : "log-000001",
"index_uuid" : "YxSf5gHiRhuUuv5J9oCP_g",
"policy_id" : "rollover_policy",
"policy_seq_no" : 0,
"policy_primary_term" : 1,
"index_creation_date" : 1723872442738,
"state" : {
"name" : "rollover",
"start_time" : 1723873754028
},
"retry_info" : {
"failed" : false,
"consumed_retries" : 0
},
"info" : {
"message" : "Successfully initialized policy: rollover_policy"
},
"enabled" : true
},
"total_managed_indices" : 1
}
