### PR TITLE
Fix for test failure related to SnapshotInfo object creation

### DIFF
--- a/src/test/kotlin/org/opensearch/indexmanagement/snapshotmanagement/TestUtils.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/snapshotmanagement/TestUtils.kt
@@ -231,6 +231,7 @@ fun mockSnapshotInfo(
             false,
             mapOf("sm_policy" to policyName),
             remoteStoreIndexShallowCopy,
+            0,
         )
     return result
 }


### PR DESCRIPTION
### Description
To resolve the compile-time error caused due to change in [SnapshotInfo](https://github.com/opensearch-project/OpenSearch/blob/main/server/src/main/java/org/opensearch/snapshots/SnapshotInfo.java) class, I've updated the TestUtils.kt to create the object of SnapshotInfo with additional pinnedTimestamp (0) parameter.

Kindly let me know if this solution is fine :)

### Related Issues
Resolves #1236 
<!-- List any other related issues here -->

### Check List
- ~[ ] New functionality includes testing.~
- ~[ ] New functionality has been documented.~
- ~[ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).~
- [x] Commits are signed per the DCO using `--signoff`.
- ~[ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/index-management/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
