### PR TITLE
[Backport 2.x] Use adminClient when searching system index in integ tests (#1286)

### DIFF
--- a/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/IndexStateManagementRestTestCase.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/IndexStateManagementRestTestCase.kt
@@ -365,7 +365,7 @@ abstract class IndexStateManagementRestTestCase : IndexManagementRestTestCase() 
                 }
             }
         """.trimIndent()
-        val response = client().makeRequest(
+        val response = adminClient().makeRequest(
             "POST", "$INDEX_MANAGEMENT_INDEX/_search", emptyMap(),
             StringEntity(request, APPLICATION_JSON),
         )
@@ -380,7 +380,7 @@ abstract class IndexStateManagementRestTestCase : IndexManagementRestTestCase() 
     }
 
     protected fun getManagedIndexConfigByDocId(id: String): ManagedIndexConfig? {
-        val response = client().makeRequest("GET", "$INDEX_MANAGEMENT_INDEX/_doc/$id")
+        val response = adminClient().makeRequest("GET", "$INDEX_MANAGEMENT_INDEX/_doc/$id")
         assertEquals("Request failed", RestStatus.OK, response.restStatus())
         val getResponse = GetResponse.fromXContent(createParser(jsonXContent, response.entity.content))
         assertTrue("Did not find managed index config", getResponse.isExists)
@@ -832,7 +832,7 @@ abstract class IndexStateManagementRestTestCase : IndexManagementRestTestCase() 
         metadataId: String,
         header: BasicHeader = BasicHeader(HttpHeaders.CONTENT_TYPE, "application/json"),
     ): RollupMetadata {
-        val response = client().makeRequest("GET", "$INDEX_MANAGEMENT_INDEX/_doc/$metadataId", null, header)
+        val response = adminClient().makeRequest("GET", "$INDEX_MANAGEMENT_INDEX/_doc/$metadataId", null, header)
         assertEquals("Unable to get rollup metadata $metadataId", RestStatus.OK, response.restStatus())
 
         val parser = createParser(XContentType.JSON.xContent(), response.entity.content)
@@ -889,7 +889,7 @@ abstract class IndexStateManagementRestTestCase : IndexManagementRestTestCase() 
         metadataId: String,
         header: BasicHeader = BasicHeader(HttpHeaders.CONTENT_TYPE, "application/json"),
     ): TransformMetadata {
-        val response = client().makeRequest("GET", "$INDEX_MANAGEMENT_INDEX/_doc/$metadataId", null, header)
+        val response = adminClient().makeRequest("GET", "$INDEX_MANAGEMENT_INDEX/_doc/$metadataId", null, header)
         assertEquals("Unable to get transform metadata $metadataId", RestStatus.OK, response.restStatus())
 
         val parser = createParser(XContentType.JSON.xContent(), response.entity.content)

--- a/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/resthandler/IndexStateManagementRestApiIT.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/resthandler/IndexStateManagementRestApiIT.kt
@@ -148,7 +148,7 @@ class IndexStateManagementRestApiIT : IndexStateManagementRestTestCase() {
     fun `test mappings after policy creation`() {
         createRandomPolicy()
 
-        val response = client().makeRequest("GET", "/$INDEX_MANAGEMENT_INDEX/_mapping")
+        val response = adminClient().makeRequest("GET", "/$INDEX_MANAGEMENT_INDEX/_mapping")
         val parserMap =
             createParser(XContentType.JSON.xContent(), response.entity.content).map() as Map<String, Map<String, Any>>
         val mappingsMap = parserMap[INDEX_MANAGEMENT_INDEX]!!["mappings"] as Map<String, Any>
@@ -265,7 +265,7 @@ class IndexStateManagementRestApiIT : IndexStateManagementRestTestCase() {
                 }
             }
         """.trimIndent()
-        val response = client().makeRequest(
+        val response = adminClient().makeRequest(
             "POST", "$INDEX_MANAGEMENT_INDEX/_search", emptyMap(),
             StringEntity(request, APPLICATION_JSON),
         )

--- a/src/test/kotlin/org/opensearch/indexmanagement/rollup/RollupRestTestCase.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/rollup/RollupRestTestCase.kt
@@ -205,7 +205,7 @@ abstract class RollupRestTestCase : IndexManagementRestTestCase() {
         refresh: Boolean = true,
         header: BasicHeader = BasicHeader(HttpHeaders.CONTENT_TYPE, "application/json"),
     ): RollupMetadata {
-        val response = client().makeRequest("GET", "$INDEX_MANAGEMENT_INDEX/_doc/$metadataId?refresh=$refresh", null, header)
+        val response = adminClient().makeRequest("GET", "$INDEX_MANAGEMENT_INDEX/_doc/$metadataId?refresh=$refresh", null, header)
         assertEquals("Unable to get rollup metadata $metadataId", RestStatus.OK, response.restStatus())
         return parseRollupMetadata(response)
     }
@@ -216,7 +216,7 @@ abstract class RollupRestTestCase : IndexManagementRestTestCase() {
         refresh: Boolean = true,
         header: BasicHeader = BasicHeader(HttpHeaders.CONTENT_TYPE, "application/json"),
     ): RollupMetadata {
-        val response = client().makeRequest("GET", "$INDEX_MANAGEMENT_INDEX/_doc/$metadataId?routing=$routingId&refresh=$refresh", null, header)
+        val response = adminClient().makeRequest("GET", "$INDEX_MANAGEMENT_INDEX/_doc/$metadataId?routing=$routingId&refresh=$refresh", null, header)
         assertEquals("Unable to get rollup metadata $metadataId", RestStatus.OK, response.restStatus())
 
         return parseRollupMetadata(response)


### PR DESCRIPTION
Manual backport of #1286 to 2.x