### PR TITLE
Move non-active maintainers to emeritus.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*   @bowenlan-amzn @getsaurabh02 @lezzago @praveensameneni @xluo-aws @gaobinlong @Hailong-am @amsiglan @sbcd90 @eirsep @AWSHurneyt @jowg-amazon @r1walz @vikasvb90
+*   @bowenlan-amzn @Hailong-am @r1walz @vikasvb90

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -6,17 +6,22 @@ This document contains a list of maintainers in this repo. See [opensearch-proje
 
 | Maintainer            | GitHub ID                                             | Affiliation |
 |-----------------------|-------------------------------------------------------| ----------- |
-| Ashish Agrawal        | [lezzago](https://github.com/lezzago)                 | Amazon      |
+| Vikas Bansal          | [vikasvb90](https://github.com/vikasvb90)             | Amazon      |
 | Bowen Lan             | [bowenlan-amzn](https://github.com/bowenlan-amzn)     | Amazon      |
+| Hailong Cui           | [Hailong-am](https://github.com/Hailong-am)           | Amazon      |
+| Rohit Ashiwal         | [r1walz](https://github.com/r1walz)                   | Independent |
+
+## Emeritus
+
+| Maintainer            | GitHub ID                                             | Affiliation |
+|-----------------------|-------------------------------------------------------| ----------- |
+| Amardeepsingh Siglani | [amsiglan](https://github.com/amsiglan)               | Amazon      |
+| Binlong Gao           | [gaobinlong](https://github.com/gaobinlong)           | Amazon      |
+| Ashish Agrawal        | [lezzago](https://github.com/lezzago)                 | Amazon      |
+| Joanne Wang           | [jowg-amazon](https://github.com/jowg-amazon)         | Amazon      |
 | Praveen Sameneni      | [praveensameneni](https://github.com/praveensameneni) | Amazon      |
 | Saurabh Singh         | [getsaurabh02](https://github.com/getsaurabh02/)      | Amazon      |
-| Xuesong Luo           | [xluo-aws](https://github.com/xluo-aws)               | Amazon      |
-| Hailong Cui           | [Hailong-am](https://github.com/Hailong-am)           | Amazon      |
-| Binlong Gao           | [gaobinlong](https://github.com/gaobinlong)           | Amazon      |
-| Amardeepsingh Siglani | [amsiglan](https://github.com/amsiglan)               | Amazon      |
 | Subhobrata Dey        | [sbcd90](https://github.com/sbcd90)                   | Amazon      |
 | Surya Sashank Nistala | [eirsep](https://github.com/eirsep)                   | Amazon      |
 | Thomas Hurney         | [AWSHurneyt](https://github.com/AWSHurneyt)           | Amazon      |
-| Joanne Wang           | [jowg-amazon](https://github.com/jowg-amazon)         | Amazon      |
-| Rohit Ashiwal         | [r1walz](https://github.com/r1walz)                   | Amazon      |
-| Vikas Bansal          | [vikasvb90](https://github.com/vikasvb90)             | Amazon      |
+| Xuesong Luo           | [xluo-aws](https://github.com/xluo-aws)               | Amazon      |


### PR DESCRIPTION
### Description

Per https://github.com/opensearch-project/index-management/issues/1230 moving inactive maintainers to emeritus.

Sort names alphabetically.

### Related Issues

Closes https://github.com/opensearch-project/index-management/issues/1230.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/index-management/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
