### PR TITLE
Use adminClient instead of client when interacting with system index in integTests

### DIFF
--- a/src/test/kotlin/org/opensearch/indexmanagement/IndexManagementIndicesIT.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/IndexManagementIndicesIT.kt
@@ -135,7 +135,7 @@ class IndexManagementIndicesIT : IndexStateManagementRestTestCase() {
                     .replace("\"schema_version\": $configSchemaVersion", "\"schema_version\": 0")
 
         val entity = StringEntity(mapping, ContentType.APPLICATION_JSON)
-        client().makeRequest(
+        adminClient().makeRequest(
             RestRequest.Method.PUT.toString(),
             "/$INDEX_MANAGEMENT_INDEX/_mapping", emptyMap(), entity,
         )

--- a/src/test/kotlin/org/opensearch/indexmanagement/IndexManagementRestTestCase.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/IndexManagementRestTestCase.kt
@@ -249,7 +249,7 @@ abstract class IndexManagementRestTestCase : ODFERestTestCase() {
         val startTimeMillis = desiredStartTimeMillis ?: (Instant.now().toEpochMilli() - millis)
         val waitForActiveShards = if (isMultiNode) "all" else "1"
         val response =
-            client().makeRequest(
+            adminClient().makeRequest(
                 "POST", "${IndexManagementPlugin.INDEX_MANAGEMENT_INDEX}/_update/${update.id}?wait_for_active_shards=$waitForActiveShards",
                 StringEntity(
                     "{\"doc\":{\"transform\":{\"schedule\":{\"interval\":{\"start_time\":" +

--- a/src/test/kotlin/org/opensearch/indexmanagement/IndexManagementRestTestCase.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/IndexManagementRestTestCase.kt
@@ -219,7 +219,7 @@ abstract class IndexManagementRestTestCase : ODFERestTestCase() {
         // Since from the log, this happens very fast (within 0.1~0.2s), the above cluster explain may not have the granularity to catch this.
         logger.info("Update rollup start time to $startTimeMillis")
         val response =
-            client().makeRequest(
+            adminClient().makeRequest(
                 "POST", "${IndexManagementPlugin.INDEX_MANAGEMENT_INDEX}/_update/${update.id}?wait_for_active_shards=$waitForActiveShards&refresh=true",
                 StringEntity(
                     "{\"doc\":{\"rollup\":{\"schedule\":{\"interval\":{\"start_time\":" +

--- a/src/test/kotlin/org/opensearch/indexmanagement/SecurityRestTestCase.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/SecurityRestTestCase.kt
@@ -492,7 +492,7 @@ abstract class SecurityRestTestCase : IndexManagementRestTestCase() {
     }
 
     protected fun deleteIndexByName(index: String) {
-        executeRequest(request = Request(RestRequest.Method.DELETE.name, "/$index"), client = client())
+        executeRequest(request = Request(RestRequest.Method.DELETE.name, "/$index"), client = adminClient())
     }
 
     protected fun validateSourceIndex(indexName: String) {

--- a/src/test/kotlin/org/opensearch/indexmanagement/controlcenter/notification/filter/NotificationActionListenerIT.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/controlcenter/notification/filter/NotificationActionListenerIT.kt
@@ -401,7 +401,7 @@ class NotificationActionListenerIT : IndexManagementRestTestCase() {
         closeIndex("source-index")
 
         // delete system index
-        client.makeRequest("DELETE", IndexManagementPlugin.CONTROL_CENTER_INDEX)
+        adminClient().makeRequest("DELETE", IndexManagementPlugin.CONTROL_CENTER_INDEX)
 
         val response =
             client.makeRequest(

--- a/src/test/kotlin/org/opensearch/indexmanagement/controlcenter/notification/resthandler/LRONConfigRestTestCase.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/controlcenter/notification/resthandler/LRONConfigRestTestCase.kt
@@ -31,7 +31,7 @@ abstract class LRONConfigRestTestCase : IndexManagementRestTestCase() {
     @After
     fun removeAllDocs() {
         try {
-            client().makeRequest(
+            adminClient().makeRequest(
                 "POST",
                 "${IndexManagementPlugin.CONTROL_CENTER_INDEX}/_delete_by_query",
                 mapOf("refresh" to "true"),

--- a/src/test/kotlin/org/opensearch/indexmanagement/controlcenter/notification/resthandler/RestIndexLRONConfigActionIT.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/controlcenter/notification/resthandler/RestIndexLRONConfigActionIT.kt
@@ -182,7 +182,7 @@ class RestIndexLRONConfigActionIT : LRONConfigRestTestCase() {
         val lronConfig = randomLRONConfig(taskId = randomTaskId(nodeId = nodeIdsInRestIT.random()))
         createLRONConfig(lronConfig)
 
-        val response = client().makeRequest("GET", "/${IndexManagementPlugin.CONTROL_CENTER_INDEX}/_mapping")
+        val response = adminClient().makeRequest("GET", "/${IndexManagementPlugin.CONTROL_CENTER_INDEX}/_mapping")
         val parserMap = createParser(XContentType.JSON.xContent(), response.entity.content).map() as Map<String, Map<String, Any>>
         val mappingsMap = parserMap[IndexManagementPlugin.CONTROL_CENTER_INDEX]!!["mappings"] as Map<String, Any>
         val expected =

--- a/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/IndexStateManagementRestTestCase.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/IndexStateManagementRestTestCase.kt
@@ -469,7 +469,7 @@ abstract class IndexStateManagementRestTestCase : IndexManagementRestTestCase() 
         val waitForActiveShards = if (isMultiNode) "all" else "1"
         val endpoint = "$INDEX_MANAGEMENT_INDEX/_update/${update.id}?wait_for_active_shards=$waitForActiveShards;retry_on_conflict=$retryOnConflict"
         val response =
-            client().makeRequest(
+            adminClient().makeRequest(
                 "POST", endpoint,
                 StringEntity(
                     "{\"doc\":{\"managed_index\":{\"schedule\":{\"interval\":{\"start_time\":" +


### PR DESCRIPTION
### Description

Opening this PR to attempt to fix security CI checks. There are a few instances where the `adminClient` should be used instead of `client` in integTests.

To test I am running a local node with security, JS + ISM installed.

Running tests with

```
./gradlew integTestRemote -Dtests.rest.cluster=localhost:9200 -Dtests.cluster=localhost:9200 -Dtests.clustername="smoketestnode" -Duser=admin -Dpassword=myStrongPassword123\! -Dsecurity=true -Dhttps=true
```

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/index-management/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
