### PR TITLE
upgrade upload-artifact to version 3

### DIFF
--- a/.github/workflows/bwc-test-workflow.yml
+++ b/.github/workflows/bwc-test-workflow.yml
@@ -30,4 +30,5 @@ jobs:
         if: failure()
         with:
           name: logs
+          overwrite: 'true'
           path: build/testclusters/indexmanagementBwcCluster*/logs/*

--- a/.github/workflows/bwc-test-workflow.yml
+++ b/.github/workflows/bwc-test-workflow.yml
@@ -26,7 +26,7 @@ jobs:
           echo "Running backwards compatibility tests..."
           ./gradlew bwcTestSuite
       - name: Upload failed logs
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: logs

--- a/.github/workflows/docker-security-test-workflow.yml
+++ b/.github/workflows/docker-security-test-workflow.yml
@@ -84,7 +84,7 @@ jobs:
             echo "Security plugin is NOT available skipping this run as tests without security have already been run"
           fi
       - name: Upload failed logs
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: logs
@@ -96,7 +96,7 @@ jobs:
       - name: Tar logs
         run: tar cvzf ./logs.tgz ./logs
       - name: Upload logs to GitHub
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: logs.tgz

--- a/.github/workflows/docker-security-test-workflow.yml
+++ b/.github/workflows/docker-security-test-workflow.yml
@@ -88,6 +88,7 @@ jobs:
         if: failure()
         with:
           name: logs
+          overwrite: 'true'
           path: build/testclusters/integTest-*/logs/*
       - name: Collect docker logs on failure
         uses: jwalton/gh-docker-logs@v2
@@ -100,4 +101,5 @@ jobs:
         if: failure()
         with:
           name: logs.tgz
+          overwrite: 'true'
           path: ./logs.tgz

--- a/.github/workflows/multi-node-test-workflow.yml
+++ b/.github/workflows/multi-node-test-workflow.yml
@@ -53,7 +53,7 @@ jobs:
           chown -R 1000:1000 `pwd`
           su `id -un 1000` -c "./gradlew integTest -PnumNodes=3 ${{ env.TEST_FILTER }}"
       - name: Upload failed logs
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         if: failure()
         with:
           name: logs

--- a/.github/workflows/multi-node-test-workflow.yml
+++ b/.github/workflows/multi-node-test-workflow.yml
@@ -53,7 +53,7 @@ jobs:
           chown -R 1000:1000 `pwd`
           su `id -un 1000` -c "./gradlew integTest -PnumNodes=3 ${{ env.TEST_FILTER }}"
       - name: Upload failed logs
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: logs

--- a/.github/workflows/multi-node-test-workflow.yml
+++ b/.github/workflows/multi-node-test-workflow.yml
@@ -57,4 +57,5 @@ jobs:
         if: failure()
         with:
           name: logs
+          overwrite: 'true'
           path: build/testclusters/integTest-*/logs/*

--- a/.github/workflows/security-test-workflow.yml
+++ b/.github/workflows/security-test-workflow.yml
@@ -42,7 +42,7 @@ jobs:
           chown -R 1000:1000 `pwd`
           su `id -un 1000` -c "./gradlew integTest -Dsecurity=true -Dhttps=true --tests '*IT'"
       - name: Upload failed logs
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         if: failure()
         with:
           name: logs

--- a/.github/workflows/security-test-workflow.yml
+++ b/.github/workflows/security-test-workflow.yml
@@ -46,4 +46,5 @@ jobs:
         if: failure()
         with:
           name: logs
+          overwrite: 'true'
           path: build/testclusters/integTest-*/logs/*

--- a/.github/workflows/security-test-workflow.yml
+++ b/.github/workflows/security-test-workflow.yml
@@ -42,7 +42,7 @@ jobs:
           chown -R 1000:1000 `pwd`
           su `id -un 1000` -c "./gradlew integTest -Dsecurity=true -Dhttps=true --tests '*IT'"
       - name: Upload failed logs
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: logs

--- a/.github/workflows/test-and-build-workflow.yml
+++ b/.github/workflows/test-and-build-workflow.yml
@@ -71,7 +71,8 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
       # This step uses the upload-artifact Github action: https://github.com/actions/upload-artifact
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v4
+        # v4 requires node.js 20 which is not supported
+        uses: actions/upload-artifact@v3
         with:
           name: index-management-plugin-ubuntu-latest-${{ matrix.java }}
           path: index-management-artifacts

--- a/.github/workflows/test-and-build-workflow.yml
+++ b/.github/workflows/test-and-build-workflow.yml
@@ -56,7 +56,7 @@ jobs:
           chown -R 1000:1000 `pwd`
           su `id -un 1000` -c "./gradlew build ${{ env.TEST_FILTER }}"
       - name: Upload failed logs
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         if: ${{ failure() }}
         with:
           name: logs
@@ -71,7 +71,7 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
       # This step uses the upload-artifact Github action: https://github.com/actions/upload-artifact
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v4
         with:
           name: index-management-plugin-ubuntu-latest
           path: index-management-artifacts
@@ -127,7 +127,7 @@ jobs:
           cp ./build/distributions/*.zip index-management-artifacts
       # This step uses the upload-artifact Github action: https://github.com/actions/upload-artifact
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v4
         with:
           name: index-management-plugin-${{ matrix.os }}
           path: index-management-artifacts

--- a/.github/workflows/test-and-build-workflow.yml
+++ b/.github/workflows/test-and-build-workflow.yml
@@ -59,7 +59,7 @@ jobs:
         uses: actions/upload-artifact@v4
         if: ${{ failure() }}
         with:
-          name: logs
+          name: logs-${{ matrix.java }}-${{ matrix.feature }}
           path: build/testclusters/integTest-*/logs/*
       - name: Create Artifact Path
         run: |
@@ -73,8 +73,9 @@ jobs:
       - name: Upload Artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: index-management-plugin-ubuntu-latest
+          name: index-management-plugin-ubuntu-latest-${{ matrix.java }}
           path: index-management-artifacts
+          overwrite: 'true'
 
   test-and-build-windows-macos:
     env:
@@ -129,5 +130,6 @@ jobs:
       - name: Upload Artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: index-management-plugin-${{ matrix.os }}
+          name: index-management-plugin-${{ matrix.os }}-${{ matrix.java }}
           path: index-management-artifacts
+          overwrite: 'true'


### PR DESCRIPTION
### Description
upgrade upload-artifact to version 3 as v1 and v2 are deprecated per https://github.blog/changelog/2024-02-13-deprecation-notice-v1-and-v2-of-the-artifact-actions/ 

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/index-management/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
