### PR TITLE
get bwc version from latest 2.x

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -637,8 +637,21 @@ task integTestRemote(type: RestIntegTestTask) {
 }
 
 // === Set up BWC tests ===
-
-String bwcVersionShort = "2.19.0"
+// get latest 2.x version from OpenSearch 2.x branch
+static def fetchVersionProperties() {
+    def url = 'https://raw.githubusercontent.com/opensearch-project/OpenSearch/refs/heads/2.x/buildSrc/version.properties'
+    def content = new URL(url).text
+    // Use regex to extract the version number
+    def matcher = content =~ /opensearch\s*=\s*(\d+\.\d+\.\d+)/
+    if (matcher.find()) {
+        def version = matcher.group(1)
+        println("Extracted latest 2.x version: $version")
+        return version
+    } else {
+        return "2.19.0"
+    }
+}
+String bwcVersionShort = fetchVersionProperties()
 String bwcVersion = bwcVersionShort + ".0"
 String baseName = "indexmanagementBwcCluster"
 


### PR DESCRIPTION
### Description

Instead of using hardcode BWC version, get latest value from OpenSearch 2.x branch

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/index-management/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
