### PR TITLE
Move non-active maintainer to emeritus

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*   @bowenlan-amzn @Hailong-am @r1walz @vikasvb90
+*   @bowenlan-amzn @Hailong-am @vikasvb90

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -9,7 +9,6 @@ This document contains a list of maintainers in this repo. See [opensearch-proje
 | Vikas Bansal          | [vikasvb90](https://github.com/vikasvb90)             | Amazon      |
 | Bowen Lan             | [bowenlan-amzn](https://github.com/bowenlan-amzn)     | Amazon      |
 | Hailong Cui           | [Hailong-am](https://github.com/Hailong-am)           | Amazon      |
-| Rohit Ashiwal         | [r1walz](https://github.com/r1walz)                   | Independent |
 
 ## Emeritus
 
@@ -25,3 +24,4 @@ This document contains a list of maintainers in this repo. See [opensearch-proje
 | Surya Sashank Nistala | [eirsep](https://github.com/eirsep)                   | Amazon      |
 | Thomas Hurney         | [AWSHurneyt](https://github.com/AWSHurneyt)           | Amazon      |
 | Xuesong Luo           | [xluo-aws](https://github.com/xluo-aws)               | Amazon      |
+| Rohit Ashiwal         | [r1walz](https://github.com/r1walz)                   | Independent |


### PR DESCRIPTION
### Description
Moves non-active maintainer to emeritus

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/index-management/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
