### PR TITLE
[Backport 2.x] Use adminClient instead of client when interacting with system index in integTests (#1222)

### DIFF
--- a/src/test/kotlin/org/opensearch/indexmanagement/IndexManagementIndicesIT.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/IndexManagementIndicesIT.kt
@@ -132,7 +132,7 @@ class IndexManagementIndicesIT : IndexStateManagementRestTestCase() {
             .replace("\"schema_version\": $configSchemaVersion", "\"schema_version\": 0")
 
         val entity = StringEntity(mapping, ContentType.APPLICATION_JSON)
-        client().makeRequest(
+        adminClient().makeRequest(
             RestRequest.Method.PUT.toString(),
             "/$INDEX_MANAGEMENT_INDEX/_mapping", emptyMap(), entity,
         )

--- a/src/test/kotlin/org/opensearch/indexmanagement/IndexManagementRestTestCase.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/IndexManagementRestTestCase.kt
@@ -219,14 +219,15 @@ abstract class IndexManagementRestTestCase : ODFERestTestCase() {
         // During this period, this update got missed
         // Since from the log, this happens very fast (within 0.1~0.2s), the above cluster explain may not have the granularity to catch this.
         logger.info("Update rollup start time to $startTimeMillis")
-        val response = client().makeRequest(
-            "POST", "${IndexManagementPlugin.INDEX_MANAGEMENT_INDEX}/_update/${update.id}?wait_for_active_shards=$waitForActiveShards&refresh=true",
-            StringEntity(
-                "{\"doc\":{\"rollup\":{\"schedule\":{\"interval\":{\"start_time\":" +
-                    "\"$startTimeMillis\"}}}}}",
-                ContentType.APPLICATION_JSON,
-            ),
-        )
+        val response =
+            adminClient().makeRequest(
+                "POST", "${IndexManagementPlugin.INDEX_MANAGEMENT_INDEX}/_update/${update.id}?wait_for_active_shards=$waitForActiveShards&refresh=true",
+                StringEntity(
+                    "{\"doc\":{\"rollup\":{\"schedule\":{\"interval\":{\"start_time\":" +
+                        "\"$startTimeMillis\"}}}}}",
+                    ContentType.APPLICATION_JSON,
+                ),
+            )
 
         assertEquals("Request failed", RestStatus.OK, response.restStatus())
     }
@@ -248,14 +249,15 @@ abstract class IndexManagementRestTestCase : ODFERestTestCase() {
         val millis = Duration.of(intervalSchedule.interval.toLong(), intervalSchedule.unit).minusSeconds(2).toMillis()
         val startTimeMillis = desiredStartTimeMillis ?: (Instant.now().toEpochMilli() - millis)
         val waitForActiveShards = if (isMultiNode) "all" else "1"
-        val response = client().makeRequest(
-            "POST", "${IndexManagementPlugin.INDEX_MANAGEMENT_INDEX}/_update/${update.id}?wait_for_active_shards=$waitForActiveShards",
-            StringEntity(
-                "{\"doc\":{\"transform\":{\"schedule\":{\"interval\":{\"start_time\":" +
-                    "\"$startTimeMillis\"}}}}}",
-                ContentType.APPLICATION_JSON,
-            ),
-        )
+        val response =
+            adminClient().makeRequest(
+                "POST", "${IndexManagementPlugin.INDEX_MANAGEMENT_INDEX}/_update/${update.id}?wait_for_active_shards=$waitForActiveShards",
+                StringEntity(
+                    "{\"doc\":{\"transform\":{\"schedule\":{\"interval\":{\"start_time\":" +
+                        "\"$startTimeMillis\"}}}}}",
+                    ContentType.APPLICATION_JSON,
+                ),
+            )
 
         assertEquals("Request failed", RestStatus.OK, response.restStatus())
     }

--- a/src/test/kotlin/org/opensearch/indexmanagement/SecurityRestTestCase.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/SecurityRestTestCase.kt
@@ -486,7 +486,7 @@ abstract class SecurityRestTestCase : IndexManagementRestTestCase() {
     }
 
     protected fun deleteIndexByName(index: String) {
-        executeRequest(request = Request(RestRequest.Method.DELETE.name, "/$index"), client = client())
+        executeRequest(request = Request(RestRequest.Method.DELETE.name, "/$index"), client = adminClient())
     }
 
     protected fun validateSourceIndex(indexName: String) {

--- a/src/test/kotlin/org/opensearch/indexmanagement/controlcenter/notification/filter/NotificationActionListenerIT.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/controlcenter/notification/filter/NotificationActionListenerIT.kt
@@ -393,7 +393,7 @@ class NotificationActionListenerIT : IndexManagementRestTestCase() {
         closeIndex("source-index")
 
         // delete system index
-        client.makeRequest("DELETE", IndexManagementPlugin.CONTROL_CENTER_INDEX)
+        adminClient().makeRequest("DELETE", IndexManagementPlugin.CONTROL_CENTER_INDEX)
 
         val response = client.makeRequest(
             "POST", "source-index/_open",

--- a/src/test/kotlin/org/opensearch/indexmanagement/controlcenter/notification/resthandler/LRONConfigRestTestCase.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/controlcenter/notification/resthandler/LRONConfigRestTestCase.kt
@@ -31,7 +31,7 @@ abstract class LRONConfigRestTestCase : IndexManagementRestTestCase() {
     @After
     fun removeAllDocs() {
         try {
-            client().makeRequest(
+            adminClient().makeRequest(
                 "POST",
                 "${IndexManagementPlugin.CONTROL_CENTER_INDEX}/_delete_by_query",
                 mapOf("refresh" to "true"),

--- a/src/test/kotlin/org/opensearch/indexmanagement/controlcenter/notification/resthandler/RestIndexLRONConfigActionIT.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/controlcenter/notification/resthandler/RestIndexLRONConfigActionIT.kt
@@ -178,7 +178,7 @@ class RestIndexLRONConfigActionIT : LRONConfigRestTestCase() {
         val lronConfig = randomLRONConfig(taskId = randomTaskId(nodeId = nodeIdsInRestIT.random()))
         createLRONConfig(lronConfig)
 
-        val response = client().makeRequest("GET", "/${IndexManagementPlugin.CONTROL_CENTER_INDEX}/_mapping")
+        val response = adminClient().makeRequest("GET", "/${IndexManagementPlugin.CONTROL_CENTER_INDEX}/_mapping")
         val parserMap = createParser(XContentType.JSON.xContent(), response.entity.content).map() as Map<String, Map<String, Any>>
         val mappingsMap = parserMap[IndexManagementPlugin.CONTROL_CENTER_INDEX]!!["mappings"] as Map<String, Any>
         val expected = createParser(

--- a/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/IndexStateManagementRestTestCase.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/IndexStateManagementRestTestCase.kt
@@ -451,14 +451,15 @@ abstract class IndexStateManagementRestTestCase : IndexManagementRestTestCase() 
         val startTimeMillis = desiredStartTimeMillis ?: Instant.now().toEpochMilli() - millis
         val waitForActiveShards = if (isMultiNode) "all" else "1"
         val endpoint = "$INDEX_MANAGEMENT_INDEX/_update/${update.id}?wait_for_active_shards=$waitForActiveShards;retry_on_conflict=$retryOnConflict"
-        val response = client().makeRequest(
-            "POST", endpoint,
-            StringEntity(
-                "{\"doc\":{\"managed_index\":{\"schedule\":{\"interval\":{\"start_time\":" +
-                    "\"$startTimeMillis\"}}}}}",
-                APPLICATION_JSON,
-            ),
-        )
+        val response =
+            adminClient().makeRequest(
+                "POST", endpoint,
+                StringEntity(
+                    "{\"doc\":{\"managed_index\":{\"schedule\":{\"interval\":{\"start_time\":" +
+                        "\"$startTimeMillis\"}}}}}",
+                    ContentType.APPLICATION_JSON,
+                ),
+            )
 
         assertEquals("Request failed", RestStatus.OK, response.restStatus())
     }

--- a/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/IndexStateManagementRestTestCase.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/IndexStateManagementRestTestCase.kt
@@ -457,7 +457,7 @@ abstract class IndexStateManagementRestTestCase : IndexManagementRestTestCase() 
                 StringEntity(
                     "{\"doc\":{\"managed_index\":{\"schedule\":{\"interval\":{\"start_time\":" +
                         "\"$startTimeMillis\"}}}}}",
-                    ContentType.APPLICATION_JSON,
+                    APPLICATION_JSON,
                 ),
             )
 


### PR DESCRIPTION
Backport #1222 to 2.x