### PR TITLE
bump com.pinterest.ktlint:ktlint-cli from 1.1.0 to 1.5.0 and appease ktlint 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -232,7 +232,7 @@ dependencies {
     testImplementation "com.nhaarman.mockitokotlin2:mockito-kotlin:2.2.0"
     testImplementation "org.mockito:mockito-core:${versions.mockito}"
 
-    add("ktlint", "com.pinterest.ktlint:ktlint-cli:1.1.0") {
+    add("ktlint", "com.pinterest.ktlint:ktlint-cli:1.5.0") {
         attributes {
             attribute(Bundling.BUNDLING_ATTRIBUTE, objects.named(Bundling, Bundling.EXTERNAL))
         }

--- a/spi/src/main/kotlin/org.opensearch.indexmanagement.spi/IndexManagementExtension.kt
+++ b/spi/src/main/kotlin/org.opensearch.indexmanagement.spi/IndexManagementExtension.kt
@@ -26,9 +26,7 @@ interface IndexManagementExtension {
      * should represent if the extension is enabled or disabled, and should not represent extension health or the availability of some extension
      * dependency.
      */
-    fun statusChecker(): StatusChecker {
-        return DefaultStatusChecker()
-    }
+    fun statusChecker(): StatusChecker = DefaultStatusChecker()
 
     /**
      * Name of the extension
@@ -40,9 +38,7 @@ interface IndexManagementExtension {
      * indices provide the metadata service that can provide the index metadata for these indices. An extension need to label the metadata service
      * with a type string which is used to distinguish indices in IndexManagement plugin
      */
-    fun getIndexMetadataService(): Map<String, IndexMetadataService> {
-        return mapOf()
-    }
+    fun getIndexMetadataService(): Map<String, IndexMetadataService> = mapOf()
 
     /**
      * Caution: Experimental and can be removed in future
@@ -50,7 +46,5 @@ interface IndexManagementExtension {
      * If extension wants IndexManagement to determine cluster state indices UUID based on custom index setting if
      * present of cluster state override this method.
      */
-    fun overrideClusterStateIndexUuidSetting(): String? {
-        return null
-    }
+    fun overrideClusterStateIndexUuidSetting(): String? = null
 }

--- a/spi/src/main/kotlin/org.opensearch.indexmanagement.spi/indexstatemanagement/Action.kt
+++ b/spi/src/main/kotlin/org.opensearch.indexmanagement.spi/indexstatemanagement/Action.kt
@@ -20,7 +20,8 @@ import java.time.Instant
 abstract class Action(
     val type: String,
     val actionIndex: Int,
-) : ToXContentObject, Writeable {
+) : ToXContentObject,
+    Writeable {
     var configTimeout: ActionTimeout? = null
     var configRetry: ActionRetry? = ActionRetry(DEFAULT_RETRIES)
     var customAction: Boolean = false

--- a/spi/src/main/kotlin/org.opensearch.indexmanagement.spi/indexstatemanagement/StatusChecker.kt
+++ b/spi/src/main/kotlin/org.opensearch.indexmanagement.spi/indexstatemanagement/StatusChecker.kt
@@ -11,9 +11,7 @@ interface StatusChecker {
     /**
      * checks and returns the status of the extension
      */
-    fun check(clusterState: ClusterState): Status {
-        return Status.ENABLED
-    }
+    fun check(clusterState: ClusterState): Status = Status.ENABLED
 }
 
 enum class Status(private val value: String) {
@@ -21,9 +19,7 @@ enum class Status(private val value: String) {
     DISABLED("disabled"),
     ;
 
-    override fun toString(): String {
-        return value
-    }
+    override fun toString(): String = value
 }
 
 class DefaultStatusChecker : StatusChecker

--- a/spi/src/main/kotlin/org.opensearch.indexmanagement.spi/indexstatemanagement/Step.kt
+++ b/spi/src/main/kotlin/org.opensearch.indexmanagement.spi/indexstatemanagement/Step.kt
@@ -135,16 +135,14 @@ abstract class Step(val name: String, val isSafeToDisableOn: Boolean = true) {
 
     abstract fun isIdempotent(): Boolean
 
-    final fun getStepStartTime(metadata: ManagedIndexMetaData): Instant {
-        return when {
-            metadata.stepMetaData == null -> Instant.now()
-            metadata.stepMetaData.name != this.name -> Instant.now()
-            // The managed index metadata is a historical snapshot of the metadata and refers to what has happened from the previous
-            // execution, so if we ever see it as COMPLETED it means we are always going to be in a new step, this specifically
-            // helps with the Transition -> Transition (empty state) sequence which the above do not capture
-            metadata.stepMetaData.stepStatus == StepStatus.COMPLETED -> Instant.now()
-            else -> Instant.ofEpochMilli(metadata.stepMetaData.startTime)
-        }
+    final fun getStepStartTime(metadata: ManagedIndexMetaData): Instant = when {
+        metadata.stepMetaData == null -> Instant.now()
+        metadata.stepMetaData.name != this.name -> Instant.now()
+        // The managed index metadata is a historical snapshot of the metadata and refers to what has happened from the previous
+        // execution, so if we ever see it as COMPLETED it means we are always going to be in a new step, this specifically
+        // helps with the Transition -> Transition (empty state) sequence which the above do not capture
+        metadata.stepMetaData.stepStatus == StepStatus.COMPLETED -> Instant.now()
+        else -> Instant.ofEpochMilli(metadata.stepMetaData.startTime)
     }
 
     final fun getStartingStepMetaData(metadata: ManagedIndexMetaData): StepMetaData = StepMetaData(name, getStepStartTime(metadata).toEpochMilli(), StepStatus.STARTING)
@@ -157,18 +155,14 @@ abstract class Step(val name: String, val isSafeToDisableOn: Boolean = true) {
         TIMED_OUT("timed_out"),
         ;
 
-        override fun toString(): String {
-            return status
-        }
+        override fun toString(): String = status
 
         override fun writeTo(out: StreamOutput) {
             out.writeString(status)
         }
 
         companion object {
-            fun read(streamInput: StreamInput): StepStatus {
-                return valueOf(streamInput.readString().uppercase(Locale.ROOT))
-            }
+            fun read(streamInput: StreamInput): StepStatus = valueOf(streamInput.readString().uppercase(Locale.ROOT))
         }
     }
 }

--- a/spi/src/main/kotlin/org.opensearch.indexmanagement.spi/indexstatemanagement/Validate.kt
+++ b/spi/src/main/kotlin/org.opensearch.indexmanagement.spi/indexstatemanagement/Validate.kt
@@ -29,18 +29,14 @@ abstract class Validate(
         FAILED("failed"),
         ;
 
-        override fun toString(): String {
-            return status
-        }
+        override fun toString(): String = status
 
         override fun writeTo(out: StreamOutput) {
             out.writeString(status)
         }
 
         companion object {
-            fun read(streamInput: StreamInput): ValidationStatus {
-                return valueOf(streamInput.readString().uppercase(Locale.ROOT))
-            }
+            fun read(streamInput: StreamInput): ValidationStatus = valueOf(streamInput.readString().uppercase(Locale.ROOT))
         }
     }
 }

--- a/spi/src/main/kotlin/org.opensearch.indexmanagement.spi/indexstatemanagement/metrics/IndexManagementActionsMetrics.kt
+++ b/spi/src/main/kotlin/org.opensearch.indexmanagement.spi/indexstatemanagement/metrics/IndexManagementActionsMetrics.kt
@@ -110,7 +110,5 @@ class IndexManagementActionsMetrics private constructor() {
         )
     }
 
-    fun getActionMetrics(actionName: String): ActionMetrics? {
-        return actionMetricsMap[actionName]
-    }
+    fun getActionMetrics(actionName: String): ActionMetrics? = actionMetricsMap[actionName]
 }

--- a/spi/src/main/kotlin/org.opensearch.indexmanagement.spi/indexstatemanagement/model/ActionMetaData.kt
+++ b/spi/src/main/kotlin/org.opensearch.indexmanagement.spi/indexstatemanagement/model/ActionMetaData.kt
@@ -30,7 +30,8 @@ data class ActionMetaData(
     val consumedRetries: Int,
     val lastRetryTime: Long?,
     val actionProperties: ActionProperties?,
-) : Writeable, ToXContentFragment {
+) : Writeable,
+    ToXContentFragment {
     override fun writeTo(out: StreamOutput) {
         out.writeString(name)
         out.writeOptionalLong(startTime)
@@ -60,9 +61,7 @@ data class ActionMetaData(
         return builder
     }
 
-    fun getMapValueString(): String {
-        return Strings.toString(XContentType.JSON, this)
-    }
+    fun getMapValueString(): String = Strings.toString(XContentType.JSON, this)
 
     companion object {
         const val ACTION = "action"

--- a/spi/src/main/kotlin/org.opensearch.indexmanagement.spi/indexstatemanagement/model/ActionProperties.kt
+++ b/spi/src/main/kotlin/org.opensearch.indexmanagement.spi/indexstatemanagement/model/ActionProperties.kt
@@ -26,7 +26,8 @@ data class ActionProperties(
     val hasRollupFailed: Boolean? = null,
     val shrinkActionProperties: ShrinkActionProperties? = null,
     val transformActionProperties: TransformActionProperties? = null,
-) : Writeable, ToXContentFragment {
+) : Writeable,
+    ToXContentFragment {
     override fun writeTo(out: StreamOutput) {
         out.writeOptionalInt(maxNumSegments)
         out.writeOptionalString(snapshotName)

--- a/spi/src/main/kotlin/org.opensearch.indexmanagement.spi/indexstatemanagement/model/ActionRetry.kt
+++ b/spi/src/main/kotlin/org.opensearch.indexmanagement.spi/indexstatemanagement/model/ActionRetry.kt
@@ -24,7 +24,8 @@ data class ActionRetry(
     val count: Long,
     val backoff: Backoff = Backoff.EXPONENTIAL,
     val delay: TimeValue = TimeValue.timeValueMinutes(1),
-) : ToXContentFragment, Writeable {
+) : ToXContentFragment,
+    Writeable {
     init {
         require(count >= 0) { "Count for ActionRetry must be a non-negative number" }
     }
@@ -109,9 +110,7 @@ data class ActionRetry(
 
         private val logger = LogManager.getLogger(javaClass)
 
-        override fun toString(): String {
-            return type
-        }
+        override fun toString(): String = type
 
         @Suppress("ReturnCount")
         fun shouldBackoff(actionMetaData: ActionMetaData?, actionRetry: ActionRetry?): Pair<Boolean, Long?> {

--- a/spi/src/main/kotlin/org.opensearch.indexmanagement.spi/indexstatemanagement/model/ActionTimeout.kt
+++ b/spi/src/main/kotlin/org.opensearch.indexmanagement.spi/indexstatemanagement/model/ActionTimeout.kt
@@ -15,10 +15,10 @@ import org.opensearch.core.xcontent.XContentBuilder
 import org.opensearch.core.xcontent.XContentParser
 import java.io.IOException
 
-data class ActionTimeout(val timeout: TimeValue) : ToXContentFragment, Writeable {
-    override fun toXContent(builder: XContentBuilder, params: ToXContent.Params): XContentBuilder {
-        return builder.field(TIMEOUT_FIELD, timeout.stringRep)
-    }
+data class ActionTimeout(val timeout: TimeValue) :
+    ToXContentFragment,
+    Writeable {
+    override fun toXContent(builder: XContentBuilder, params: ToXContent.Params): XContentBuilder = builder.field(TIMEOUT_FIELD, timeout.stringRep)
 
     @Throws(IOException::class)
     constructor(sin: StreamInput) : this(

--- a/spi/src/main/kotlin/org.opensearch.indexmanagement.spi/indexstatemanagement/model/ManagedIndexMetaData.kt
+++ b/spi/src/main/kotlin/org.opensearch.indexmanagement.spi/indexstatemanagement/model/ManagedIndexMetaData.kt
@@ -39,7 +39,8 @@ data class ManagedIndexMetaData(
     val seqNo: Long = SequenceNumbers.UNASSIGNED_SEQ_NO,
     val primaryTerm: Long = SequenceNumbers.UNASSIGNED_PRIMARY_TERM,
     val rolledOverIndexName: String? = null,
-) : Writeable, ToXContentFragment {
+) : Writeable,
+    ToXContentFragment {
     @Suppress("ComplexMethod")
     fun toMap(): Map<String, String> {
         val resultMap = mutableMapOf<String, String>()
@@ -324,24 +325,22 @@ data class ManagedIndexMetaData(
             return managedIndexMetaData
         }
 
-        fun fromMap(map: Map<String, String?>): ManagedIndexMetaData {
-            return ManagedIndexMetaData(
-                index = requireNotNull(map[INDEX]) { "$INDEX is null" },
-                indexUuid = requireNotNull(map[INDEX_UUID]) { "$INDEX_UUID is null" },
-                policyID = requireNotNull(map[POLICY_ID]) { "$POLICY_ID is null" },
-                policySeqNo = map[POLICY_SEQ_NO]?.toLong(),
-                policyPrimaryTerm = map[POLICY_PRIMARY_TERM]?.toLong(),
-                policyCompleted = map[POLICY_COMPLETED]?.toBoolean(),
-                rolledOver = map[ROLLED_OVER]?.toBoolean(),
-                rolledOverIndexName = map[ROLLED_OVER_INDEX_NAME],
-                indexCreationDate = map[INDEX_CREATION_DATE]?.toLong(),
-                transitionTo = map[TRANSITION_TO],
-                stateMetaData = StateMetaData.fromManagedIndexMetaDataMap(map),
-                actionMetaData = ActionMetaData.fromManagedIndexMetaDataMap(map),
-                stepMetaData = StepMetaData.fromManagedIndexMetaDataMap(map),
-                policyRetryInfo = PolicyRetryInfoMetaData.fromManagedIndexMetaDataMap(map),
-                info = map[INFO]?.let { XContentHelper.convertToMap(JsonXContent.jsonXContent, it, false) },
-            )
-        }
+        fun fromMap(map: Map<String, String?>): ManagedIndexMetaData = ManagedIndexMetaData(
+            index = requireNotNull(map[INDEX]) { "$INDEX is null" },
+            indexUuid = requireNotNull(map[INDEX_UUID]) { "$INDEX_UUID is null" },
+            policyID = requireNotNull(map[POLICY_ID]) { "$POLICY_ID is null" },
+            policySeqNo = map[POLICY_SEQ_NO]?.toLong(),
+            policyPrimaryTerm = map[POLICY_PRIMARY_TERM]?.toLong(),
+            policyCompleted = map[POLICY_COMPLETED]?.toBoolean(),
+            rolledOver = map[ROLLED_OVER]?.toBoolean(),
+            rolledOverIndexName = map[ROLLED_OVER_INDEX_NAME],
+            indexCreationDate = map[INDEX_CREATION_DATE]?.toLong(),
+            transitionTo = map[TRANSITION_TO],
+            stateMetaData = StateMetaData.fromManagedIndexMetaDataMap(map),
+            actionMetaData = ActionMetaData.fromManagedIndexMetaDataMap(map),
+            stepMetaData = StepMetaData.fromManagedIndexMetaDataMap(map),
+            policyRetryInfo = PolicyRetryInfoMetaData.fromManagedIndexMetaDataMap(map),
+            info = map[INFO]?.let { XContentHelper.convertToMap(JsonXContent.jsonXContent, it, false) },
+        )
     }
 }

--- a/spi/src/main/kotlin/org.opensearch.indexmanagement.spi/indexstatemanagement/model/PolicyRetryInfoMetaData.kt
+++ b/spi/src/main/kotlin/org.opensearch.indexmanagement.spi/indexstatemanagement/model/PolicyRetryInfoMetaData.kt
@@ -23,17 +23,16 @@ import java.nio.charset.StandardCharsets
 data class PolicyRetryInfoMetaData(
     val failed: Boolean,
     val consumedRetries: Int,
-) : Writeable, ToXContentFragment {
+) : Writeable,
+    ToXContentFragment {
     override fun writeTo(out: StreamOutput) {
         out.writeBoolean(failed)
         out.writeInt(consumedRetries)
     }
 
-    override fun toXContent(builder: XContentBuilder, params: ToXContent.Params): XContentBuilder {
-        return builder
-            .field(FAILED, failed)
-            .field(CONSUMED_RETRIES, consumedRetries)
-    }
+    override fun toXContent(builder: XContentBuilder, params: ToXContent.Params): XContentBuilder = builder
+        .field(FAILED, failed)
+        .field(CONSUMED_RETRIES, consumedRetries)
 
     fun getMapValueString(): String = Strings.toString(XContentType.JSON, this)
 

--- a/spi/src/main/kotlin/org.opensearch.indexmanagement.spi/indexstatemanagement/model/ShrinkActionProperties.kt
+++ b/spi/src/main/kotlin/org.opensearch.indexmanagement.spi/indexstatemanagement/model/ShrinkActionProperties.kt
@@ -24,7 +24,8 @@ data class ShrinkActionProperties(
     val lockDurationSecond: Long,
     // Used to store the original index allocation and write block setting to reapply after shrink
     val originalIndexSettings: Map<String, String>,
-) : Writeable, ToXContentFragment {
+) : Writeable,
+    ToXContentFragment {
     override fun writeTo(out: StreamOutput) {
         out.writeString(nodeName)
         out.writeString(targetIndexName)

--- a/spi/src/main/kotlin/org.opensearch.indexmanagement.spi/indexstatemanagement/model/StateMetaData.kt
+++ b/spi/src/main/kotlin/org.opensearch.indexmanagement.spi/indexstatemanagement/model/StateMetaData.kt
@@ -25,17 +25,16 @@ import java.nio.charset.StandardCharsets
 data class StateMetaData(
     val name: String,
     val startTime: Long,
-) : Writeable, ToXContentFragment {
+) : Writeable,
+    ToXContentFragment {
     override fun writeTo(out: StreamOutput) {
         out.writeString(name)
         out.writeLong(startTime)
     }
 
-    override fun toXContent(builder: XContentBuilder, params: ToXContent.Params): XContentBuilder {
-        return builder
-            .field(NAME, name)
-            .field(START_TIME, startTime)
-    }
+    override fun toXContent(builder: XContentBuilder, params: ToXContent.Params): XContentBuilder = builder
+        .field(NAME, name)
+        .field(START_TIME, startTime)
 
     fun getMapValueString(): String = Strings.toString(XContentType.JSON, this)
 

--- a/spi/src/main/kotlin/org.opensearch.indexmanagement.spi/indexstatemanagement/model/StepContext.kt
+++ b/spi/src/main/kotlin/org.opensearch.indexmanagement.spi/indexstatemanagement/model/StepContext.kt
@@ -23,7 +23,5 @@ class StepContext(
     val settings: Settings,
     val lockService: LockService,
 ) {
-    fun getUpdatedContext(metadata: ManagedIndexMetaData): StepContext {
-        return StepContext(metadata, this.clusterService, this.client, this.threadContext, this.user, this.scriptService, this.settings, this.lockService)
-    }
+    fun getUpdatedContext(metadata: ManagedIndexMetaData): StepContext = StepContext(metadata, this.clusterService, this.client, this.threadContext, this.user, this.scriptService, this.settings, this.lockService)
 }

--- a/spi/src/main/kotlin/org.opensearch.indexmanagement.spi/indexstatemanagement/model/StepMetaData.kt
+++ b/spi/src/main/kotlin/org.opensearch.indexmanagement.spi/indexstatemanagement/model/StepMetaData.kt
@@ -28,7 +28,8 @@ data class StepMetaData(
     val name: String,
     val startTime: Long,
     val stepStatus: Step.StepStatus,
-) : Writeable, ToXContentFragment {
+) : Writeable,
+    ToXContentFragment {
     override fun writeTo(out: StreamOutput) {
         out.writeString(name)
         out.writeLong(startTime)
@@ -44,9 +45,7 @@ data class StepMetaData(
         return builder
     }
 
-    fun getMapValueString(): String {
-        return Strings.toString(XContentType.JSON, this)
-    }
+    fun getMapValueString(): String = Strings.toString(XContentType.JSON, this)
 
     companion object {
         const val STEP = "step"

--- a/spi/src/main/kotlin/org.opensearch.indexmanagement.spi/indexstatemanagement/model/TransformActionProperties.kt
+++ b/spi/src/main/kotlin/org.opensearch.indexmanagement.spi/indexstatemanagement/model/TransformActionProperties.kt
@@ -16,7 +16,8 @@ import org.opensearch.core.xcontent.XContentParserUtils.ensureExpectedToken
 
 data class TransformActionProperties(
     val transformId: String?,
-) : Writeable, ToXContentFragment {
+) : Writeable,
+    ToXContentFragment {
     override fun writeTo(out: StreamOutput) {
         out.writeOptionalString(transformId)
     }

--- a/spi/src/main/kotlin/org.opensearch.indexmanagement.spi/indexstatemanagement/model/ValidationResult.kt
+++ b/spi/src/main/kotlin/org.opensearch.indexmanagement.spi/indexstatemanagement/model/ValidationResult.kt
@@ -25,7 +25,8 @@ import java.util.Locale
 data class ValidationResult(
     val validationMessage: String,
     val validationStatus: Validate.ValidationStatus,
-) : Writeable, ToXContentFragment {
+) : Writeable,
+    ToXContentFragment {
     override fun writeTo(out: StreamOutput) {
         out.writeString(validationMessage)
         validationStatus.writeTo(out)
@@ -38,9 +39,7 @@ data class ValidationResult(
         return builder
     }
 
-    fun getMapValueString(): String {
-        return Strings.toString(XContentType.JSON, this)
-    }
+    fun getMapValueString(): String = Strings.toString(XContentType.JSON, this)
 
     companion object {
         const val VALIDATE = "validate"

--- a/src/main/kotlin/org/opensearch/indexmanagement/IndexManagementPlugin.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/IndexManagementPlugin.kt
@@ -200,8 +200,14 @@ import org.opensearch.watcher.ResourceWatcherService
 import java.util.function.Supplier
 
 @Suppress("TooManyFunctions")
-class IndexManagementPlugin : JobSchedulerExtension, NetworkPlugin, ActionPlugin, ExtensiblePlugin, SystemIndexPlugin,
-    TelemetryAwarePlugin, Plugin() {
+class IndexManagementPlugin :
+    Plugin(),
+    JobSchedulerExtension,
+    NetworkPlugin,
+    ActionPlugin,
+    ExtensiblePlugin,
+    SystemIndexPlugin,
+    TelemetryAwarePlugin {
     private val logger = LogManager.getLogger(javaClass)
     lateinit var indexManagementIndices: IndexManagementIndices
     lateinit var actionValidation: ActionValidation
@@ -248,9 +254,7 @@ class IndexManagementPlugin : JobSchedulerExtension, NetworkPlugin, ActionPlugin
 
     override fun getJobRunner(): ScheduledJobRunner = IndexManagementRunner
 
-    override fun getGuiceServiceClasses(): Collection<Class<out LifecycleComponent?>> {
-        return mutableListOf<Class<out LifecycleComponent?>>(GuiceHolder::class.java)
-    }
+    override fun getGuiceServiceClasses(): Collection<Class<out LifecycleComponent?>> = mutableListOf<Class<out LifecycleComponent?>>(GuiceHolder::class.java)
 
     @Suppress("ComplexMethod")
     override fun getJobParser(): ScheduledJobParser {
@@ -330,42 +334,40 @@ class IndexManagementPlugin : JobSchedulerExtension, NetworkPlugin, ActionPlugin
         settingsFilter: SettingsFilter,
         indexNameExpressionResolver: IndexNameExpressionResolver,
         nodesInCluster: Supplier<DiscoveryNodes>,
-    ): List<RestHandler> {
-        return listOf(
-            RestRefreshSearchAnalyzerAction(),
-            RestIndexPolicyAction(settings, clusterService),
-            RestGetPolicyAction(),
-            RestDeletePolicyAction(),
-            RestExplainAction(),
-            RestRetryFailedManagedIndexAction(),
-            RestAddPolicyAction(),
-            RestRemovePolicyAction(),
-            RestChangePolicyAction(),
-            RestDeleteRollupAction(),
-            RestGetRollupAction(),
-            RestIndexRollupAction(),
-            RestStartRollupAction(),
-            RestStopRollupAction(),
-            RestExplainRollupAction(),
-            RestIndexTransformAction(),
-            RestGetTransformAction(),
-            RestPreviewTransformAction(),
-            RestDeleteTransformAction(),
-            RestExplainTransformAction(),
-            RestStartTransformAction(),
-            RestStopTransformAction(),
-            RestGetSMPolicyHandler(),
-            RestStartSMPolicyHandler(),
-            RestStopSMPolicyHandler(),
-            RestExplainSMPolicyHandler(),
-            RestDeleteSMPolicyHandler(),
-            RestCreateSMPolicyHandler(),
-            RestUpdateSMPolicyHandler(),
-            RestIndexLRONConfigAction(),
-            RestGetLRONConfigAction(),
-            RestDeleteLRONConfigAction(),
-        )
-    }
+    ): List<RestHandler> = listOf(
+        RestRefreshSearchAnalyzerAction(),
+        RestIndexPolicyAction(settings, clusterService),
+        RestGetPolicyAction(),
+        RestDeletePolicyAction(),
+        RestExplainAction(),
+        RestRetryFailedManagedIndexAction(),
+        RestAddPolicyAction(),
+        RestRemovePolicyAction(),
+        RestChangePolicyAction(),
+        RestDeleteRollupAction(),
+        RestGetRollupAction(),
+        RestIndexRollupAction(),
+        RestStartRollupAction(),
+        RestStopRollupAction(),
+        RestExplainRollupAction(),
+        RestIndexTransformAction(),
+        RestGetTransformAction(),
+        RestPreviewTransformAction(),
+        RestDeleteTransformAction(),
+        RestExplainTransformAction(),
+        RestStartTransformAction(),
+        RestStopTransformAction(),
+        RestGetSMPolicyHandler(),
+        RestStartSMPolicyHandler(),
+        RestStopSMPolicyHandler(),
+        RestExplainSMPolicyHandler(),
+        RestDeleteSMPolicyHandler(),
+        RestCreateSMPolicyHandler(),
+        RestUpdateSMPolicyHandler(),
+        RestIndexLRONConfigAction(),
+        RestGetLRONConfigAction(),
+        RestDeleteLRONConfigAction(),
+    )
 
     @Suppress("LongMethod")
     override fun createComponents(
@@ -501,140 +503,130 @@ class IndexManagementPlugin : JobSchedulerExtension, NetworkPlugin, ActionPlugin
     }
 
     @Suppress("LongMethod")
-    override fun getSettings(): List<Setting<*>> {
-        return listOf(
-            ManagedIndexSettings.HISTORY_ENABLED,
-            ManagedIndexSettings.HISTORY_INDEX_MAX_AGE,
-            ManagedIndexSettings.HISTORY_MAX_DOCS,
-            ManagedIndexSettings.HISTORY_RETENTION_PERIOD,
-            ManagedIndexSettings.HISTORY_ROLLOVER_CHECK_PERIOD,
-            ManagedIndexSettings.HISTORY_NUMBER_OF_SHARDS,
-            ManagedIndexSettings.HISTORY_NUMBER_OF_REPLICAS,
-            ManagedIndexSettings.POLICY_ID,
-            ManagedIndexSettings.ROLLOVER_ALIAS,
-            ManagedIndexSettings.ROLLOVER_SKIP,
-            ManagedIndexSettings.INDEX_STATE_MANAGEMENT_ENABLED,
-            ManagedIndexSettings.ACTION_VALIDATION_ENABLED,
-            ManagedIndexSettings.AUTO_MANAGE,
-            ManagedIndexSettings.JITTER,
-            ManagedIndexSettings.JOB_INTERVAL,
-            ManagedIndexSettings.SWEEP_PERIOD,
-            ManagedIndexSettings.SWEEP_SKIP_PERIOD,
-            ManagedIndexSettings.COORDINATOR_BACKOFF_COUNT,
-            ManagedIndexSettings.COORDINATOR_BACKOFF_MILLIS,
-            ManagedIndexSettings.ALLOW_LIST,
-            ManagedIndexSettings.SNAPSHOT_DENY_LIST,
-            ManagedIndexSettings.RESTRICTED_INDEX_PATTERN,
-            RollupSettings.ROLLUP_INGEST_BACKOFF_COUNT,
-            RollupSettings.ROLLUP_INGEST_BACKOFF_MILLIS,
-            RollupSettings.ROLLUP_SEARCH_BACKOFF_COUNT,
-            RollupSettings.ROLLUP_SEARCH_BACKOFF_MILLIS,
-            RollupSettings.ROLLUP_INDEX,
-            RollupSettings.ROLLUP_ENABLED,
-            RollupSettings.ROLLUP_SEARCH_ENABLED,
-            RollupSettings.ROLLUP_DASHBOARDS,
-            RollupSettings.ROLLUP_SEARCH_ALL_JOBS,
-            RollupSettings.ROLLUP_SEARCH_SOURCE_INDICES,
-            TransformSettings.TRANSFORM_JOB_INDEX_BACKOFF_COUNT,
-            TransformSettings.TRANSFORM_JOB_INDEX_BACKOFF_MILLIS,
-            TransformSettings.TRANSFORM_JOB_SEARCH_BACKOFF_COUNT,
-            TransformSettings.TRANSFORM_JOB_SEARCH_BACKOFF_MILLIS,
-            TransformSettings.TRANSFORM_CIRCUIT_BREAKER_ENABLED,
-            TransformSettings.TRANSFORM_CIRCUIT_BREAKER_JVM_THRESHOLD,
-            IndexManagementSettings.FILTER_BY_BACKEND_ROLES,
-            LegacyOpenDistroManagedIndexSettings.HISTORY_ENABLED,
-            LegacyOpenDistroManagedIndexSettings.HISTORY_INDEX_MAX_AGE,
-            LegacyOpenDistroManagedIndexSettings.HISTORY_MAX_DOCS,
-            LegacyOpenDistroManagedIndexSettings.HISTORY_RETENTION_PERIOD,
-            LegacyOpenDistroManagedIndexSettings.HISTORY_ROLLOVER_CHECK_PERIOD,
-            LegacyOpenDistroManagedIndexSettings.HISTORY_NUMBER_OF_SHARDS,
-            LegacyOpenDistroManagedIndexSettings.HISTORY_NUMBER_OF_REPLICAS,
-            LegacyOpenDistroManagedIndexSettings.POLICY_ID,
-            LegacyOpenDistroManagedIndexSettings.ROLLOVER_ALIAS,
-            LegacyOpenDistroManagedIndexSettings.ROLLOVER_SKIP,
-            LegacyOpenDistroManagedIndexSettings.INDEX_STATE_MANAGEMENT_ENABLED,
-            LegacyOpenDistroManagedIndexSettings.JOB_INTERVAL,
-            LegacyOpenDistroManagedIndexSettings.SWEEP_PERIOD,
-            LegacyOpenDistroManagedIndexSettings.COORDINATOR_BACKOFF_COUNT,
-            LegacyOpenDistroManagedIndexSettings.COORDINATOR_BACKOFF_MILLIS,
-            LegacyOpenDistroManagedIndexSettings.ALLOW_LIST,
-            LegacyOpenDistroManagedIndexSettings.SNAPSHOT_DENY_LIST,
-            LegacyOpenDistroManagedIndexSettings.AUTO_MANAGE,
-            LegacyOpenDistroManagedIndexSettings.RESTRICTED_INDEX_PATTERN,
-            LegacyOpenDistroRollupSettings.ROLLUP_INGEST_BACKOFF_COUNT,
-            LegacyOpenDistroRollupSettings.ROLLUP_INGEST_BACKOFF_MILLIS,
-            LegacyOpenDistroRollupSettings.ROLLUP_SEARCH_BACKOFF_COUNT,
-            LegacyOpenDistroRollupSettings.ROLLUP_SEARCH_BACKOFF_MILLIS,
-            LegacyOpenDistroRollupSettings.ROLLUP_INDEX,
-            LegacyOpenDistroRollupSettings.ROLLUP_ENABLED,
-            LegacyOpenDistroRollupSettings.ROLLUP_SEARCH_ENABLED,
-            LegacyOpenDistroRollupSettings.ROLLUP_DASHBOARDS,
-            SnapshotManagementSettings.FILTER_BY_BACKEND_ROLES,
-        )
-    }
+    override fun getSettings(): List<Setting<*>> = listOf(
+        ManagedIndexSettings.HISTORY_ENABLED,
+        ManagedIndexSettings.HISTORY_INDEX_MAX_AGE,
+        ManagedIndexSettings.HISTORY_MAX_DOCS,
+        ManagedIndexSettings.HISTORY_RETENTION_PERIOD,
+        ManagedIndexSettings.HISTORY_ROLLOVER_CHECK_PERIOD,
+        ManagedIndexSettings.HISTORY_NUMBER_OF_SHARDS,
+        ManagedIndexSettings.HISTORY_NUMBER_OF_REPLICAS,
+        ManagedIndexSettings.POLICY_ID,
+        ManagedIndexSettings.ROLLOVER_ALIAS,
+        ManagedIndexSettings.ROLLOVER_SKIP,
+        ManagedIndexSettings.INDEX_STATE_MANAGEMENT_ENABLED,
+        ManagedIndexSettings.ACTION_VALIDATION_ENABLED,
+        ManagedIndexSettings.AUTO_MANAGE,
+        ManagedIndexSettings.JITTER,
+        ManagedIndexSettings.JOB_INTERVAL,
+        ManagedIndexSettings.SWEEP_PERIOD,
+        ManagedIndexSettings.SWEEP_SKIP_PERIOD,
+        ManagedIndexSettings.COORDINATOR_BACKOFF_COUNT,
+        ManagedIndexSettings.COORDINATOR_BACKOFF_MILLIS,
+        ManagedIndexSettings.ALLOW_LIST,
+        ManagedIndexSettings.SNAPSHOT_DENY_LIST,
+        ManagedIndexSettings.RESTRICTED_INDEX_PATTERN,
+        RollupSettings.ROLLUP_INGEST_BACKOFF_COUNT,
+        RollupSettings.ROLLUP_INGEST_BACKOFF_MILLIS,
+        RollupSettings.ROLLUP_SEARCH_BACKOFF_COUNT,
+        RollupSettings.ROLLUP_SEARCH_BACKOFF_MILLIS,
+        RollupSettings.ROLLUP_INDEX,
+        RollupSettings.ROLLUP_ENABLED,
+        RollupSettings.ROLLUP_SEARCH_ENABLED,
+        RollupSettings.ROLLUP_DASHBOARDS,
+        RollupSettings.ROLLUP_SEARCH_ALL_JOBS,
+        RollupSettings.ROLLUP_SEARCH_SOURCE_INDICES,
+        TransformSettings.TRANSFORM_JOB_INDEX_BACKOFF_COUNT,
+        TransformSettings.TRANSFORM_JOB_INDEX_BACKOFF_MILLIS,
+        TransformSettings.TRANSFORM_JOB_SEARCH_BACKOFF_COUNT,
+        TransformSettings.TRANSFORM_JOB_SEARCH_BACKOFF_MILLIS,
+        TransformSettings.TRANSFORM_CIRCUIT_BREAKER_ENABLED,
+        TransformSettings.TRANSFORM_CIRCUIT_BREAKER_JVM_THRESHOLD,
+        IndexManagementSettings.FILTER_BY_BACKEND_ROLES,
+        LegacyOpenDistroManagedIndexSettings.HISTORY_ENABLED,
+        LegacyOpenDistroManagedIndexSettings.HISTORY_INDEX_MAX_AGE,
+        LegacyOpenDistroManagedIndexSettings.HISTORY_MAX_DOCS,
+        LegacyOpenDistroManagedIndexSettings.HISTORY_RETENTION_PERIOD,
+        LegacyOpenDistroManagedIndexSettings.HISTORY_ROLLOVER_CHECK_PERIOD,
+        LegacyOpenDistroManagedIndexSettings.HISTORY_NUMBER_OF_SHARDS,
+        LegacyOpenDistroManagedIndexSettings.HISTORY_NUMBER_OF_REPLICAS,
+        LegacyOpenDistroManagedIndexSettings.POLICY_ID,
+        LegacyOpenDistroManagedIndexSettings.ROLLOVER_ALIAS,
+        LegacyOpenDistroManagedIndexSettings.ROLLOVER_SKIP,
+        LegacyOpenDistroManagedIndexSettings.INDEX_STATE_MANAGEMENT_ENABLED,
+        LegacyOpenDistroManagedIndexSettings.JOB_INTERVAL,
+        LegacyOpenDistroManagedIndexSettings.SWEEP_PERIOD,
+        LegacyOpenDistroManagedIndexSettings.COORDINATOR_BACKOFF_COUNT,
+        LegacyOpenDistroManagedIndexSettings.COORDINATOR_BACKOFF_MILLIS,
+        LegacyOpenDistroManagedIndexSettings.ALLOW_LIST,
+        LegacyOpenDistroManagedIndexSettings.SNAPSHOT_DENY_LIST,
+        LegacyOpenDistroManagedIndexSettings.AUTO_MANAGE,
+        LegacyOpenDistroManagedIndexSettings.RESTRICTED_INDEX_PATTERN,
+        LegacyOpenDistroRollupSettings.ROLLUP_INGEST_BACKOFF_COUNT,
+        LegacyOpenDistroRollupSettings.ROLLUP_INGEST_BACKOFF_MILLIS,
+        LegacyOpenDistroRollupSettings.ROLLUP_SEARCH_BACKOFF_COUNT,
+        LegacyOpenDistroRollupSettings.ROLLUP_SEARCH_BACKOFF_MILLIS,
+        LegacyOpenDistroRollupSettings.ROLLUP_INDEX,
+        LegacyOpenDistroRollupSettings.ROLLUP_ENABLED,
+        LegacyOpenDistroRollupSettings.ROLLUP_SEARCH_ENABLED,
+        LegacyOpenDistroRollupSettings.ROLLUP_DASHBOARDS,
+        SnapshotManagementSettings.FILTER_BY_BACKEND_ROLES,
+    )
 
-    override fun getActions(): List<ActionPlugin.ActionHandler<out ActionRequest, out ActionResponse>> {
-        return listOf(
-            ActionPlugin.ActionHandler(RemovePolicyAction.INSTANCE, TransportRemovePolicyAction::class.java),
-            ActionPlugin.ActionHandler(RefreshSearchAnalyzerAction.INSTANCE, TransportRefreshSearchAnalyzerAction::class.java),
-            ActionPlugin.ActionHandler(AddPolicyAction.INSTANCE, TransportAddPolicyAction::class.java),
-            ActionPlugin.ActionHandler(RetryFailedManagedIndexAction.INSTANCE, TransportRetryFailedManagedIndexAction::class.java),
-            ActionPlugin.ActionHandler(ChangePolicyAction.INSTANCE, TransportChangePolicyAction::class.java),
-            ActionPlugin.ActionHandler(IndexPolicyAction.INSTANCE, TransportIndexPolicyAction::class.java),
-            ActionPlugin.ActionHandler(ExplainAction.INSTANCE, TransportExplainAction::class.java),
-            ActionPlugin.ActionHandler(DeletePolicyAction.INSTANCE, TransportDeletePolicyAction::class.java),
-            ActionPlugin.ActionHandler(GetPolicyAction.INSTANCE, TransportGetPolicyAction::class.java),
-            ActionPlugin.ActionHandler(GetPoliciesAction.INSTANCE, TransportGetPoliciesAction::class.java),
-            ActionPlugin.ActionHandler(DeleteRollupAction.INSTANCE, TransportDeleteRollupAction::class.java),
-            ActionPlugin.ActionHandler(GetRollupAction.INSTANCE, TransportGetRollupAction::class.java),
-            ActionPlugin.ActionHandler(GetRollupsAction.INSTANCE, TransportGetRollupsAction::class.java),
-            ActionPlugin.ActionHandler(IndexRollupAction.INSTANCE, TransportIndexRollupAction::class.java),
-            ActionPlugin.ActionHandler(StartRollupAction.INSTANCE, TransportStartRollupAction::class.java),
-            ActionPlugin.ActionHandler(StopRollupAction.INSTANCE, TransportStopRollupAction::class.java),
-            ActionPlugin.ActionHandler(ExplainRollupAction.INSTANCE, TransportExplainRollupAction::class.java),
-            ActionPlugin.ActionHandler(UpdateRollupMappingAction.INSTANCE, TransportUpdateRollupMappingAction::class.java),
-            ActionPlugin.ActionHandler(IndexTransformAction.INSTANCE, TransportIndexTransformAction::class.java),
-            ActionPlugin.ActionHandler(GetTransformAction.INSTANCE, TransportGetTransformAction::class.java),
-            ActionPlugin.ActionHandler(GetTransformsAction.INSTANCE, TransportGetTransformsAction::class.java),
-            ActionPlugin.ActionHandler(PreviewTransformAction.INSTANCE, TransportPreviewTransformAction::class.java),
-            ActionPlugin.ActionHandler(DeleteTransformsAction.INSTANCE, TransportDeleteTransformsAction::class.java),
-            ActionPlugin.ActionHandler(ExplainTransformAction.INSTANCE, TransportExplainTransformAction::class.java),
-            ActionPlugin.ActionHandler(StartTransformAction.INSTANCE, TransportStartTransformAction::class.java),
-            ActionPlugin.ActionHandler(StopTransformAction.INSTANCE, TransportStopTransformAction::class.java),
-            ActionPlugin.ActionHandler(ManagedIndexAction.INSTANCE, TransportManagedIndexAction::class.java),
-            ActionPlugin.ActionHandler(SMActions.INDEX_SM_POLICY_ACTION_TYPE, TransportIndexSMPolicyAction::class.java),
-            ActionPlugin.ActionHandler(SMActions.GET_SM_POLICY_ACTION_TYPE, TransportGetSMPolicyAction::class.java),
-            ActionPlugin.ActionHandler(SMActions.DELETE_SM_POLICY_ACTION_TYPE, TransportDeleteSMPolicyAction::class.java),
-            ActionPlugin.ActionHandler(SMActions.START_SM_POLICY_ACTION_TYPE, TransportStartSMAction::class.java),
-            ActionPlugin.ActionHandler(SMActions.STOP_SM_POLICY_ACTION_TYPE, TransportStopSMAction::class.java),
-            ActionPlugin.ActionHandler(SMActions.EXPLAIN_SM_POLICY_ACTION_TYPE, TransportExplainSMAction::class.java),
-            ActionPlugin.ActionHandler(SMActions.GET_SM_POLICIES_ACTION_TYPE, TransportGetSMPoliciesAction::class.java),
-            ActionPlugin.ActionHandler(IndexLRONConfigAction.INSTANCE, TransportIndexLRONConfigAction::class.java),
-            ActionPlugin.ActionHandler(GetLRONConfigAction.INSTANCE, TransportGetLRONConfigAction::class.java),
-            ActionPlugin.ActionHandler(DeleteLRONConfigAction.INSTANCE, TransportDeleteLRONConfigAction::class.java),
-        )
-    }
+    override fun getActions(): List<ActionPlugin.ActionHandler<out ActionRequest, out ActionResponse>> = listOf(
+        ActionPlugin.ActionHandler(RemovePolicyAction.INSTANCE, TransportRemovePolicyAction::class.java),
+        ActionPlugin.ActionHandler(RefreshSearchAnalyzerAction.INSTANCE, TransportRefreshSearchAnalyzerAction::class.java),
+        ActionPlugin.ActionHandler(AddPolicyAction.INSTANCE, TransportAddPolicyAction::class.java),
+        ActionPlugin.ActionHandler(RetryFailedManagedIndexAction.INSTANCE, TransportRetryFailedManagedIndexAction::class.java),
+        ActionPlugin.ActionHandler(ChangePolicyAction.INSTANCE, TransportChangePolicyAction::class.java),
+        ActionPlugin.ActionHandler(IndexPolicyAction.INSTANCE, TransportIndexPolicyAction::class.java),
+        ActionPlugin.ActionHandler(ExplainAction.INSTANCE, TransportExplainAction::class.java),
+        ActionPlugin.ActionHandler(DeletePolicyAction.INSTANCE, TransportDeletePolicyAction::class.java),
+        ActionPlugin.ActionHandler(GetPolicyAction.INSTANCE, TransportGetPolicyAction::class.java),
+        ActionPlugin.ActionHandler(GetPoliciesAction.INSTANCE, TransportGetPoliciesAction::class.java),
+        ActionPlugin.ActionHandler(DeleteRollupAction.INSTANCE, TransportDeleteRollupAction::class.java),
+        ActionPlugin.ActionHandler(GetRollupAction.INSTANCE, TransportGetRollupAction::class.java),
+        ActionPlugin.ActionHandler(GetRollupsAction.INSTANCE, TransportGetRollupsAction::class.java),
+        ActionPlugin.ActionHandler(IndexRollupAction.INSTANCE, TransportIndexRollupAction::class.java),
+        ActionPlugin.ActionHandler(StartRollupAction.INSTANCE, TransportStartRollupAction::class.java),
+        ActionPlugin.ActionHandler(StopRollupAction.INSTANCE, TransportStopRollupAction::class.java),
+        ActionPlugin.ActionHandler(ExplainRollupAction.INSTANCE, TransportExplainRollupAction::class.java),
+        ActionPlugin.ActionHandler(UpdateRollupMappingAction.INSTANCE, TransportUpdateRollupMappingAction::class.java),
+        ActionPlugin.ActionHandler(IndexTransformAction.INSTANCE, TransportIndexTransformAction::class.java),
+        ActionPlugin.ActionHandler(GetTransformAction.INSTANCE, TransportGetTransformAction::class.java),
+        ActionPlugin.ActionHandler(GetTransformsAction.INSTANCE, TransportGetTransformsAction::class.java),
+        ActionPlugin.ActionHandler(PreviewTransformAction.INSTANCE, TransportPreviewTransformAction::class.java),
+        ActionPlugin.ActionHandler(DeleteTransformsAction.INSTANCE, TransportDeleteTransformsAction::class.java),
+        ActionPlugin.ActionHandler(ExplainTransformAction.INSTANCE, TransportExplainTransformAction::class.java),
+        ActionPlugin.ActionHandler(StartTransformAction.INSTANCE, TransportStartTransformAction::class.java),
+        ActionPlugin.ActionHandler(StopTransformAction.INSTANCE, TransportStopTransformAction::class.java),
+        ActionPlugin.ActionHandler(ManagedIndexAction.INSTANCE, TransportManagedIndexAction::class.java),
+        ActionPlugin.ActionHandler(SMActions.INDEX_SM_POLICY_ACTION_TYPE, TransportIndexSMPolicyAction::class.java),
+        ActionPlugin.ActionHandler(SMActions.GET_SM_POLICY_ACTION_TYPE, TransportGetSMPolicyAction::class.java),
+        ActionPlugin.ActionHandler(SMActions.DELETE_SM_POLICY_ACTION_TYPE, TransportDeleteSMPolicyAction::class.java),
+        ActionPlugin.ActionHandler(SMActions.START_SM_POLICY_ACTION_TYPE, TransportStartSMAction::class.java),
+        ActionPlugin.ActionHandler(SMActions.STOP_SM_POLICY_ACTION_TYPE, TransportStopSMAction::class.java),
+        ActionPlugin.ActionHandler(SMActions.EXPLAIN_SM_POLICY_ACTION_TYPE, TransportExplainSMAction::class.java),
+        ActionPlugin.ActionHandler(SMActions.GET_SM_POLICIES_ACTION_TYPE, TransportGetSMPoliciesAction::class.java),
+        ActionPlugin.ActionHandler(IndexLRONConfigAction.INSTANCE, TransportIndexLRONConfigAction::class.java),
+        ActionPlugin.ActionHandler(GetLRONConfigAction.INSTANCE, TransportGetLRONConfigAction::class.java),
+        ActionPlugin.ActionHandler(DeleteLRONConfigAction.INSTANCE, TransportDeleteLRONConfigAction::class.java),
+    )
 
-    override fun getTransportInterceptors(namedWriteableRegistry: NamedWriteableRegistry, threadContext: ThreadContext): List<TransportInterceptor> {
-        return listOf(rollupInterceptor)
-    }
+    override fun getTransportInterceptors(namedWriteableRegistry: NamedWriteableRegistry, threadContext: ThreadContext): List<TransportInterceptor> = listOf(rollupInterceptor)
 
-    override fun getActionFilters(): List<ActionFilter> {
-        return listOf(fieldCapsFilter, indexOperationActionFilter)
-    }
+    override fun getActionFilters(): List<ActionFilter> = listOf(fieldCapsFilter, indexOperationActionFilter)
 
-    override fun getSystemIndexDescriptors(settings: Settings): Collection<SystemIndexDescriptor> {
-        return listOf(
-            SystemIndexDescriptor(
-                INDEX_MANAGEMENT_INDEX,
-                "Index for storing index management configuration and metadata.",
-            ),
-            SystemIndexDescriptor(
-                CONTROL_CENTER_INDEX,
-                "Index for storing notification policy of long running index operations.",
-            ),
-        )
-    }
+    override fun getSystemIndexDescriptors(settings: Settings): Collection<SystemIndexDescriptor> = listOf(
+        SystemIndexDescriptor(
+            INDEX_MANAGEMENT_INDEX,
+            "Index for storing index management configuration and metadata.",
+        ),
+        SystemIndexDescriptor(
+            CONTROL_CENTER_INDEX,
+            "Index for storing notification policy of long running index operations.",
+        ),
+    )
 }
 
 class GuiceHolder
@@ -644,9 +636,7 @@ constructor(
 ) : LifecycleComponent {
     override fun close() { /* do nothing */ }
 
-    override fun lifecycleState(): Lifecycle.State? {
-        return null
-    }
+    override fun lifecycleState(): Lifecycle.State? = null
 
     override fun addLifecycleListener(listener: LifecycleListener) { /* do nothing */ }
 

--- a/src/main/kotlin/org/opensearch/indexmanagement/IndexManagementPlugin.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/IndexManagementPlugin.kt
@@ -613,7 +613,10 @@ class IndexManagementPlugin :
         ActionPlugin.ActionHandler(DeleteLRONConfigAction.INSTANCE, TransportDeleteLRONConfigAction::class.java),
     )
 
-    override fun getTransportInterceptors(namedWriteableRegistry: NamedWriteableRegistry, threadContext: ThreadContext): List<TransportInterceptor> = listOf(rollupInterceptor)
+    override fun getTransportInterceptors(
+        namedWriteableRegistry: NamedWriteableRegistry,
+        threadContext: ThreadContext,
+    ): List<TransportInterceptor> = listOf(rollupInterceptor)
 
     override fun getActionFilters(): List<ActionFilter> = listOf(fieldCapsFilter, indexOperationActionFilter)
 

--- a/src/main/kotlin/org/opensearch/indexmanagement/common/model/dimension/Dimension.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/common/model/dimension/Dimension.kt
@@ -18,16 +18,15 @@ abstract class Dimension(
     val type: Type,
     open val sourceField: String,
     open val targetField: String,
-) : ToXContentObject, Writeable {
+) : ToXContentObject,
+    Writeable {
     enum class Type(val type: String) {
         DATE_HISTOGRAM("date_histogram"),
         TERMS("terms"),
         HISTOGRAM("histogram"),
         ;
 
-        override fun toString(): String {
-            return type
-        }
+        override fun toString(): String = type
     }
 
     abstract fun toSourceBuilder(appendType: Boolean = false): CompositeValuesSourceBuilder<*>

--- a/src/main/kotlin/org/opensearch/indexmanagement/common/model/dimension/Histogram.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/common/model/dimension/Histogram.kt
@@ -40,15 +40,13 @@ data class Histogram(
         interval = sin.readDouble(),
     )
 
-    override fun toXContent(builder: XContentBuilder, params: ToXContent.Params): XContentBuilder {
-        return builder.startObject()
-            .startObject(type.type)
-            .field(DIMENSION_SOURCE_FIELD_FIELD, sourceField)
-            .field(DIMENSION_TARGET_FIELD_FIELD, targetField)
-            .field(HISTOGRAM_INTERVAL_FIELD, interval)
-            .endObject()
-            .endObject()
-    }
+    override fun toXContent(builder: XContentBuilder, params: ToXContent.Params): XContentBuilder = builder.startObject()
+        .startObject(type.type)
+        .field(DIMENSION_SOURCE_FIELD_FIELD, sourceField)
+        .field(DIMENSION_TARGET_FIELD_FIELD, targetField)
+        .field(HISTOGRAM_INTERVAL_FIELD, interval)
+        .endObject()
+        .endObject()
 
     override fun writeTo(out: StreamOutput) {
         out.writeString(sourceField)

--- a/src/main/kotlin/org/opensearch/indexmanagement/common/model/dimension/Terms.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/common/model/dimension/Terms.kt
@@ -35,14 +35,12 @@ data class Terms(
         targetField = sin.readString(),
     )
 
-    override fun toXContent(builder: XContentBuilder, params: ToXContent.Params): XContentBuilder {
-        return builder.startObject()
-            .startObject(type.type)
-            .field(DIMENSION_SOURCE_FIELD_FIELD, sourceField)
-            .field(DIMENSION_TARGET_FIELD_FIELD, targetField)
-            .endObject()
-            .endObject()
-    }
+    override fun toXContent(builder: XContentBuilder, params: ToXContent.Params): XContentBuilder = builder.startObject()
+        .startObject(type.type)
+        .field(DIMENSION_SOURCE_FIELD_FIELD, sourceField)
+        .field(DIMENSION_TARGET_FIELD_FIELD, targetField)
+        .endObject()
+        .endObject()
 
     override fun writeTo(out: StreamOutput) {
         out.writeString(sourceField)
@@ -56,9 +54,7 @@ data class Terms(
             .field(this.sourceField)
     }
 
-    override fun toBucketQuery(bucketKey: Any): AbstractQueryBuilder<*> {
-        return TermsQueryBuilder(sourceField, bucketKey)
-    }
+    override fun toBucketQuery(bucketKey: Any): AbstractQueryBuilder<*> = TermsQueryBuilder(sourceField, bucketKey)
 
     override fun canBeRealizedInMappings(mappings: Map<String, Any>): Boolean {
         val fieldType = getFieldFromMappings(sourceField, mappings)?.get("type") ?: return false

--- a/src/main/kotlin/org/opensearch/indexmanagement/common/model/notification/Channel.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/common/model/notification/Channel.kt
@@ -24,16 +24,16 @@ import org.opensearch.indexmanagement.opensearchapi.suspendUntil
 import org.opensearch.indexmanagement.util.SecurityUtils.Companion.generateUserString
 import java.io.IOException
 
-data class Channel(val id: String) : ToXContent, Writeable {
+data class Channel(val id: String) :
+    ToXContent,
+    Writeable {
     init {
         require(id.isNotEmpty()) { "Channel ID cannot be empty" }
     }
 
-    override fun toXContent(builder: XContentBuilder, params: ToXContent.Params): XContentBuilder {
-        return builder.startObject()
-            .field(ID, id)
-            .endObject()
-    }
+    override fun toXContent(builder: XContentBuilder, params: ToXContent.Params): XContentBuilder = builder.startObject()
+        .field(ID, id)
+        .endObject()
 
     @Throws(IOException::class)
     constructor(sin: StreamInput) : this(

--- a/src/main/kotlin/org/opensearch/indexmanagement/common/model/rest/SearchParams.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/common/model/rest/SearchParams.kt
@@ -44,9 +44,7 @@ data class SearchParams(
         out.writeString(queryString)
     }
 
-    fun getSortBuilder(): FieldSortBuilder {
-        return SortBuilders
-            .fieldSort(this.sortField)
-            .order(SortOrder.fromString(this.sortOrder))
-    }
+    fun getSortBuilder(): FieldSortBuilder = SortBuilders
+        .fieldSort(this.sortField)
+        .order(SortOrder.fromString(this.sortOrder))
 }

--- a/src/main/kotlin/org/opensearch/indexmanagement/controlcenter/notification/LRONConfigResponse.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/controlcenter/notification/LRONConfigResponse.kt
@@ -21,7 +21,8 @@ import java.io.IOException
 class LRONConfigResponse(
     val id: String,
     val lronConfig: LRONConfig,
-) : ActionResponse(), ToXContentObject {
+) : ActionResponse(),
+    ToXContentObject {
     @Throws(IOException::class)
     constructor(sin: StreamInput) : this(
         id = sin.readString(),

--- a/src/main/kotlin/org/opensearch/indexmanagement/controlcenter/notification/action/get/GetLRONConfigResponse.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/controlcenter/notification/action/get/GetLRONConfigResponse.kt
@@ -20,7 +20,8 @@ import java.io.IOException
 class GetLRONConfigResponse(
     val lronConfigResponses: List<LRONConfigResponse>,
     val totalNumber: Int,
-) : ActionResponse(), ToXContentObject {
+) : ActionResponse(),
+    ToXContentObject {
     @Throws(IOException::class)
     constructor(sin: StreamInput) : this(
         lronConfigResponses = sin.readList(::LRONConfigResponse),

--- a/src/main/kotlin/org/opensearch/indexmanagement/controlcenter/notification/action/index/IndexLRONConfigAction.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/controlcenter/notification/action/index/IndexLRONConfigAction.kt
@@ -8,8 +8,7 @@ package org.opensearch.indexmanagement.controlcenter.notification.action.index
 import org.opensearch.action.ActionType
 import org.opensearch.indexmanagement.controlcenter.notification.LRONConfigResponse
 
-class IndexLRONConfigAction private constructor() :
-    ActionType<LRONConfigResponse>(NAME, ::LRONConfigResponse) {
+class IndexLRONConfigAction private constructor() : ActionType<LRONConfigResponse>(NAME, ::LRONConfigResponse) {
     companion object {
         val INSTANCE = IndexLRONConfigAction()
         const val NAME = "cluster:admin/opensearch/controlcenter/lron/write"

--- a/src/main/kotlin/org/opensearch/indexmanagement/controlcenter/notification/filter/NotificationActionListener.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/controlcenter/notification/filter/NotificationActionListener.kt
@@ -294,9 +294,7 @@ class NotificationActionListener<Request : ActionRequest, Response : ActionRespo
         }.toSet()
     }
 
-    fun escapeQueryString(query: String): String {
-        return query.replace("/", "\\/").replace(":", "\\:")
-    }
+    fun escapeQueryString(query: String): String = query.replace("/", "\\/").replace(":", "\\:")
 
     companion object {
         val MAX_WAIT_TIME: TimeValue = TimeValue.timeValueHours(1)

--- a/src/main/kotlin/org/opensearch/indexmanagement/controlcenter/notification/filter/parser/ForceMergeIndexRespParser.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/controlcenter/notification/filter/parser/ForceMergeIndexRespParser.kt
@@ -14,8 +14,7 @@ import org.opensearch.indexmanagement.controlcenter.notification.filter.Operatio
 import java.lang.Exception
 import java.util.function.Consumer
 
-class ForceMergeIndexRespParser(val request: ForceMergeRequest, val clusterService: ClusterService) :
-    ResponseParser<ForceMergeResponse> {
+class ForceMergeIndexRespParser(val request: ForceMergeRequest, val clusterService: ClusterService) : ResponseParser<ForceMergeResponse> {
     private val indexNameWithCluster = getIndexName(request, clusterService)
 
     override fun parseAndSendNotification(
@@ -60,20 +59,18 @@ class ForceMergeIndexRespParser(val request: ForceMergeRequest, val clusterServi
         response: ForceMergeResponse?,
         exception: Exception?,
         isTimeout: Boolean,
-    ): String {
-        return if (exception != null) {
-            if (exception is OpenSearchException) {
-                "index [" + exception.index.name + "] ${exception.message}."
-            } else {
-                exception.message ?: ""
-            }
-        } else if (response != null && !response.shardFailures.isNullOrEmpty()) {
-            response.shardFailures.joinToString(",") { "index [${it.index()}] shard [${it.shardId()}] ${it.reason()}" }
-        } else if (request.indices().size == 1) {
-            "The force merge operation on $indexNameWithCluster ${NotificationActionListener.COMPLETED}"
+    ): String = if (exception != null) {
+        if (exception is OpenSearchException) {
+            "index [" + exception.index.name + "] ${exception.message}."
         } else {
-            "$indexNameWithCluster have been merged."
+            exception.message ?: ""
         }
+    } else if (response != null && !response.shardFailures.isNullOrEmpty()) {
+        response.shardFailures.joinToString(",") { "index [${it.index()}] shard [${it.shardId()}] ${it.reason()}" }
+    } else if (request.indices().size == 1) {
+        "The force merge operation on $indexNameWithCluster ${NotificationActionListener.COMPLETED}"
+    } else {
+        "$indexNameWithCluster have been merged."
     }
 
     override fun buildNotificationTitle(operationResult: OperationResult): String {

--- a/src/main/kotlin/org/opensearch/indexmanagement/controlcenter/notification/filter/parser/ReindexRespParser.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/controlcenter/notification/filter/parser/ReindexRespParser.kt
@@ -118,7 +118,5 @@ class ReindexRespParser(
         return result.toString()
     }
 
-    override fun buildNotificationTitle(operationResult: OperationResult): String {
-        return "Reindex operation on $sourceIndex has ${getOperationResultTitleDesc(operationResult)}"
-    }
+    override fun buildNotificationTitle(operationResult: OperationResult): String = "Reindex operation on $sourceIndex has ${getOperationResultTitleDesc(operationResult)}"
 }

--- a/src/main/kotlin/org/opensearch/indexmanagement/controlcenter/notification/filter/parser/ReindexRespParser.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/controlcenter/notification/filter/parser/ReindexRespParser.kt
@@ -118,5 +118,6 @@ class ReindexRespParser(
         return result.toString()
     }
 
-    override fun buildNotificationTitle(operationResult: OperationResult): String = "Reindex operation on $sourceIndex has ${getOperationResultTitleDesc(operationResult)}"
+    override fun buildNotificationTitle(operationResult: OperationResult): String =
+        "Reindex operation on $sourceIndex has ${getOperationResultTitleDesc(operationResult)}"
 }

--- a/src/main/kotlin/org/opensearch/indexmanagement/controlcenter/notification/filter/parser/ResponseParser.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/controlcenter/notification/filter/parser/ResponseParser.kt
@@ -57,12 +57,10 @@ interface ResponseParser<Response : ActionResponse> {
         }
     }
 
-    fun getOperationResultTitleDesc(result: OperationResult): String {
-        return when (result) {
-            OperationResult.COMPLETE -> "completed"
-            OperationResult.FAILED -> "failed"
-            OperationResult.TIMEOUT -> "timed out"
-            OperationResult.CANCELLED -> "been cancelled"
-        }
+    fun getOperationResultTitleDesc(result: OperationResult): String = when (result) {
+        OperationResult.COMPLETE -> "completed"
+        OperationResult.FAILED -> "failed"
+        OperationResult.TIMEOUT -> "timed out"
+        OperationResult.CANCELLED -> "been cancelled"
     }
 }

--- a/src/main/kotlin/org/opensearch/indexmanagement/controlcenter/notification/model/LRONCondition.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/controlcenter/notification/model/LRONCondition.kt
@@ -20,17 +20,14 @@ import java.io.IOException
 data class LRONCondition(
     val success: Boolean = DEFAULT_ENABLED,
     val failure: Boolean = DEFAULT_ENABLED,
-) : ToXContentObject, Writeable {
-    fun toXContent(builder: XContentBuilder): XContentBuilder {
-        return toXContent(builder, ToXContent.EMPTY_PARAMS)
-    }
+) : ToXContentObject,
+    Writeable {
+    fun toXContent(builder: XContentBuilder): XContentBuilder = toXContent(builder, ToXContent.EMPTY_PARAMS)
 
-    override fun toXContent(builder: XContentBuilder, params: ToXContent.Params): XContentBuilder {
-        return builder.startObject()
-            .field(SUCCESS_FIELD, success)
-            .field(FAILURE_FIELD, failure)
-            .endObject()
-    }
+    override fun toXContent(builder: XContentBuilder, params: ToXContent.Params): XContentBuilder = builder.startObject()
+        .field(SUCCESS_FIELD, success)
+        .field(FAILURE_FIELD, failure)
+        .endObject()
 
     @Throws(IOException::class)
     constructor(sin: StreamInput) : this(
@@ -44,9 +41,7 @@ data class LRONCondition(
         out.writeBoolean(failure)
     }
 
-    fun isEnabled(): Boolean {
-        return success || failure
-    }
+    fun isEnabled(): Boolean = success || failure
 
     companion object {
         const val SUCCESS_FIELD = "success"
@@ -62,9 +57,7 @@ data class LRONCondition(
             id: String = NO_ID,
             seqNo: Long = SequenceNumbers.UNASSIGNED_SEQ_NO,
             primaryTerm: Long = SequenceNumbers.UNASSIGNED_PRIMARY_TERM,
-        ): LRONCondition {
-            return parse(xcp)
-        }
+        ): LRONCondition = parse(xcp)
 
         @JvmStatic
         @Suppress("MaxLineLength", "ComplexMethod", "NestedBlockDepth")

--- a/src/main/kotlin/org/opensearch/indexmanagement/controlcenter/notification/model/LRONConfig.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/controlcenter/notification/model/LRONConfig.kt
@@ -32,7 +32,8 @@ data class LRONConfig(
     val channels: List<Channel>?,
     val user: User?,
     val priority: Int?,
-) : ToXContentObject, Writeable {
+) : ToXContentObject,
+    Writeable {
     init {
         validateTaskIdAndActionName(taskId, actionName)
         if (lronCondition.isEnabled()) {
@@ -40,9 +41,7 @@ data class LRONConfig(
         }
     }
 
-    fun toXContent(builder: XContentBuilder): XContentBuilder {
-        return toXContent(builder, ToXContent.EMPTY_PARAMS)
-    }
+    fun toXContent(builder: XContentBuilder): XContentBuilder = toXContent(builder, ToXContent.EMPTY_PARAMS)
 
     override fun toXContent(builder: XContentBuilder, params: ToXContent.Params): XContentBuilder {
         builder.startObject()
@@ -120,9 +119,7 @@ data class LRONConfig(
             id: String = NO_ID,
             seqNo: Long = SequenceNumbers.UNASSIGNED_SEQ_NO,
             primaryTerm: Long = SequenceNumbers.UNASSIGNED_PRIMARY_TERM,
-        ): LRONConfig {
-            return parse(xcp)
-        }
+        ): LRONConfig = parse(xcp)
 
         @JvmStatic
         @Suppress("MaxLineLength", "ComplexMethod", "NestedBlockDepth")

--- a/src/main/kotlin/org/opensearch/indexmanagement/controlcenter/notification/resthandler/RestDeleteLRONConfigAction.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/controlcenter/notification/resthandler/RestDeleteLRONConfigAction.kt
@@ -16,15 +16,11 @@ import org.opensearch.rest.action.RestToXContentListener
 import java.io.IOException
 
 class RestDeleteLRONConfigAction : BaseRestHandler() {
-    override fun routes(): List<RestHandler.Route> {
-        return listOf(
-            RestHandler.Route(RestRequest.Method.DELETE, "${IndexManagementPlugin.LRON_BASE_URI}/{id}"),
-        )
-    }
+    override fun routes(): List<RestHandler.Route> = listOf(
+        RestHandler.Route(RestRequest.Method.DELETE, "${IndexManagementPlugin.LRON_BASE_URI}/{id}"),
+    )
 
-    override fun getName(): String {
-        return "delete_lron_config_action"
-    }
+    override fun getName(): String = "delete_lron_config_action"
 
     @Throws(IOException::class)
     override fun prepareRequest(request: RestRequest, client: NodeClient): RestChannelConsumer {

--- a/src/main/kotlin/org/opensearch/indexmanagement/controlcenter/notification/resthandler/RestGetLRONConfigAction.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/controlcenter/notification/resthandler/RestGetLRONConfigAction.kt
@@ -18,16 +18,12 @@ import org.opensearch.rest.action.RestToXContentListener
 import java.io.IOException
 
 class RestGetLRONConfigAction : BaseRestHandler() {
-    override fun routes(): List<RestHandler.Route> {
-        return listOf(
-            RestHandler.Route(RestRequest.Method.GET, IndexManagementPlugin.LRON_BASE_URI),
-            RestHandler.Route(RestRequest.Method.GET, "${IndexManagementPlugin.LRON_BASE_URI}/{id}"),
-        )
-    }
+    override fun routes(): List<RestHandler.Route> = listOf(
+        RestHandler.Route(RestRequest.Method.GET, IndexManagementPlugin.LRON_BASE_URI),
+        RestHandler.Route(RestRequest.Method.GET, "${IndexManagementPlugin.LRON_BASE_URI}/{id}"),
+    )
 
-    override fun getName(): String {
-        return "get_lron_config_action"
-    }
+    override fun getName(): String = "get_lron_config_action"
 
     @Throws(IOException::class)
     override fun prepareRequest(request: RestRequest, client: NodeClient): RestChannelConsumer {

--- a/src/main/kotlin/org/opensearch/indexmanagement/controlcenter/notification/resthandler/RestIndexLRONConfigAction.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/controlcenter/notification/resthandler/RestIndexLRONConfigAction.kt
@@ -21,16 +21,12 @@ import org.opensearch.rest.action.RestToXContentListener
 import java.io.IOException
 
 class RestIndexLRONConfigAction : BaseRestHandler() {
-    override fun routes(): List<RestHandler.Route> {
-        return listOf(
-            RestHandler.Route(RestRequest.Method.POST, IndexManagementPlugin.LRON_BASE_URI),
-            RestHandler.Route(RestRequest.Method.PUT, "${IndexManagementPlugin.LRON_BASE_URI}/{id}"),
-        )
-    }
+    override fun routes(): List<RestHandler.Route> = listOf(
+        RestHandler.Route(RestRequest.Method.POST, IndexManagementPlugin.LRON_BASE_URI),
+        RestHandler.Route(RestRequest.Method.PUT, "${IndexManagementPlugin.LRON_BASE_URI}/{id}"),
+    )
 
-    override fun getName(): String {
-        return "create_lron_config_action"
-    }
+    override fun getName(): String = "create_lron_config_action"
 
     @Throws(IOException::class)
     override fun prepareRequest(request: RestRequest, client: NodeClient): RestChannelConsumer {

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/DefaultIndexMetadataService.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/DefaultIndexMetadataService.kt
@@ -51,17 +51,13 @@ class DefaultIndexMetadataService(private val customUUIDSetting: String? = null)
      * This method prioritize the custom index setting provided by extension to decide the index UUID
      * Custom index UUID is needed when index moved out of cluster and re-attach back, it will get a new UUID in cluster metadata
      */
-    fun getIndexUUID(indexMetadata: IndexMetadata): String {
-        return if (customUUIDSetting != null) {
-            indexMetadata.settings.get(customUUIDSetting, indexMetadata.indexUUID)
-        } else {
-            indexMetadata.indexUUID
-        }
+    fun getIndexUUID(indexMetadata: IndexMetadata): String = if (customUUIDSetting != null) {
+        indexMetadata.settings.get(customUUIDSetting, indexMetadata.indexUUID)
+    } else {
+        indexMetadata.indexUUID
     }
 
-    override suspend fun getMetadataForAllIndices(client: Client, clusterService: ClusterService): Map<String, ISMIndexMetadata> {
-        return getMetadata(listOf("*"), client, clusterService)
-    }
+    override suspend fun getMetadataForAllIndices(client: Client, clusterService: ClusterService): Map<String, ISMIndexMetadata> = getMetadata(listOf("*"), client, clusterService)
 
     companion object {
         const val DEFAULT_GET_METADATA_TIMEOUT_IN_MILLIS = 30000L

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/DefaultIndexMetadataService.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/DefaultIndexMetadataService.kt
@@ -57,7 +57,8 @@ class DefaultIndexMetadataService(private val customUUIDSetting: String? = null)
         indexMetadata.indexUUID
     }
 
-    override suspend fun getMetadataForAllIndices(client: Client, clusterService: ClusterService): Map<String, ISMIndexMetadata> = getMetadata(listOf("*"), client, clusterService)
+    override suspend fun getMetadataForAllIndices(client: Client, clusterService: ClusterService): Map<String, ISMIndexMetadata> =
+        getMetadata(listOf("*"), client, clusterService)
 
     companion object {
         const val DEFAULT_GET_METADATA_TIMEOUT_IN_MILLIS = 30000L

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/IndexMetadataProvider.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/IndexMetadataProvider.kt
@@ -35,9 +35,7 @@ class IndexMetadataProvider(
         }
     }
 
-    fun isUnManageableIndex(index: String): Boolean {
-        return Regex(restrictedIndexPattern).matches(index)
-    }
+    fun isUnManageableIndex(index: String): Boolean = Regex(restrictedIndexPattern).matches(index)
 
     suspend fun getISMIndexMetadataByType(type: String = DEFAULT_INDEX_TYPE, indexNames: List<String>): Map<String, ISMIndexMetadata> {
         val service = services[type] ?: throw IllegalArgumentException(getTypeNotRecognizedMessage(type))
@@ -90,9 +88,7 @@ class IndexMetadataProvider(
             metadata
         }
 
-    fun getIndexMetadataWriteOverrideSettings(): List<String> {
-        return services.values.mapNotNull { it.getIndexMetadataWriteOverrideSetting() }
-    }
+    fun getIndexMetadataWriteOverrideSettings(): List<String> = services.values.mapNotNull { it.getIndexMetadataWriteOverrideSetting() }
 
     companion object {
         const val EVALUATION_FAILURE_MESSAGE = "Matches restricted index pattern defined in the cluster setting"

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/IndexStateManagementHistory.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/IndexStateManagementHistory.kt
@@ -299,7 +299,9 @@ class IndexStateManagementHistory(
         }
     }
 
-    private fun shouldAddManagedIndexMetaDataToHistory(managedIndexMetaData: ManagedIndexMetaData): Boolean = when (managedIndexMetaData.stepMetaData?.stepStatus) {
+    private fun shouldAddManagedIndexMetaDataToHistory(
+        managedIndexMetaData: ManagedIndexMetaData,
+    ): Boolean = when (managedIndexMetaData.stepMetaData?.stepStatus) {
         Step.StepStatus.STARTING -> false
         Step.StepStatus.CONDITION_NOT_MET -> false
         else -> true

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/IndexStateManagementHistory.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/IndexStateManagementHistory.kt
@@ -207,8 +207,7 @@ class IndexStateManagementHistory(
 
             if ((Instant.now().toEpochMilli() - creationTime) > historyRetentionPeriod.millis) {
                 val alias =
-                    indexMetaData.aliases.firstNotNullOfOrNull {
-                            alias ->
+                    indexMetaData.aliases.firstNotNullOfOrNull { alias ->
                         IndexManagementIndices.HISTORY_WRITE_INDEX_ALIAS == alias.value.alias
                     }
                 if (alias != null && historyEnabled) {
@@ -300,12 +299,10 @@ class IndexStateManagementHistory(
         }
     }
 
-    private fun shouldAddManagedIndexMetaDataToHistory(managedIndexMetaData: ManagedIndexMetaData): Boolean {
-        return when (managedIndexMetaData.stepMetaData?.stepStatus) {
-            Step.StepStatus.STARTING -> false
-            Step.StepStatus.CONDITION_NOT_MET -> false
-            else -> true
-        }
+    private fun shouldAddManagedIndexMetaDataToHistory(managedIndexMetaData: ManagedIndexMetaData): Boolean = when (managedIndexMetaData.stepMetaData?.stepStatus) {
+        Step.StepStatus.STARTING -> false
+        Step.StepStatus.CONDITION_NOT_MET -> false
+        else -> true
     }
 
     private fun createManagedIndexMetaDataHistoryIndexRequest(managedIndexMetaData: ManagedIndexMetaData): IndexRequest {

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/ManagedIndexCoordinator.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/ManagedIndexCoordinator.kt
@@ -113,9 +113,9 @@ class ManagedIndexCoordinator(
     indexManagementIndices: IndexManagementIndices,
     private val indexMetadataProvider: IndexMetadataProvider,
     private val xContentRegistry: NamedXContentRegistry,
-) : ClusterStateListener,
-    CoroutineScope by CoroutineScope(SupervisorJob() + Dispatchers.Default + CoroutineName("ManagedIndexCoordinator")),
-    LifecycleListener() {
+) : LifecycleListener(),
+    ClusterStateListener,
+    CoroutineScope by CoroutineScope(SupervisorJob() + Dispatchers.Default + CoroutineName("ManagedIndexCoordinator")) {
     private val logger = LogManager.getLogger(javaClass)
     private val ismIndices = indexManagementIndices
 
@@ -160,9 +160,7 @@ class ManagedIndexCoordinator(
         }
     }
 
-    private fun executorName(): String {
-        return ThreadPool.Names.MANAGEMENT
-    }
+    private fun executorName(): String = ThreadPool.Names.MANAGEMENT
 
     fun onClusterManager() {
         onClusterManagerTimeStamp = System.currentTimeMillis()

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/PluginVersionSweepCoordinator.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/PluginVersionSweepCoordinator.kt
@@ -26,8 +26,8 @@ class PluginVersionSweepCoordinator(
     settings: Settings,
     private val threadPool: ThreadPool,
     var clusterService: ClusterService,
-) : CoroutineScope by CoroutineScope(SupervisorJob() + Dispatchers.Default + CoroutineName("ISMPluginSweepCoordinator")),
-    LifecycleListener(),
+) : LifecycleListener(),
+    CoroutineScope by CoroutineScope(SupervisorJob() + Dispatchers.Default + CoroutineName("ISMPluginSweepCoordinator")),
     ClusterStateListener {
     private val logger = LogManager.getLogger(javaClass)
 

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/action/AliasAction.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/action/AliasAction.kt
@@ -38,9 +38,7 @@ class AliasAction(
 
     private val steps = listOf(attemptAliasActionsStep)
 
-    override fun getStepToExecute(context: StepContext): Step {
-        return attemptAliasActionsStep
-    }
+    override fun getStepToExecute(context: StepContext): Step = attemptAliasActionsStep
 
     override fun getSteps(): List<Step> = steps
 

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/action/AllocationAction.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/action/AllocationAction.kt
@@ -28,9 +28,7 @@ class AllocationAction(
 
     private val steps = listOf(attemptAllocationStep)
 
-    override fun getStepToExecute(context: StepContext): Step {
-        return attemptAllocationStep
-    }
+    override fun getStepToExecute(context: StepContext): Step = attemptAllocationStep
 
     override fun getSteps(): List<Step> = steps
 

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/action/AllocationActionParser.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/action/AllocationActionParser.kt
@@ -49,9 +49,7 @@ class AllocationActionParser : ActionParser() {
         return AllocationAction(require, include, exclude, waitFor, index)
     }
 
-    override fun getActionType(): String {
-        return AllocationAction.name
-    }
+    override fun getActionType(): String = AllocationAction.name
 
     private fun assignObject(xcp: XContentParser, objectMap: MutableMap<String, String>) {
         ensureExpectedToken(Token.START_OBJECT, xcp.currentToken(), xcp)

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/action/CloseAction.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/action/CloseAction.kt
@@ -21,9 +21,7 @@ class CloseAction(
 
     private val steps = listOf(attemptCloseStep)
 
-    override fun getStepToExecute(context: StepContext): Step {
-        return attemptCloseStep
-    }
+    override fun getStepToExecute(context: StepContext): Step = attemptCloseStep
 
     override fun getSteps(): List<Step> = steps
 }

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/action/CloseActionParser.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/action/CloseActionParser.kt
@@ -24,7 +24,5 @@ class CloseActionParser : ActionParser() {
         return CloseAction(index)
     }
 
-    override fun getActionType(): String {
-        return CloseAction.name
-    }
+    override fun getActionType(): String = CloseAction.name
 }

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/action/DeleteAction.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/action/DeleteAction.kt
@@ -20,9 +20,7 @@ class DeleteAction(
     private val attemptDeleteStep = AttemptDeleteStep()
     private val steps = listOf(attemptDeleteStep)
 
-    override fun getStepToExecute(context: StepContext): Step {
-        return attemptDeleteStep
-    }
+    override fun getStepToExecute(context: StepContext): Step = attemptDeleteStep
 
     override fun getSteps(): List<Step> = steps
 }

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/action/DeleteActionParser.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/action/DeleteActionParser.kt
@@ -24,7 +24,5 @@ class DeleteActionParser : ActionParser() {
         return DeleteAction(index)
     }
 
-    override fun getActionType(): String {
-        return DeleteAction.name
-    }
+    override fun getActionType(): String = DeleteAction.name
 }

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/action/ForceMergeActionParser.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/action/ForceMergeActionParser.kt
@@ -39,7 +39,5 @@ class ForceMergeActionParser : ActionParser() {
         )
     }
 
-    override fun getActionType(): String {
-        return ForceMergeAction.name
-    }
+    override fun getActionType(): String = ForceMergeAction.name
 }

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/action/IndexPriorityActionParser.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/action/IndexPriorityActionParser.kt
@@ -39,7 +39,5 @@ class IndexPriorityActionParser : ActionParser() {
         )
     }
 
-    override fun getActionType(): String {
-        return IndexPriorityAction.name
-    }
+    override fun getActionType(): String = IndexPriorityAction.name
 }

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/action/NotificationAction.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/action/NotificationAction.kt
@@ -31,9 +31,7 @@ class NotificationAction(
     private val attemptNotificationStep = AttemptNotificationStep(this)
     private val steps = listOf(attemptNotificationStep)
 
-    override fun getStepToExecute(context: StepContext): Step {
-        return attemptNotificationStep
-    }
+    override fun getStepToExecute(context: StepContext): Step = attemptNotificationStep
 
     override fun getSteps(): List<Step> = steps
 

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/action/NotificationActionParser.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/action/NotificationActionParser.kt
@@ -54,7 +54,5 @@ class NotificationActionParser : ActionParser() {
         )
     }
 
-    override fun getActionType(): String {
-        return NotificationAction.name
-    }
+    override fun getActionType(): String = NotificationAction.name
 }

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/action/OpenAction.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/action/OpenAction.kt
@@ -20,9 +20,7 @@ class OpenAction(
     private val attemptOpenStep = AttemptOpenStep()
     private val steps = listOf(attemptOpenStep)
 
-    override fun getStepToExecute(context: StepContext): Step {
-        return attemptOpenStep
-    }
+    override fun getStepToExecute(context: StepContext): Step = attemptOpenStep
 
     override fun getSteps(): List<Step> = steps
 }

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/action/OpenActionParser.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/action/OpenActionParser.kt
@@ -24,7 +24,5 @@ class OpenActionParser : ActionParser() {
         return OpenAction(index)
     }
 
-    override fun getActionType(): String {
-        return OpenAction.name
-    }
+    override fun getActionType(): String = OpenAction.name
 }

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/action/ReadOnlyAction.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/action/ReadOnlyAction.kt
@@ -20,9 +20,7 @@ class ReadOnlyAction(
     private val setReadOnlyStep = SetReadOnlyStep()
     private val steps = listOf(setReadOnlyStep)
 
-    override fun getStepToExecute(context: StepContext): Step {
-        return setReadOnlyStep
-    }
+    override fun getStepToExecute(context: StepContext): Step = setReadOnlyStep
 
     override fun getSteps(): List<Step> = steps
 }

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/action/ReadOnlyActionParser.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/action/ReadOnlyActionParser.kt
@@ -24,7 +24,5 @@ class ReadOnlyActionParser : ActionParser() {
         return ReadOnlyAction(index)
     }
 
-    override fun getActionType(): String {
-        return ReadOnlyAction.name
-    }
+    override fun getActionType(): String = ReadOnlyAction.name
 }

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/action/ReadWriteAction.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/action/ReadWriteAction.kt
@@ -20,9 +20,7 @@ class ReadWriteAction(
     private val setReadWriteStep = SetReadWriteStep()
     private val steps = listOf(setReadWriteStep)
 
-    override fun getStepToExecute(context: StepContext): Step {
-        return setReadWriteStep
-    }
+    override fun getStepToExecute(context: StepContext): Step = setReadWriteStep
 
     override fun getSteps(): List<Step> = steps
 }

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/action/ReadWriteActionParser.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/action/ReadWriteActionParser.kt
@@ -24,7 +24,5 @@ class ReadWriteActionParser : ActionParser() {
         return ReadWriteAction(index)
     }
 
-    override fun getActionType(): String {
-        return ReadWriteAction.name
-    }
+    override fun getActionType(): String = ReadWriteAction.name
 }

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/action/ReplicaCountAction.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/action/ReplicaCountAction.kt
@@ -24,9 +24,7 @@ class ReplicaCountAction(
     private val attemptReplicaCountStep = AttemptReplicaCountStep(this)
     private val steps = listOf(attemptReplicaCountStep)
 
-    override fun getStepToExecute(context: StepContext): Step {
-        return attemptReplicaCountStep
-    }
+    override fun getStepToExecute(context: StepContext): Step = attemptReplicaCountStep
 
     override fun getSteps(): List<Step> = steps
 

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/action/ReplicaCountActionParser.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/action/ReplicaCountActionParser.kt
@@ -38,7 +38,5 @@ class ReplicaCountActionParser : ActionParser() {
         )
     }
 
-    override fun getActionType(): String {
-        return ReplicaCountAction.name
-    }
+    override fun getActionType(): String = ReplicaCountAction.name
 }

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/action/RolloverAction.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/action/RolloverAction.kt
@@ -37,9 +37,7 @@ class RolloverAction(
     private val attemptRolloverStep = AttemptRolloverStep(this)
     private val steps = listOf(attemptRolloverStep)
 
-    override fun getStepToExecute(context: StepContext): Step {
-        return attemptRolloverStep
-    }
+    override fun getStepToExecute(context: StepContext): Step = attemptRolloverStep
 
     override fun getSteps(): List<Step> = steps
 

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/action/RolloverActionParser.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/action/RolloverActionParser.kt
@@ -56,7 +56,5 @@ class RolloverActionParser : ActionParser() {
         return RolloverAction(minSize, minDocs, minAge, minPrimaryShardSize, copyAlias, index)
     }
 
-    override fun getActionType(): String {
-        return RolloverAction.name
-    }
+    override fun getActionType(): String = RolloverAction.name
 }

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/action/RollupActionParser.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/action/RollupActionParser.kt
@@ -36,7 +36,5 @@ class RollupActionParser : ActionParser() {
         return RollupAction(ismRollup = requireNotNull(ismRollup) { "RollupAction rollup is null" }, index)
     }
 
-    override fun getActionType(): String {
-        return RollupAction.name
-    }
+    override fun getActionType(): String = RollupAction.name
 }

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/action/ShrinkActionParser.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/action/ShrinkActionParser.kt
@@ -75,7 +75,5 @@ class ShrinkActionParser : ActionParser() {
         return ShrinkAction(numNewShards, maxShardSize, percentageOfSourceShards, targetIndexTemplate, aliases, switchAliases, forceUnsafe, index)
     }
 
-    override fun getActionType(): String {
-        return ShrinkAction.name
-    }
+    override fun getActionType(): String = ShrinkAction.name
 }

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/action/SnapshotActionParser.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/action/SnapshotActionParser.kt
@@ -46,7 +46,5 @@ class SnapshotActionParser : ActionParser() {
         )
     }
 
-    override fun getActionType(): String {
-        return SnapshotAction.name
-    }
+    override fun getActionType(): String = SnapshotAction.name
 }

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/action/TransformActionParser.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/action/TransformActionParser.kt
@@ -36,7 +36,5 @@ class TransformActionParser : ActionParser() {
         return TransformAction(ismTransform = requireNotNull(ismTransform) { "TransformAction transform is null." }, index)
     }
 
-    override fun getActionType(): String {
-        return TransformAction.name
-    }
+    override fun getActionType(): String = TransformAction.name
 }

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/action/TransitionsAction.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/action/TransitionsAction.kt
@@ -21,9 +21,7 @@ class TransitionsAction(
 
     override fun getSteps(): List<Step> = steps
 
-    override fun getStepToExecute(context: StepContext): Step {
-        return attemptTransitionStep
-    }
+    override fun getStepToExecute(context: StepContext): Step = attemptTransitionStep
 
     companion object {
         const val name = "transition"

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/model/ChangePolicy.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/model/ChangePolicy.kt
@@ -36,7 +36,8 @@ data class ChangePolicy(
     val include: List<StateFilter>,
     val isSafe: Boolean,
     val user: User? = null,
-) : Writeable, ToXContentObject {
+) : Writeable,
+    ToXContentObject {
     @Throws(IOException::class)
     constructor(sin: StreamInput) : this(
         policyID = sin.readString(),

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/model/ErrorNotification.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/model/ErrorNotification.kt
@@ -23,7 +23,8 @@ data class ErrorNotification(
     val destination: Destination?,
     val channel: Channel?,
     val messageTemplate: Script,
-) : ToXContentObject, Writeable {
+) : ToXContentObject,
+    Writeable {
     init {
         require(destination != null || channel != null) { "ErrorNotification must contain a destination or channel" }
         require(destination == null || channel == null) { "ErrorNotification can only contain a single destination or channel" }

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/model/ExplainFilter.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/model/ExplainFilter.kt
@@ -25,7 +25,8 @@ data class ExplainFilter(
     val state: String? = null,
     val actionType: String? = null,
     val failed: Boolean? = null,
-) : ToXContentObject, Writeable {
+) : ToXContentObject,
+    Writeable {
     @Throws(IOException::class)
     constructor(sin: StreamInput) : this(
         policyID = sin.readOptionalString(),

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/model/ISMTemplate.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/model/ISMTemplate.kt
@@ -24,19 +24,18 @@ data class ISMTemplate(
     val indexPatterns: List<String>,
     val priority: Int,
     val lastUpdatedTime: Instant,
-) : ToXContentObject, Writeable {
+) : ToXContentObject,
+    Writeable {
     init {
         require(priority >= 0) { "Requires priority to be >= 0" }
         require(indexPatterns.isNotEmpty()) { "Requires at least one index pattern" }
     }
 
-    override fun toXContent(builder: XContentBuilder, params: ToXContent.Params): XContentBuilder {
-        return builder.startObject()
-            .field(INDEX_PATTERN, indexPatterns)
-            .field(PRIORITY, priority)
-            .optionalTimeField(LAST_UPDATED_TIME_FIELD, lastUpdatedTime)
-            .endObject()
-    }
+    override fun toXContent(builder: XContentBuilder, params: ToXContent.Params): XContentBuilder = builder.startObject()
+        .field(INDEX_PATTERN, indexPatterns)
+        .field(PRIORITY, priority)
+        .optionalTimeField(LAST_UPDATED_TIME_FIELD, lastUpdatedTime)
+        .endObject()
 
     @Throws(IOException::class)
     constructor(sin: StreamInput) : this(

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/model/ManagedIndexConfig.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/model/ManagedIndexConfig.kt
@@ -59,9 +59,7 @@ data class ManagedIndexConfig(
 
     override fun getLockDurationSeconds(): Long = 3600L // 1 hour
 
-    override fun getJitter(): Double? {
-        return jobJitter
-    }
+    override fun getJitter(): Double? = jobJitter
 
     override fun toXContent(builder: XContentBuilder, params: ToXContent.Params): XContentBuilder {
         builder

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/model/Policy.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/model/Policy.kt
@@ -40,7 +40,8 @@ data class Policy(
     val states: List<State>,
     val ismTemplate: List<ISMTemplate>? = null,
     val user: User? = null,
-) : ToXContentObject, Writeable {
+) : ToXContentObject,
+    Writeable {
     init {
         val distinctStateNames = states.map { it.name }.distinct()
         states.forEach { state ->
@@ -55,9 +56,7 @@ data class Policy(
         requireNotNull(states.find { it.name == defaultState }) { "Policy must have a valid default state" }
     }
 
-    fun toXContent(builder: XContentBuilder): XContentBuilder {
-        return toXContent(builder, ToXContent.EMPTY_PARAMS)
-    }
+    fun toXContent(builder: XContentBuilder): XContentBuilder = toXContent(builder, ToXContent.EMPTY_PARAMS)
 
     override fun toXContent(builder: XContentBuilder, params: ToXContent.Params): XContentBuilder {
         builder.startObject()

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/model/State.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/model/State.kt
@@ -27,7 +27,8 @@ data class State(
     val name: String,
     val actions: List<Action>,
     val transitions: List<Transition>,
-) : ToXContentObject, Writeable {
+) : ToXContentObject,
+    Writeable {
     init {
         require(name.isNotBlank()) { "State must contain a valid name" }
         var hasDelete = false

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/model/Transition.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/model/Transition.kt
@@ -23,7 +23,8 @@ import java.io.IOException
 data class Transition(
     val stateName: String,
     val conditions: Conditions?,
-) : ToXContentObject, Writeable {
+) : ToXContentObject,
+    Writeable {
     override fun toXContent(builder: XContentBuilder, params: ToXContent.Params): XContentBuilder {
         builder.startObject()
             .field(STATE_NAME_FIELD, stateName)
@@ -79,7 +80,8 @@ data class Conditions(
     val size: ByteSizeValue? = null,
     val cron: CronSchedule? = null,
     val rolloverAge: TimeValue? = null,
-) : ToXContentObject, Writeable {
+) : ToXContentObject,
+    Writeable {
     init {
         val conditionsList = listOf(indexAge, docCount, size, cron, rolloverAge)
         require(conditionsList.filterNotNull().size == 1) { "Cannot provide more than one Transition condition" }

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/model/destination/Chime.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/model/destination/Chime.kt
@@ -23,12 +23,12 @@ import java.io.IOException
  * Temporary import from alerting, this will be removed once we pull notifications out of
  * alerting so all plugins can consume and use.
  */
-data class Chime(val url: String) : ToXContent, Writeable {
-    override fun toXContent(builder: XContentBuilder, params: ToXContent.Params): XContentBuilder {
-        return builder.startObject(TYPE)
-            .field(URL, url)
-            .endObject()
-    }
+data class Chime(val url: String) :
+    ToXContent,
+    Writeable {
+    override fun toXContent(builder: XContentBuilder, params: ToXContent.Params): XContentBuilder = builder.startObject(TYPE)
+        .field(URL, url)
+        .endObject()
 
     @Throws(IOException::class)
     constructor(sin: StreamInput) : this(
@@ -65,7 +65,5 @@ data class Chime(val url: String) : ToXContent, Writeable {
     }
 
     // Complete JSON structure is now constructed in the notification plugin
-    fun constructMessageContent(subject: String?, message: String): String {
-        return if (Strings.isNullOrEmpty(subject)) message else "$subject \n\n $message"
-    }
+    fun constructMessageContent(subject: String?, message: String): String = if (Strings.isNullOrEmpty(subject)) message else "$subject \n\n $message"
 }

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/model/destination/CustomWebhook.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/model/destination/CustomWebhook.kt
@@ -33,26 +33,25 @@ data class CustomWebhook(
     val headerParams: Map<String, String>,
     val username: String?,
     val password: String?,
-) : ToXContent, Writeable {
+) : ToXContent,
+    Writeable {
     init {
         require(!(Strings.isNullOrEmpty(url) && Strings.isNullOrEmpty(host))) {
             "Url or Host name must be provided."
         }
     }
 
-    override fun toXContent(builder: XContentBuilder, params: ToXContent.Params): XContentBuilder {
-        return builder.startObject(TYPE)
-            .field(URL, url)
-            .field(SCHEME_FIELD, scheme)
-            .field(HOST_FIELD, host)
-            .field(PORT_FIELD, port)
-            .field(PATH_FIELD, path)
-            .field(QUERY_PARAMS_FIELD, queryParams)
-            .field(HEADER_PARAMS_FIELD, headerParams)
-            .field(USERNAME_FIELD, username)
-            .field(PASSWORD_FIELD, password)
-            .endObject()
-    }
+    override fun toXContent(builder: XContentBuilder, params: ToXContent.Params): XContentBuilder = builder.startObject(TYPE)
+        .field(URL, url)
+        .field(SCHEME_FIELD, scheme)
+        .field(HOST_FIELD, host)
+        .field(PORT_FIELD, port)
+        .field(PATH_FIELD, path)
+        .field(QUERY_PARAMS_FIELD, queryParams)
+        .field(HEADER_PARAMS_FIELD, headerParams)
+        .field(USERNAME_FIELD, username)
+        .field(PASSWORD_FIELD, password)
+        .endObject()
 
     constructor(sin: StreamInput) : this(
         sin.readOptionalString(),
@@ -127,8 +126,6 @@ data class CustomWebhook(
         }
 
         @Suppress("UNCHECKED_CAST")
-        fun suppressWarning(map: MutableMap<String?, Any?>?): MutableMap<String, String> {
-            return map as MutableMap<String, String>
-        }
+        fun suppressWarning(map: MutableMap<String?, Any?>?): MutableMap<String, String> = map as MutableMap<String, String>
     }
 }

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/model/destination/Destination.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/model/destination/Destination.kt
@@ -32,7 +32,8 @@ data class Destination(
     val chime: Chime?,
     val slack: Slack?,
     val customWebhook: CustomWebhook?,
-) : ToXContentObject, Writeable {
+) : ToXContentObject,
+    Writeable {
     override fun toXContent(builder: XContentBuilder, params: ToXContent.Params): XContentBuilder {
         builder.startObject()
             .field(type.value, constructResponseForDestinationType(type))
@@ -143,15 +144,13 @@ data class Destination(
         return content
     }
 
-    private fun getLegacyCustomWebhookMessageURL(customWebhook: CustomWebhook?, compiledMessage: String): String {
-        return LegacyCustomWebhookMessage.Builder("custom_webhook")
-            .withUrl(customWebhook?.url)
-            .withScheme(customWebhook?.scheme)
-            .withHost(customWebhook?.host)
-            .withPort(customWebhook?.port)
-            .withPath(customWebhook?.path)
-            .withQueryParams(customWebhook?.queryParams)
-            .withMessage(compiledMessage)
-            .build().uri.toString()
-    }
+    private fun getLegacyCustomWebhookMessageURL(customWebhook: CustomWebhook?, compiledMessage: String): String = LegacyCustomWebhookMessage.Builder("custom_webhook")
+        .withUrl(customWebhook?.url)
+        .withScheme(customWebhook?.scheme)
+        .withHost(customWebhook?.host)
+        .withPort(customWebhook?.port)
+        .withPath(customWebhook?.path)
+        .withQueryParams(customWebhook?.queryParams)
+        .withMessage(compiledMessage)
+        .build().uri.toString()
 }

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/model/destination/Destination.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/model/destination/Destination.kt
@@ -144,7 +144,10 @@ data class Destination(
         return content
     }
 
-    private fun getLegacyCustomWebhookMessageURL(customWebhook: CustomWebhook?, compiledMessage: String): String = LegacyCustomWebhookMessage.Builder("custom_webhook")
+    private fun getLegacyCustomWebhookMessageURL(
+        customWebhook: CustomWebhook?,
+        compiledMessage: String,
+    ): String = LegacyCustomWebhookMessage.Builder("custom_webhook")
         .withUrl(customWebhook?.url)
         .withScheme(customWebhook?.scheme)
         .withHost(customWebhook?.host)

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/model/destination/Slack.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/model/destination/Slack.kt
@@ -23,12 +23,12 @@ import java.io.IOException
  * Temporary import from alerting, this will be removed once we pull notifications out of
  * alerting so all plugins can consume and use.
  */
-data class Slack(val url: String) : ToXContent, Writeable {
-    override fun toXContent(builder: XContentBuilder, params: ToXContent.Params): XContentBuilder {
-        return builder.startObject(TYPE)
-            .field(URL, url)
-            .endObject()
-    }
+data class Slack(val url: String) :
+    ToXContent,
+    Writeable {
+    override fun toXContent(builder: XContentBuilder, params: ToXContent.Params): XContentBuilder = builder.startObject(TYPE)
+        .field(URL, url)
+        .endObject()
 
     @Throws(IOException::class)
     constructor(sin: StreamInput) : this(
@@ -65,7 +65,5 @@ data class Slack(val url: String) : ToXContent, Writeable {
     }
 
     // Complete JSON structure is now constructed in the notification plugin
-    fun constructMessageContent(subject: String?, message: String): String {
-        return if (Strings.isNullOrEmpty(subject)) message else "$subject \n\n $message"
-    }
+    fun constructMessageContent(subject: String?, message: String): String = if (Strings.isNullOrEmpty(subject)) message else "$subject \n\n $message"
 }

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/opensearchapi/OpenSearchExtensions.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/opensearchapi/OpenSearchExtensions.kt
@@ -192,7 +192,5 @@ fun XContentBuilder.buildMetadata(name: String, metadata: ToXContentFragment, pa
 }
 
 // Get the oldest rollover time or null if index was never rolled over
-fun IndexMetadata.getOldestRolloverTime(): Instant? {
-    return this.rolloverInfos.values.minOfOrNull { it.time } // oldest should be min as its epoch time
-        ?.let { Instant.ofEpochMilli(it) }
-}
+fun IndexMetadata.getOldestRolloverTime(): Instant? = this.rolloverInfos.values.minOfOrNull { it.time } // oldest should be min as its epoch time
+    ?.let { Instant.ofEpochMilli(it) }

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/resthandler/RestAddPolicyAction.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/resthandler/RestAddPolicyAction.kt
@@ -26,22 +26,18 @@ import java.io.IOException
 class RestAddPolicyAction : BaseRestHandler() {
     override fun getName(): String = "add_policy_action"
 
-    override fun routes(): List<Route> {
-        return emptyList()
-    }
+    override fun routes(): List<Route> = emptyList()
 
-    override fun replacedRoutes(): List<ReplacedRoute> {
-        return listOf(
-            ReplacedRoute(
-                POST, ADD_POLICY_BASE_URI,
-                POST, LEGACY_ADD_POLICY_BASE_URI,
-            ),
-            ReplacedRoute(
-                POST, "$ADD_POLICY_BASE_URI/{index}",
-                POST, "$LEGACY_ADD_POLICY_BASE_URI/{index}",
-            ),
-        )
-    }
+    override fun replacedRoutes(): List<ReplacedRoute> = listOf(
+        ReplacedRoute(
+            POST, ADD_POLICY_BASE_URI,
+            POST, LEGACY_ADD_POLICY_BASE_URI,
+        ),
+        ReplacedRoute(
+            POST, "$ADD_POLICY_BASE_URI/{index}",
+            POST, "$LEGACY_ADD_POLICY_BASE_URI/{index}",
+        ),
+    )
 
     @Throws(IOException::class)
     @Suppress("SpreadOperator") // There is no way around dealing with java vararg without spread operator.

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/resthandler/RestChangePolicyAction.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/resthandler/RestChangePolicyAction.kt
@@ -26,22 +26,18 @@ import org.opensearch.rest.action.RestToXContentListener
 import java.io.IOException
 
 class RestChangePolicyAction : BaseRestHandler() {
-    override fun routes(): List<Route> {
-        return emptyList()
-    }
+    override fun routes(): List<Route> = emptyList()
 
-    override fun replacedRoutes(): List<ReplacedRoute> {
-        return listOf(
-            ReplacedRoute(
-                POST, CHANGE_POLICY_BASE_URI,
-                POST, LEGACY_CHANGE_POLICY_BASE_URI,
-            ),
-            ReplacedRoute(
-                POST, "$CHANGE_POLICY_BASE_URI/{index}",
-                POST, "$LEGACY_CHANGE_POLICY_BASE_URI/{index}",
-            ),
-        )
-    }
+    override fun replacedRoutes(): List<ReplacedRoute> = listOf(
+        ReplacedRoute(
+            POST, CHANGE_POLICY_BASE_URI,
+            POST, LEGACY_CHANGE_POLICY_BASE_URI,
+        ),
+        ReplacedRoute(
+            POST, "$CHANGE_POLICY_BASE_URI/{index}",
+            POST, "$LEGACY_CHANGE_POLICY_BASE_URI/{index}",
+        ),
+    )
 
     override fun getName(): String = "change_policy_action"
 

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/resthandler/RestDeletePolicyAction.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/resthandler/RestDeletePolicyAction.kt
@@ -21,18 +21,14 @@ import org.opensearch.rest.action.RestStatusToXContentListener
 import java.io.IOException
 
 class RestDeletePolicyAction : BaseRestHandler() {
-    override fun routes(): List<Route> {
-        return emptyList()
-    }
+    override fun routes(): List<Route> = emptyList()
 
-    override fun replacedRoutes(): List<ReplacedRoute> {
-        return listOf(
-            ReplacedRoute(
-                DELETE, "$POLICY_BASE_URI/{policyID}",
-                DELETE, "$LEGACY_POLICY_BASE_URI/{policyID}",
-            ),
-        )
-    }
+    override fun replacedRoutes(): List<ReplacedRoute> = listOf(
+        ReplacedRoute(
+            DELETE, "$POLICY_BASE_URI/{policyID}",
+            DELETE, "$LEGACY_POLICY_BASE_URI/{policyID}",
+        ),
+    )
 
     override fun getName(): String = "delete_policy_action"
 

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/resthandler/RestExplainAction.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/resthandler/RestExplainAction.kt
@@ -42,34 +42,28 @@ class RestExplainAction : BaseRestHandler() {
         const val LEGACY_EXPLAIN_BASE_URI = "$LEGACY_ISM_BASE_URI/explain"
     }
 
-    override fun routes(): List<Route> {
-        return emptyList()
-    }
+    override fun routes(): List<Route> = emptyList()
 
-    override fun replacedRoutes(): List<ReplacedRoute> {
-        return listOf(
-            ReplacedRoute(
-                GET, EXPLAIN_BASE_URI,
-                GET, LEGACY_EXPLAIN_BASE_URI,
-            ),
-            ReplacedRoute(
-                GET, "$EXPLAIN_BASE_URI/{index}",
-                GET, "$LEGACY_EXPLAIN_BASE_URI/{index}",
-            ),
-            ReplacedRoute(
-                POST, EXPLAIN_BASE_URI,
-                POST, LEGACY_EXPLAIN_BASE_URI,
-            ),
-            ReplacedRoute(
-                POST, "$EXPLAIN_BASE_URI/{index}",
-                POST, "$LEGACY_EXPLAIN_BASE_URI/{index}",
-            ),
-        )
-    }
+    override fun replacedRoutes(): List<ReplacedRoute> = listOf(
+        ReplacedRoute(
+            GET, EXPLAIN_BASE_URI,
+            GET, LEGACY_EXPLAIN_BASE_URI,
+        ),
+        ReplacedRoute(
+            GET, "$EXPLAIN_BASE_URI/{index}",
+            GET, "$LEGACY_EXPLAIN_BASE_URI/{index}",
+        ),
+        ReplacedRoute(
+            POST, EXPLAIN_BASE_URI,
+            POST, LEGACY_EXPLAIN_BASE_URI,
+        ),
+        ReplacedRoute(
+            POST, "$EXPLAIN_BASE_URI/{index}",
+            POST, "$LEGACY_EXPLAIN_BASE_URI/{index}",
+        ),
+    )
 
-    override fun getName(): String {
-        return "ism_explain_action"
-    }
+    override fun getName(): String = "ism_explain_action"
 
     override fun prepareRequest(request: RestRequest, client: NodeClient): RestChannelConsumer {
         log.debug("${request.method()} ${request.path()}")

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/resthandler/RestGetPolicyAction.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/resthandler/RestGetPolicyAction.kt
@@ -29,30 +29,24 @@ import org.opensearch.search.fetch.subphase.FetchSourceContext
 private val log = LogManager.getLogger(RestGetPolicyAction::class.java)
 
 class RestGetPolicyAction : BaseRestHandler() {
-    override fun routes(): List<Route> {
-        return emptyList()
-    }
+    override fun routes(): List<Route> = emptyList()
 
-    override fun replacedRoutes(): List<ReplacedRoute> {
-        return listOf(
-            ReplacedRoute(
-                GET, POLICY_BASE_URI,
-                GET, LEGACY_POLICY_BASE_URI,
-            ),
-            ReplacedRoute(
-                GET, "$POLICY_BASE_URI/{policyID}",
-                GET, "$LEGACY_POLICY_BASE_URI/{policyID}",
-            ),
-            ReplacedRoute(
-                HEAD, "$POLICY_BASE_URI/{policyID}",
-                HEAD, "$LEGACY_POLICY_BASE_URI/{policyID}",
-            ),
-        )
-    }
+    override fun replacedRoutes(): List<ReplacedRoute> = listOf(
+        ReplacedRoute(
+            GET, POLICY_BASE_URI,
+            GET, LEGACY_POLICY_BASE_URI,
+        ),
+        ReplacedRoute(
+            GET, "$POLICY_BASE_URI/{policyID}",
+            GET, "$LEGACY_POLICY_BASE_URI/{policyID}",
+        ),
+        ReplacedRoute(
+            HEAD, "$POLICY_BASE_URI/{policyID}",
+            HEAD, "$LEGACY_POLICY_BASE_URI/{policyID}",
+        ),
+    )
 
-    override fun getName(): String {
-        return "get_policy_action"
-    }
+    override fun getName(): String = "get_policy_action"
 
     override fun prepareRequest(request: RestRequest, client: NodeClient): RestChannelConsumer {
         log.debug("${request.method()} ${request.path()}")

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/resthandler/RestIndexPolicyAction.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/resthandler/RestIndexPolicyAction.kt
@@ -46,26 +46,20 @@ class RestIndexPolicyAction(
         clusterService.clusterSettings.addSettingsUpdateConsumer(ALLOW_LIST) { allowList = it }
     }
 
-    override fun routes(): List<Route> {
-        return emptyList()
-    }
+    override fun routes(): List<Route> = emptyList()
 
-    override fun replacedRoutes(): List<ReplacedRoute> {
-        return listOf(
-            ReplacedRoute(
-                PUT, POLICY_BASE_URI,
-                PUT, LEGACY_POLICY_BASE_URI,
-            ),
-            ReplacedRoute(
-                PUT, "$POLICY_BASE_URI/{policyID}",
-                PUT, "$LEGACY_POLICY_BASE_URI/{policyID}",
-            ),
-        )
-    }
+    override fun replacedRoutes(): List<ReplacedRoute> = listOf(
+        ReplacedRoute(
+            PUT, POLICY_BASE_URI,
+            PUT, LEGACY_POLICY_BASE_URI,
+        ),
+        ReplacedRoute(
+            PUT, "$POLICY_BASE_URI/{policyID}",
+            PUT, "$LEGACY_POLICY_BASE_URI/{policyID}",
+        ),
+    )
 
-    override fun getName(): String {
-        return "index_policy_action"
-    }
+    override fun getName(): String = "index_policy_action"
 
     @Throws(IOException::class)
     override fun prepareRequest(request: RestRequest, client: NodeClient): RestChannelConsumer {

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/resthandler/RestRemovePolicyAction.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/resthandler/RestRemovePolicyAction.kt
@@ -22,22 +22,18 @@ import org.opensearch.rest.action.RestToXContentListener
 import java.io.IOException
 
 class RestRemovePolicyAction : BaseRestHandler() {
-    override fun routes(): List<Route> {
-        return emptyList()
-    }
+    override fun routes(): List<Route> = emptyList()
 
-    override fun replacedRoutes(): List<ReplacedRoute> {
-        return listOf(
-            ReplacedRoute(
-                POST, REMOVE_POLICY_BASE_URI,
-                POST, LEGACY_REMOVE_POLICY_BASE_URI,
-            ),
-            ReplacedRoute(
-                POST, "$REMOVE_POLICY_BASE_URI/{index}",
-                POST, "$LEGACY_REMOVE_POLICY_BASE_URI/{index}",
-            ),
-        )
-    }
+    override fun replacedRoutes(): List<ReplacedRoute> = listOf(
+        ReplacedRoute(
+            POST, REMOVE_POLICY_BASE_URI,
+            POST, LEGACY_REMOVE_POLICY_BASE_URI,
+        ),
+        ReplacedRoute(
+            POST, "$REMOVE_POLICY_BASE_URI/{index}",
+            POST, "$LEGACY_REMOVE_POLICY_BASE_URI/{index}",
+        ),
+    )
 
     override fun getName(): String = "remove_policy_action"
 

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/resthandler/RestRetryFailedManagedIndexAction.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/resthandler/RestRetryFailedManagedIndexAction.kt
@@ -25,26 +25,20 @@ import org.opensearch.rest.RestRequest.Method.POST
 import org.opensearch.rest.action.RestToXContentListener
 
 class RestRetryFailedManagedIndexAction : BaseRestHandler() {
-    override fun routes(): List<Route> {
-        return emptyList()
-    }
+    override fun routes(): List<Route> = emptyList()
 
-    override fun replacedRoutes(): List<ReplacedRoute> {
-        return listOf(
-            ReplacedRoute(
-                POST, RETRY_BASE_URI,
-                POST, LEGACY_RETRY_BASE_URI,
-            ),
-            ReplacedRoute(
-                POST, "$RETRY_BASE_URI/{index}",
-                POST, "$LEGACY_RETRY_BASE_URI/{index}",
-            ),
-        )
-    }
+    override fun replacedRoutes(): List<ReplacedRoute> = listOf(
+        ReplacedRoute(
+            POST, RETRY_BASE_URI,
+            POST, LEGACY_RETRY_BASE_URI,
+        ),
+        ReplacedRoute(
+            POST, "$RETRY_BASE_URI/{index}",
+            POST, "$LEGACY_RETRY_BASE_URI/{index}",
+        ),
+    )
 
-    override fun getName(): String {
-        return "retry_failed_managed_index"
-    }
+    override fun getName(): String = "retry_failed_managed_index"
 
     @Suppress("SpreadOperator") // There is no way around dealing with java vararg without spread operator.
     override fun prepareRequest(request: RestRequest, client: NodeClient): RestChannelConsumer {

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/alias/AttemptAliasActionsStep.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/alias/AttemptAliasActionsStep.kt
@@ -61,13 +61,11 @@ class AttemptAliasActionsStep(private val action: AliasAction) : Step(name) {
         }
     }
 
-    override fun getUpdatedManagedIndexMetadata(currentMetadata: ManagedIndexMetaData): ManagedIndexMetaData {
-        return currentMetadata.copy(
-            stepMetaData = StepMetaData(name, getStepStartTime(currentMetadata).toEpochMilli(), stepStatus),
-            transitionTo = null,
-            info = info,
-        )
-    }
+    override fun getUpdatedManagedIndexMetadata(currentMetadata: ManagedIndexMetaData): ManagedIndexMetaData = currentMetadata.copy(
+        stepMetaData = StepMetaData(name, getStepStartTime(currentMetadata).toEpochMilli(), stepStatus),
+        transitionTo = null,
+        info = info,
+    )
 
     override fun isIdempotent() = true
 

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/allocation/AttemptAllocationStep.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/allocation/AttemptAllocationStep.kt
@@ -64,13 +64,11 @@ class AttemptAllocationStep(private val action: AllocationAction) : Step(name) {
         }
     }
 
-    override fun getUpdatedManagedIndexMetadata(currentMetadata: ManagedIndexMetaData): ManagedIndexMetaData {
-        return currentMetadata.copy(
-            stepMetaData = StepMetaData(name, getStepStartTime(currentMetadata).toEpochMilli(), stepStatus),
-            transitionTo = null,
-            info = info,
-        )
-    }
+    override fun getUpdatedManagedIndexMetadata(currentMetadata: ManagedIndexMetaData): ManagedIndexMetaData = currentMetadata.copy(
+        stepMetaData = StepMetaData(name, getStepStartTime(currentMetadata).toEpochMilli(), stepStatus),
+        transitionTo = null,
+        info = info,
+    )
 
     override fun isIdempotent() = true
 

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/close/AttemptCloseStep.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/close/AttemptCloseStep.kt
@@ -75,13 +75,11 @@ class AttemptCloseStep : Step(name) {
         info = mutableInfo.toMap()
     }
 
-    override fun getUpdatedManagedIndexMetadata(currentMetadata: ManagedIndexMetaData): ManagedIndexMetaData {
-        return currentMetadata.copy(
-            stepMetaData = StepMetaData(name, getStepStartTime(currentMetadata).toEpochMilli(), stepStatus),
-            transitionTo = null,
-            info = info,
-        )
-    }
+    override fun getUpdatedManagedIndexMetadata(currentMetadata: ManagedIndexMetaData): ManagedIndexMetaData = currentMetadata.copy(
+        stepMetaData = StepMetaData(name, getStepStartTime(currentMetadata).toEpochMilli(), stepStatus),
+        transitionTo = null,
+        info = info,
+    )
 
     override fun isIdempotent() = true
 

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/delete/AttemptDeleteStep.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/delete/AttemptDeleteStep.kt
@@ -71,13 +71,11 @@ class AttemptDeleteStep : Step(name) {
         info = mutableInfo.toMap()
     }
 
-    override fun getUpdatedManagedIndexMetadata(currentMetadata: ManagedIndexMetaData): ManagedIndexMetaData {
-        return currentMetadata.copy(
-            stepMetaData = StepMetaData(name, getStepStartTime(currentMetadata).toEpochMilli(), stepStatus),
-            transitionTo = null,
-            info = info,
-        )
-    }
+    override fun getUpdatedManagedIndexMetadata(currentMetadata: ManagedIndexMetaData): ManagedIndexMetaData = currentMetadata.copy(
+        stepMetaData = StepMetaData(name, getStepStartTime(currentMetadata).toEpochMilli(), stepStatus),
+        transitionTo = null,
+        info = info,
+    )
 
     override fun isIdempotent() = true
 

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/indexpriority/AttemptSetIndexPriorityStep.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/indexpriority/AttemptSetIndexPriorityStep.kt
@@ -65,13 +65,11 @@ class AttemptSetIndexPriorityStep(private val action: IndexPriorityAction) : Ste
         info = mutableInfo.toMap()
     }
 
-    override fun getUpdatedManagedIndexMetadata(currentMetadata: ManagedIndexMetaData): ManagedIndexMetaData {
-        return currentMetadata.copy(
-            stepMetaData = StepMetaData(name, getStepStartTime(currentMetadata).toEpochMilli(), stepStatus),
-            transitionTo = null,
-            info = info,
-        )
-    }
+    override fun getUpdatedManagedIndexMetadata(currentMetadata: ManagedIndexMetaData): ManagedIndexMetaData = currentMetadata.copy(
+        stepMetaData = StepMetaData(name, getStepStartTime(currentMetadata).toEpochMilli(), stepStatus),
+        transitionTo = null,
+        info = info,
+    )
 
     override fun isIdempotent() = true
 

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/notification/AttemptNotificationStep.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/notification/AttemptNotificationStep.kt
@@ -56,7 +56,11 @@ class AttemptNotificationStep(private val action: NotificationAction) : Step(nam
         info = info,
     )
 
-    private fun compileTemplate(scriptService: ScriptService, template: Script, managedIndexMetaData: ManagedIndexMetaData): String = scriptService.compile(template, TemplateScript.CONTEXT)
+    private fun compileTemplate(
+        scriptService: ScriptService,
+        template: Script,
+        managedIndexMetaData: ManagedIndexMetaData,
+    ): String = scriptService.compile(template, TemplateScript.CONTEXT)
         .newInstance(template.params + mapOf("ctx" to managedIndexMetaData.convertToMap()))
         .execute()
 

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/notification/AttemptNotificationStep.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/notification/AttemptNotificationStep.kt
@@ -50,19 +50,15 @@ class AttemptNotificationStep(private val action: NotificationAction) : Step(nam
         info = mutableInfo.toMap()
     }
 
-    override fun getUpdatedManagedIndexMetadata(currentMetadata: ManagedIndexMetaData): ManagedIndexMetaData {
-        return currentMetadata.copy(
-            stepMetaData = StepMetaData(name, getStepStartTime(currentMetadata).toEpochMilli(), stepStatus),
-            transitionTo = null,
-            info = info,
-        )
-    }
+    override fun getUpdatedManagedIndexMetadata(currentMetadata: ManagedIndexMetaData): ManagedIndexMetaData = currentMetadata.copy(
+        stepMetaData = StepMetaData(name, getStepStartTime(currentMetadata).toEpochMilli(), stepStatus),
+        transitionTo = null,
+        info = info,
+    )
 
-    private fun compileTemplate(scriptService: ScriptService, template: Script, managedIndexMetaData: ManagedIndexMetaData): String {
-        return scriptService.compile(template, TemplateScript.CONTEXT)
-            .newInstance(template.params + mapOf("ctx" to managedIndexMetaData.convertToMap()))
-            .execute()
-    }
+    private fun compileTemplate(scriptService: ScriptService, template: Script, managedIndexMetaData: ManagedIndexMetaData): String = scriptService.compile(template, TemplateScript.CONTEXT)
+        .newInstance(template.params + mapOf("ctx" to managedIndexMetaData.convertToMap()))
+        .execute()
 
     override fun isIdempotent(): Boolean = false
 

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/open/AttemptOpenStep.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/open/AttemptOpenStep.kt
@@ -57,13 +57,11 @@ class AttemptOpenStep : Step(name) {
         info = mutableInfo.toMap()
     }
 
-    override fun getUpdatedManagedIndexMetadata(currentMetadata: ManagedIndexMetaData): ManagedIndexMetaData {
-        return currentMetadata.copy(
-            stepMetaData = StepMetaData(name, getStepStartTime(currentMetadata).toEpochMilli(), stepStatus),
-            transitionTo = null,
-            info = info,
-        )
-    }
+    override fun getUpdatedManagedIndexMetadata(currentMetadata: ManagedIndexMetaData): ManagedIndexMetaData = currentMetadata.copy(
+        stepMetaData = StepMetaData(name, getStepStartTime(currentMetadata).toEpochMilli(), stepStatus),
+        transitionTo = null,
+        info = info,
+    )
 
     override fun isIdempotent() = true
 

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/readonly/SetReadOnlyStep.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/readonly/SetReadOnlyStep.kt
@@ -62,13 +62,11 @@ class SetReadOnlyStep : Step(name) {
         info = mutableInfo.toMap()
     }
 
-    override fun getUpdatedManagedIndexMetadata(currentMetadata: ManagedIndexMetaData): ManagedIndexMetaData {
-        return currentMetadata.copy(
-            stepMetaData = StepMetaData(name, getStepStartTime(currentMetadata).toEpochMilli(), stepStatus),
-            transitionTo = null,
-            info = info,
-        )
-    }
+    override fun getUpdatedManagedIndexMetadata(currentMetadata: ManagedIndexMetaData): ManagedIndexMetaData = currentMetadata.copy(
+        stepMetaData = StepMetaData(name, getStepStartTime(currentMetadata).toEpochMilli(), stepStatus),
+        transitionTo = null,
+        info = info,
+    )
 
     override fun isIdempotent(): Boolean = true
 

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/readwrite/SetReadWriteStep.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/readwrite/SetReadWriteStep.kt
@@ -64,13 +64,11 @@ class SetReadWriteStep : Step(name) {
         info = mutableInfo.toMap()
     }
 
-    override fun getUpdatedManagedIndexMetadata(currentMetadata: ManagedIndexMetaData): ManagedIndexMetaData {
-        return currentMetadata.copy(
-            stepMetaData = StepMetaData(name, getStepStartTime(currentMetadata).toEpochMilli(), stepStatus),
-            transitionTo = null,
-            info = info,
-        )
-    }
+    override fun getUpdatedManagedIndexMetadata(currentMetadata: ManagedIndexMetaData): ManagedIndexMetaData = currentMetadata.copy(
+        stepMetaData = StepMetaData(name, getStepStartTime(currentMetadata).toEpochMilli(), stepStatus),
+        transitionTo = null,
+        info = info,
+    )
 
     override fun isIdempotent(): Boolean = true
 

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/replicacount/AttemptReplicaCountStep.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/replicacount/AttemptReplicaCountStep.kt
@@ -64,13 +64,11 @@ class AttemptReplicaCountStep(private val action: ReplicaCountAction) : Step(nam
         info = mutableInfo.toMap()
     }
 
-    override fun getUpdatedManagedIndexMetadata(currentMetadata: ManagedIndexMetaData): ManagedIndexMetaData {
-        return currentMetadata.copy(
-            stepMetaData = StepMetaData(name, getStepStartTime(currentMetadata).toEpochMilli(), stepStatus),
-            transitionTo = null,
-            info = info,
-        )
-    }
+    override fun getUpdatedManagedIndexMetadata(currentMetadata: ManagedIndexMetaData): ManagedIndexMetaData = currentMetadata.copy(
+        stepMetaData = StepMetaData(name, getStepStartTime(currentMetadata).toEpochMilli(), stepStatus),
+        transitionTo = null,
+        info = info,
+    )
 
     override fun isIdempotent() = true
 

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/rollover/AttemptRolloverStep.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/rollover/AttemptRolloverStep.kt
@@ -363,15 +363,13 @@ class AttemptRolloverStep(private val action: RolloverAction) : Step(name) {
         }
     }
 
-    override fun getUpdatedManagedIndexMetadata(currentMetadata: ManagedIndexMetaData): ManagedIndexMetaData {
-        return currentMetadata.copy(
-            stepMetaData = StepMetaData(name, getStepStartTime(currentMetadata).toEpochMilli(), stepStatus),
-            rolledOver = if (currentMetadata.rolledOver == true) true else stepStatus == StepStatus.COMPLETED,
-            rolledOverIndexName = if (currentMetadata.rolledOverIndexName != null) currentMetadata.rolledOverIndexName else newIndex,
-            transitionTo = null,
-            info = info,
-        )
-    }
+    override fun getUpdatedManagedIndexMetadata(currentMetadata: ManagedIndexMetaData): ManagedIndexMetaData = currentMetadata.copy(
+        stepMetaData = StepMetaData(name, getStepStartTime(currentMetadata).toEpochMilli(), stepStatus),
+        rolledOver = if (currentMetadata.rolledOver == true) true else stepStatus == StepStatus.COMPLETED,
+        rolledOverIndexName = if (currentMetadata.rolledOverIndexName != null) currentMetadata.rolledOverIndexName else newIndex,
+        transitionTo = null,
+        info = info,
+    )
 
     private fun handleException(indexName: String, e: Exception, message: String = getFailedMessage(indexName), conditions: Any? = null) {
         logger.error(message, e)

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/shrink/AttemptShrinkStep.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/shrink/AttemptShrinkStep.kt
@@ -122,20 +122,18 @@ class AttemptShrinkStep(private val action: ShrinkAction) : ShrinkStep(name, tru
         return true
     }
 
-    override fun getUpdatedManagedIndexMetadata(currentMetadata: ManagedIndexMetaData): ManagedIndexMetaData {
-        return currentMetadata.copy(
-            actionMetaData =
-            currentMetadata.actionMetaData?.copy(
-                actionProperties =
-                ActionProperties(
-                    shrinkActionProperties = shrinkActionProperties,
-                ),
+    override fun getUpdatedManagedIndexMetadata(currentMetadata: ManagedIndexMetaData): ManagedIndexMetaData = currentMetadata.copy(
+        actionMetaData =
+        currentMetadata.actionMetaData?.copy(
+            actionProperties =
+            ActionProperties(
+                shrinkActionProperties = shrinkActionProperties,
             ),
-            stepMetaData = StepMetaData(name, getStepStartTime(currentMetadata).toEpochMilli(), stepStatus),
-            transitionTo = null,
-            info = info,
-        )
-    }
+        ),
+        stepMetaData = StepMetaData(name, getStepStartTime(currentMetadata).toEpochMilli(), stepStatus),
+        transitionTo = null,
+        info = info,
+    )
 
     override fun isIdempotent() = false
 

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/shrink/WaitForMoveShardsStep.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/shrink/WaitForMoveShardsStep.kt
@@ -96,20 +96,18 @@ class WaitForMoveShardsStep(private val action: ShrinkAction) : ShrinkStep(name,
 
     override fun getGenericFailureMessage(): String = FAILURE_MESSAGE
 
-    override fun getUpdatedManagedIndexMetadata(currentMetadata: ManagedIndexMetaData): ManagedIndexMetaData {
-        return currentMetadata.copy(
-            actionMetaData =
-            currentMetadata.actionMetaData?.copy(
-                actionProperties =
-                ActionProperties(
-                    shrinkActionProperties = shrinkActionProperties,
-                ),
+    override fun getUpdatedManagedIndexMetadata(currentMetadata: ManagedIndexMetaData): ManagedIndexMetaData = currentMetadata.copy(
+        actionMetaData =
+        currentMetadata.actionMetaData?.copy(
+            actionProperties =
+            ActionProperties(
+                shrinkActionProperties = shrinkActionProperties,
             ),
-            stepMetaData = StepMetaData(name, getStepStartTime(currentMetadata).toEpochMilli(), stepStatus),
-            transitionTo = null,
-            info = info,
-        )
-    }
+        ),
+        stepMetaData = StepMetaData(name, getStepStartTime(currentMetadata).toEpochMilli(), stepStatus),
+        transitionTo = null,
+        info = info,
+    )
 
     private suspend fun checkTimeOut(
         stepContext: StepContext,

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/shrink/WaitForShrinkStep.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/shrink/WaitForShrinkStep.kt
@@ -159,20 +159,18 @@ class WaitForShrinkStep(private val action: ShrinkAction) : ShrinkStep(name, tru
         }
     }
 
-    override fun getUpdatedManagedIndexMetadata(currentMetadata: ManagedIndexMetaData): ManagedIndexMetaData {
-        return currentMetadata.copy(
-            actionMetaData =
-            currentMetadata.actionMetaData?.copy(
-                actionProperties =
-                ActionProperties(
-                    shrinkActionProperties = shrinkActionProperties,
-                ),
+    override fun getUpdatedManagedIndexMetadata(currentMetadata: ManagedIndexMetaData): ManagedIndexMetaData = currentMetadata.copy(
+        actionMetaData =
+        currentMetadata.actionMetaData?.copy(
+            actionProperties =
+            ActionProperties(
+                shrinkActionProperties = shrinkActionProperties,
             ),
-            stepMetaData = StepMetaData(name, getStepStartTime(currentMetadata).toEpochMilli(), stepStatus),
-            transitionTo = null,
-            info = info,
-        )
-    }
+        ),
+        stepMetaData = StepMetaData(name, getStepStartTime(currentMetadata).toEpochMilli(), stepStatus),
+        transitionTo = null,
+        info = info,
+    )
 
     override fun isIdempotent() = true
 

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/transform/WaitForTransformCompletionStep.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/transform/WaitForTransformCompletionStep.kt
@@ -108,14 +108,12 @@ class WaitForTransformCompletionStep : Step(name) {
         info = mutableInfo.toMap()
     }
 
-    override fun getUpdatedManagedIndexMetadata(currentMetadata: ManagedIndexMetaData): ManagedIndexMetaData {
-        return currentMetadata.copy(
-            actionMetaData = currentMetadata.actionMetaData,
-            stepMetaData = StepMetaData(name, getStepStartTime(currentMetadata).toEpochMilli(), stepStatus),
-            transitionTo = null,
-            info = info,
-        )
-    }
+    override fun getUpdatedManagedIndexMetadata(currentMetadata: ManagedIndexMetaData): ManagedIndexMetaData = currentMetadata.copy(
+        actionMetaData = currentMetadata.actionMetaData,
+        stepMetaData = StepMetaData(name, getStepStartTime(currentMetadata).toEpochMilli(), stepStatus),
+        transitionTo = null,
+        info = info,
+    )
 
     override fun isIdempotent(): Boolean = true
 

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/transition/AttemptTransitionStep.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/transition/AttemptTransitionStep.kt
@@ -137,14 +137,12 @@ class AttemptTransitionStep(private val action: TransitionsAction) : Step(name) 
         info = mutableInfo.toMap()
     }
 
-    override fun getUpdatedManagedIndexMetadata(currentMetadata: ManagedIndexMetaData): ManagedIndexMetaData {
-        return currentMetadata.copy(
-            policyCompleted = policyCompleted,
-            transitionTo = stateName,
-            stepMetaData = StepMetaData(name, getStepStartTime(currentMetadata).toEpochMilli(), stepStatus),
-            info = info,
-        )
-    }
+    override fun getUpdatedManagedIndexMetadata(currentMetadata: ManagedIndexMetaData): ManagedIndexMetaData = currentMetadata.copy(
+        policyCompleted = policyCompleted,
+        transitionTo = stateName,
+        stepMetaData = StepMetaData(name, getStepStartTime(currentMetadata).toEpochMilli(), stepStatus),
+        info = info,
+    )
 
     @Suppress("ReturnCount")
     private suspend fun getIndexCreationDate(

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/transport/action/ISMStatusResponse.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/transport/action/ISMStatusResponse.kt
@@ -16,7 +16,9 @@ import org.opensearch.indexmanagement.indexstatemanagement.util.UPDATED_INDICES
 import org.opensearch.indexmanagement.indexstatemanagement.util.buildInvalidIndexResponse
 import java.io.IOException
 
-open class ISMStatusResponse : ActionResponse, ToXContentObject {
+open class ISMStatusResponse :
+    ActionResponse,
+    ToXContentObject {
     val updated: Int
     val failedIndices: List<FailedIndex>
 

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/transport/action/explain/ExplainResponse.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/transport/action/explain/ExplainResponse.kt
@@ -21,7 +21,9 @@ import org.opensearch.indexmanagement.spi.indexstatemanagement.model.ManagedInde
 import org.opensearch.indexmanagement.spi.indexstatemanagement.model.ValidationResult
 import java.io.IOException
 
-open class ExplainResponse : ActionResponse, ToXContentObject {
+open class ExplainResponse :
+    ActionResponse,
+    ToXContentObject {
     // TODO refactor these lists usage to map
     val indexNames: List<String>
     val indexPolicyIDs: List<String?>

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/transport/action/explain/TransportExplainAction.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/transport/action/explain/TransportExplainAction.kt
@@ -461,15 +461,13 @@ constructor(
             return null
         }
 
-        private fun parseSearchHits(hits: Array<SearchHit>): List<ManagedIndexConfig> {
-            return hits.map { hit ->
-                XContentHelper.createParser(
-                    xContentRegistry,
-                    LoggingDeprecationHandler.INSTANCE,
-                    hit.sourceRef,
-                    XContentType.JSON,
-                ).parseWithType(parse = ManagedIndexConfig.Companion::parse)
-            }
+        private fun parseSearchHits(hits: Array<SearchHit>): List<ManagedIndexConfig> = hits.map { hit ->
+            XContentHelper.createParser(
+                xContentRegistry,
+                LoggingDeprecationHandler.INSTANCE,
+                hit.sourceRef,
+                XContentType.JSON,
+            ).parseWithType(parse = ManagedIndexConfig.Companion::parse)
         }
     }
 }

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/transport/action/getpolicy/GetPoliciesRequest.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/transport/action/getpolicy/GetPoliciesRequest.kt
@@ -26,9 +26,7 @@ class GetPoliciesRequest : ActionRequest {
         searchParams = SearchParams(sin),
     )
 
-    override fun validate(): ActionRequestValidationException? {
-        return null
-    }
+    override fun validate(): ActionRequestValidationException? = null
 
     @Throws(IOException::class)
     override fun writeTo(out: StreamOutput) {

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/transport/action/getpolicy/GetPoliciesResponse.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/transport/action/getpolicy/GetPoliciesResponse.kt
@@ -20,7 +20,9 @@ import org.opensearch.indexmanagement.util._PRIMARY_TERM
 import org.opensearch.indexmanagement.util._SEQ_NO
 import java.io.IOException
 
-class GetPoliciesResponse : ActionResponse, ToXContentObject {
+class GetPoliciesResponse :
+    ActionResponse,
+    ToXContentObject {
     val policies: List<Policy>
     val totalPolicies: Int
 

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/transport/action/getpolicy/GetPolicyResponse.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/transport/action/getpolicy/GetPolicyResponse.kt
@@ -21,7 +21,9 @@ import org.opensearch.indexmanagement.util._SEQ_NO
 import org.opensearch.indexmanagement.util._VERSION
 import java.io.IOException
 
-class GetPolicyResponse : ActionResponse, ToXContentObject {
+class GetPolicyResponse :
+    ActionResponse,
+    ToXContentObject {
     val id: String
     val version: Long
     val seqNo: Long

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/transport/action/indexpolicy/IndexPolicyResponse.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/transport/action/indexpolicy/IndexPolicyResponse.kt
@@ -21,7 +21,9 @@ import org.opensearch.indexmanagement.util._SEQ_NO
 import org.opensearch.indexmanagement.util._VERSION
 import java.io.IOException
 
-class IndexPolicyResponse : ActionResponse, ToXContentObject {
+class IndexPolicyResponse :
+    ActionResponse,
+    ToXContentObject {
     val id: String
     val version: Long
     val primaryTerm: Long

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/util/ManagedIndexUtils.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/util/ManagedIndexUtils.kt
@@ -89,14 +89,12 @@ fun managedIndexConfigIndexRequest(
         .source(managedIndexConfig.toXContent(XContentFactory.jsonBuilder(), ToXContent.EMPTY_PARAMS))
 }
 
-fun managedIndexConfigIndexRequest(managedIndexConfig: ManagedIndexConfig): IndexRequest {
-    return IndexRequest(INDEX_MANAGEMENT_INDEX)
-        .id(managedIndexConfig.indexUuid)
-        .setIfPrimaryTerm(managedIndexConfig.primaryTerm)
-        .setIfSeqNo(managedIndexConfig.seqNo)
-        .routing(managedIndexConfig.indexUuid) // we want job doc and its metadata doc be routed to same shard
-        .source(managedIndexConfig.toXContent(XContentFactory.jsonBuilder(), ToXContent.EMPTY_PARAMS))
-}
+fun managedIndexConfigIndexRequest(managedIndexConfig: ManagedIndexConfig): IndexRequest = IndexRequest(INDEX_MANAGEMENT_INDEX)
+    .id(managedIndexConfig.indexUuid)
+    .setIfPrimaryTerm(managedIndexConfig.primaryTerm)
+    .setIfSeqNo(managedIndexConfig.seqNo)
+    .routing(managedIndexConfig.indexUuid) // we want job doc and its metadata doc be routed to same shard
+    .source(managedIndexConfig.toXContent(XContentFactory.jsonBuilder(), ToXContent.EMPTY_PARAMS))
 
 const val METADATA_POST_FIX = "#metadata"
 
@@ -137,28 +135,18 @@ private fun updateEnabledField(uuid: String, enabled: Boolean, enabledTime: Long
     return UpdateRequest(INDEX_MANAGEMENT_INDEX, uuid).doc(builder)
 }
 
-fun updateDisableManagedIndexRequest(uuid: String): UpdateRequest {
-    return updateEnabledField(uuid, false, null)
-}
+fun updateDisableManagedIndexRequest(uuid: String): UpdateRequest = updateEnabledField(uuid, false, null)
 
-fun updateEnableManagedIndexRequest(uuid: String): UpdateRequest {
-    return updateEnabledField(uuid, true, Instant.now().toEpochMilli())
-}
+fun updateEnableManagedIndexRequest(uuid: String): UpdateRequest = updateEnabledField(uuid, true, Instant.now().toEpochMilli())
 
-fun deleteManagedIndexRequest(uuid: String): DeleteRequest {
-    return DeleteRequest(INDEX_MANAGEMENT_INDEX, uuid)
-}
+fun deleteManagedIndexRequest(uuid: String): DeleteRequest = DeleteRequest(INDEX_MANAGEMENT_INDEX, uuid)
 
-fun deleteManagedIndexMetadataRequest(uuid: String): DeleteRequest {
-    return DeleteRequest(INDEX_MANAGEMENT_INDEX, managedIndexMetadataID(uuid)).routing(uuid)
-}
+fun deleteManagedIndexMetadataRequest(uuid: String): DeleteRequest = DeleteRequest(INDEX_MANAGEMENT_INDEX, managedIndexMetadataID(uuid)).routing(uuid)
 
-fun updateManagedIndexRequest(sweptManagedIndexConfig: SweptManagedIndexConfig): UpdateRequest {
-    return UpdateRequest(INDEX_MANAGEMENT_INDEX, sweptManagedIndexConfig.uuid)
-        .setIfPrimaryTerm(sweptManagedIndexConfig.primaryTerm)
-        .setIfSeqNo(sweptManagedIndexConfig.seqNo)
-        .doc(getPartialChangePolicyBuilder(sweptManagedIndexConfig.changePolicy))
-}
+fun updateManagedIndexRequest(sweptManagedIndexConfig: SweptManagedIndexConfig): UpdateRequest = UpdateRequest(INDEX_MANAGEMENT_INDEX, sweptManagedIndexConfig.uuid)
+    .setIfPrimaryTerm(sweptManagedIndexConfig.primaryTerm)
+    .setIfSeqNo(sweptManagedIndexConfig.seqNo)
+    .doc(getPartialChangePolicyBuilder(sweptManagedIndexConfig.changePolicy))
 
 /**
  * Finds ManagedIndices that exist in [INDEX_MANAGEMENT_INDEX] that do not exist in the cluster state
@@ -171,10 +159,8 @@ fun updateManagedIndexRequest(sweptManagedIndexConfig: SweptManagedIndexConfig):
 fun getManagedIndicesToDelete(
     currentIndexUuids: List<String>,
     currentManagedIndexUuids: List<String>,
-): List<String> {
-    return currentManagedIndexUuids.filter { currentManagedIndex ->
-        !currentIndexUuids.contains(currentManagedIndex)
-    }
+): List<String> = currentManagedIndexUuids.filter { currentManagedIndex ->
+    !currentIndexUuids.contains(currentManagedIndex)
 }
 
 fun getSweptManagedIndexSearchRequest(scroll: Boolean = false, size: Int = ManagedIndexCoordinator.MAX_HITS): SearchRequest {
@@ -283,9 +269,7 @@ fun State.getUpdatedStateMetaData(managedIndexMetaData: ManagedIndexMetaData): S
     }
 }
 
-fun Action.shouldBackoff(actionMetaData: ActionMetaData?, actionRetry: ActionRetry?): Pair<Boolean, Long?>? {
-    return this.configRetry?.backoff?.shouldBackoff(actionMetaData, actionRetry)
-}
+fun Action.shouldBackoff(actionMetaData: ActionMetaData?, actionRetry: ActionRetry?): Pair<Boolean, Long?>? = this.configRetry?.backoff?.shouldBackoff(actionMetaData, actionRetry)
 
 @Suppress("ReturnCount")
 fun Action.hasTimedOut(actionMetaData: ActionMetaData?): Boolean {

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/util/ManagedIndexUtils.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/util/ManagedIndexUtils.kt
@@ -143,7 +143,9 @@ fun deleteManagedIndexRequest(uuid: String): DeleteRequest = DeleteRequest(INDEX
 
 fun deleteManagedIndexMetadataRequest(uuid: String): DeleteRequest = DeleteRequest(INDEX_MANAGEMENT_INDEX, managedIndexMetadataID(uuid)).routing(uuid)
 
-fun updateManagedIndexRequest(sweptManagedIndexConfig: SweptManagedIndexConfig): UpdateRequest = UpdateRequest(INDEX_MANAGEMENT_INDEX, sweptManagedIndexConfig.uuid)
+fun updateManagedIndexRequest(
+    sweptManagedIndexConfig: SweptManagedIndexConfig,
+): UpdateRequest = UpdateRequest(INDEX_MANAGEMENT_INDEX, sweptManagedIndexConfig.uuid)
     .setIfPrimaryTerm(sweptManagedIndexConfig.primaryTerm)
     .setIfSeqNo(sweptManagedIndexConfig.seqNo)
     .doc(getPartialChangePolicyBuilder(sweptManagedIndexConfig.changePolicy))
@@ -269,7 +271,8 @@ fun State.getUpdatedStateMetaData(managedIndexMetaData: ManagedIndexMetaData): S
     }
 }
 
-fun Action.shouldBackoff(actionMetaData: ActionMetaData?, actionRetry: ActionRetry?): Pair<Boolean, Long?>? = this.configRetry?.backoff?.shouldBackoff(actionMetaData, actionRetry)
+fun Action.shouldBackoff(actionMetaData: ActionMetaData?, actionRetry: ActionRetry?): Pair<Boolean, Long?>? =
+    this.configRetry?.backoff?.shouldBackoff(actionMetaData, actionRetry)
 
 @Suppress("ReturnCount")
 fun Action.hasTimedOut(actionMetaData: ActionMetaData?): Boolean {

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/util/NotificationUtils.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/util/NotificationUtils.kt
@@ -58,6 +58,4 @@ suspend fun Channel.sendNotification(
     this.sendNotification(client, eventSource, compiledMessage, user)
 }
 
-fun ManagedIndexMetaData.getEventSource(title: String): EventSource {
-    return EventSource(title, indexUuid, SeverityType.INFO)
-}
+fun ManagedIndexMetaData.getEventSource(title: String): EventSource = EventSource(title, indexUuid, SeverityType.INFO)

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/util/RestHandlerUtils.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/util/RestHandlerUtils.kt
@@ -72,7 +72,9 @@ fun buildInvalidIndexResponse(builder: XContentBuilder, failedIndices: List<Fail
     }
 }
 
-data class FailedIndex(val name: String, val uuid: String, val reason: String) : Writeable, ToXContentFragment {
+data class FailedIndex(val name: String, val uuid: String, val reason: String) :
+    Writeable,
+    ToXContentFragment {
     override fun toXContent(builder: XContentBuilder, params: ToXContent.Params): XContentBuilder {
         builder.startObject()
             .field(INDEX_NAME_FIELD, name)

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/util/StepUtils.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/util/StepUtils.kt
@@ -35,11 +35,9 @@ import org.opensearch.jobscheduler.spi.utils.LockService
 import java.lang.Exception
 import java.time.Instant
 
-suspend fun issueUpdateSettingsRequest(client: Client, indexName: String, settings: Settings): AcknowledgedResponse {
-    return client.admin()
-        .indices()
-        .suspendUntil { updateSettings(UpdateSettingsRequest(settings, indexName), it) }
-}
+suspend fun issueUpdateSettingsRequest(client: Client, indexName: String, settings: Settings): AcknowledgedResponse = client.admin()
+    .indices()
+    .suspendUntil { updateSettings(UpdateSettingsRequest(settings, indexName), it) }
 
 suspend fun releaseShrinkLock(
     shrinkActionProperties: ShrinkActionProperties,
@@ -75,16 +73,14 @@ suspend fun renewShrinkLock(
 
 fun getShrinkLockModel(
     shrinkActionProperties: ShrinkActionProperties,
-): LockModel {
-    return getShrinkLockModel(
-        shrinkActionProperties.nodeName,
-        INDEX_MANAGEMENT_INDEX,
-        shrinkActionProperties.lockEpochSecond,
-        shrinkActionProperties.lockPrimaryTerm,
-        shrinkActionProperties.lockSeqNo,
-        shrinkActionProperties.lockDurationSecond,
-    )
-}
+): LockModel = getShrinkLockModel(
+    shrinkActionProperties.nodeName,
+    INDEX_MANAGEMENT_INDEX,
+    shrinkActionProperties.lockEpochSecond,
+    shrinkActionProperties.lockPrimaryTerm,
+    shrinkActionProperties.lockSeqNo,
+    shrinkActionProperties.lockDurationSecond,
+)
 
 @SuppressWarnings("LongParameterList")
 fun getShrinkLockModel(
@@ -109,18 +105,16 @@ fun getShrinkLockModel(
 }
 
 // Returns copied ShrinkActionProperties with the details of the provided lock added in
-fun getUpdatedShrinkActionProperties(shrinkActionProperties: ShrinkActionProperties, lock: LockModel): ShrinkActionProperties {
-    return ShrinkActionProperties(
-        shrinkActionProperties.nodeName,
-        shrinkActionProperties.targetIndexName,
-        shrinkActionProperties.targetNumShards,
-        lock.primaryTerm,
-        lock.seqNo,
-        lock.lockTime.epochSecond,
-        lock.lockDurationSeconds,
-        shrinkActionProperties.originalIndexSettings,
-    )
-}
+fun getUpdatedShrinkActionProperties(shrinkActionProperties: ShrinkActionProperties, lock: LockModel): ShrinkActionProperties = ShrinkActionProperties(
+    shrinkActionProperties.nodeName,
+    shrinkActionProperties.targetIndexName,
+    shrinkActionProperties.targetNumShards,
+    lock.primaryTerm,
+    lock.seqNo,
+    lock.lockTime.epochSecond,
+    lock.lockDurationSeconds,
+    shrinkActionProperties.originalIndexSettings,
+)
 
 fun getActionStartTime(managedIndexMetaData: ManagedIndexMetaData): Instant {
     val actionMetadata = managedIndexMetaData.actionMetaData
@@ -149,18 +143,16 @@ fun getFreeBytesThresholdHigh(clusterSettings: ClusterSettings, totalNodeBytes: 
     }
 }
 
-fun getDiskSettings(clusterSettings: ClusterSettings): Settings {
-    return Settings.builder().put(
-        CLUSTER_ROUTING_ALLOCATION_DISK_FLOOD_STAGE_WATERMARK_SETTING.key,
-        clusterSettings.get(CLUSTER_ROUTING_ALLOCATION_DISK_FLOOD_STAGE_WATERMARK_SETTING),
-    ).put(
-        CLUSTER_ROUTING_ALLOCATION_HIGH_DISK_WATERMARK_SETTING.key,
-        clusterSettings.get(CLUSTER_ROUTING_ALLOCATION_HIGH_DISK_WATERMARK_SETTING),
-    ).put(
-        CLUSTER_ROUTING_ALLOCATION_LOW_DISK_WATERMARK_SETTING.key,
-        clusterSettings.get(CLUSTER_ROUTING_ALLOCATION_LOW_DISK_WATERMARK_SETTING),
-    ).build()
-}
+fun getDiskSettings(clusterSettings: ClusterSettings): Settings = Settings.builder().put(
+    CLUSTER_ROUTING_ALLOCATION_DISK_FLOOD_STAGE_WATERMARK_SETTING.key,
+    clusterSettings.get(CLUSTER_ROUTING_ALLOCATION_DISK_FLOOD_STAGE_WATERMARK_SETTING),
+).put(
+    CLUSTER_ROUTING_ALLOCATION_HIGH_DISK_WATERMARK_SETTING.key,
+    clusterSettings.get(CLUSTER_ROUTING_ALLOCATION_HIGH_DISK_WATERMARK_SETTING),
+).put(
+    CLUSTER_ROUTING_ALLOCATION_LOW_DISK_WATERMARK_SETTING.key,
+    clusterSettings.get(CLUSTER_ROUTING_ALLOCATION_LOW_DISK_WATERMARK_SETTING),
+).build()
 
 /*
  * Returns the amount of memory in the node which will be free below the high watermark level after adding 2*indexSizeInBytes, or -1
@@ -205,16 +197,12 @@ suspend fun resetReadOnlyAndRouting(index: String, client: Client, originalSetti
     return true
 }
 
-fun getShrinkLockID(nodeName: String): String {
-    return LockModel.generateLockId(
-        INDEX_MANAGEMENT_INDEX,
-        getShrinkJobID(nodeName),
-    )
-}
+fun getShrinkLockID(nodeName: String): String = LockModel.generateLockId(
+    INDEX_MANAGEMENT_INDEX,
+    getShrinkJobID(nodeName),
+)
 
-fun getShrinkJobID(nodeName: String): String {
-    return "$LOCK_SOURCE_JOB_ID-$nodeName"
-}
+fun getShrinkJobID(nodeName: String): String = "$LOCK_SOURCE_JOB_ID-$nodeName"
 
 // Creates a map of shardIds to the set of node names which the shard copies reside on. For example, with 2 replicas
 // each shardId would have a set containing 3 node names, for the nodes of the primary and two replicas.

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/validation/ValidateNothing.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/validation/ValidateNothing.kt
@@ -18,7 +18,5 @@ class ValidateNothing(
     jvmService: JvmService,
 ) : Validate(settings, clusterService, jvmService) {
     // skips validation
-    override fun execute(indexName: String): Validate {
-        return this
-    }
+    override fun execute(indexName: String): Validate = this
 }

--- a/src/main/kotlin/org/opensearch/indexmanagement/opensearchapi/OpenSearchExtensions.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/opensearchapi/OpenSearchExtensions.kt
@@ -64,7 +64,10 @@ import kotlin.coroutines.suspendCoroutine
 
 const val OPENDISTRO_SECURITY_PROTECTED_INDICES_CONF_REQUEST = "_opendistro_security_protected_indices_conf_request"
 
-fun contentParser(bytesReference: BytesReference, xContentRegistry: NamedXContentRegistry = NamedXContentRegistry.EMPTY): XContentParser = XContentHelper.createParser(
+fun contentParser(
+    bytesReference: BytesReference,
+    xContentRegistry: NamedXContentRegistry = NamedXContentRegistry.EMPTY,
+): XContentParser = XContentHelper.createParser(
     xContentRegistry,
     LoggingDeprecationHandler.INSTANCE,
     bytesReference,

--- a/src/main/kotlin/org/opensearch/indexmanagement/opensearchapi/OpenSearchExtensions.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/opensearchapi/OpenSearchExtensions.kt
@@ -64,14 +64,12 @@ import kotlin.coroutines.suspendCoroutine
 
 const val OPENDISTRO_SECURITY_PROTECTED_INDICES_CONF_REQUEST = "_opendistro_security_protected_indices_conf_request"
 
-fun contentParser(bytesReference: BytesReference, xContentRegistry: NamedXContentRegistry = NamedXContentRegistry.EMPTY): XContentParser {
-    return XContentHelper.createParser(
-        xContentRegistry,
-        LoggingDeprecationHandler.INSTANCE,
-        bytesReference,
-        XContentType.JSON,
-    )
-}
+fun contentParser(bytesReference: BytesReference, xContentRegistry: NamedXContentRegistry = NamedXContentRegistry.EMPTY): XContentParser = XContentHelper.createParser(
+    xContentRegistry,
+    LoggingDeprecationHandler.INSTANCE,
+    bytesReference,
+    XContentType.JSON,
+)
 
 /** Convert an object to maps and lists representation */
 fun ToXContent.convertToMap(): Map<String, Any> {
@@ -82,14 +80,12 @@ fun ToXContent.convertToMap(): Map<String, Any> {
     return XContentHelper.convertToMap(bytesReference, false, XContentType.JSON as (MediaType)).v2()
 }
 
-fun XContentParser.instant(): Instant? {
-    return when {
-        currentToken() == Token.VALUE_NULL -> null
-        currentToken().isValue -> Instant.ofEpochMilli(longValue())
-        else -> {
-            XContentParserUtils.throwUnknownToken(currentToken(), tokenLocation)
-            null // unreachable
-        }
+fun XContentParser.instant(): Instant? = when {
+    currentToken() == Token.VALUE_NULL -> null
+    currentToken().isValue -> Instant.ofEpochMilli(longValue())
+    else -> {
+        XContentParserUtils.throwUnknownToken(currentToken(), tokenLocation)
+        null // unreachable
     }
 }
 
@@ -117,9 +113,7 @@ fun XContentBuilder.optionalISMTemplateField(name: String, ismTemplates: List<IS
     return this.field(Policy.ISM_TEMPLATE, ismTemplates.toTypedArray())
 }
 
-fun XContentBuilder.optionalUserField(name: String, user: User?): XContentBuilder {
-    return if (user == null) nullField(name) else this.field(name, user)
-}
+fun XContentBuilder.optionalUserField(name: String, user: User?): XContentBuilder = if (user == null) nullField(name) else this.field(name, user)
 
 /**
  * Parse data from SearchResponse using the defined parser and xContentRegistry
@@ -128,14 +122,12 @@ fun <T> parseFromSearchResponse(
     response: SearchResponse,
     xContentRegistry: NamedXContentRegistry = NamedXContentRegistry.EMPTY,
     parse: (xcp: XContentParser, id: String, seqNo: Long, primaryTerm: Long) -> T,
-): List<T> {
-    return response.hits.hits.map {
-        val id = it.id
-        val seqNo = it.seqNo
-        val primaryTerm = it.primaryTerm
-        val xcp = XContentHelper.createParser(xContentRegistry, LoggingDeprecationHandler.INSTANCE, it.sourceRef, XContentType.JSON)
-        xcp.parseWithType(id, seqNo, primaryTerm, parse)
-    }
+): List<T> = response.hits.hits.map {
+    val id = it.id
+    val seqNo = it.seqNo
+    val primaryTerm = it.primaryTerm
+    val xcp = XContentHelper.createParser(xContentRegistry, LoggingDeprecationHandler.INSTANCE, it.sourceRef, XContentType.JSON)
+    xcp.parseWithType(id, seqNo, primaryTerm, parse)
 }
 
 /**
@@ -200,9 +192,7 @@ suspend fun <T> BackoffPolicy.retry(
  * Retries on 502, 503 and 504 per elastic client's behavior: https://github.com/elastic/elasticsearch-net/issues/2061
  * 429 must be retried manually as it's not clear if it's ok to retry for requests other than Bulk requests.
  */
-fun OpenSearchException.isRetryable(): Boolean {
-    return (status() in listOf(RestStatus.BAD_GATEWAY, RestStatus.SERVICE_UNAVAILABLE, RestStatus.GATEWAY_TIMEOUT))
-}
+fun OpenSearchException.isRetryable(): Boolean = (status() in listOf(RestStatus.BAD_GATEWAY, RestStatus.SERVICE_UNAVAILABLE, RestStatus.GATEWAY_TIMEOUT))
 
 /**
  * Extension function for OpenSearch 6.3 and above that duplicates the OpenSearch 6.2 XContentBuilder.string() method.
@@ -328,29 +318,23 @@ suspend fun <T> withClosableContext(
     }
 }
 
-fun XContentBuilder.optionalField(name: String, value: Any?): XContentBuilder {
-    return if (value != null) {
-        this.field(name, value)
+fun XContentBuilder.optionalField(name: String, value: Any?): XContentBuilder = if (value != null) {
+    this.field(name, value)
+} else {
+    this
+}
+
+fun XContentBuilder.optionalInfoField(name: String, info: SMMetadata.Info?): XContentBuilder = if (info != null) {
+    if (info.message != null || info.cause != null) {
+        this.field(name, info)
     } else {
         this
     }
+} else {
+    this
 }
 
-fun XContentBuilder.optionalInfoField(name: String, info: SMMetadata.Info?): XContentBuilder {
-    return if (info != null) {
-        if (info.message != null || info.cause != null) {
-            this.field(name, info)
-        } else {
-            this
-        }
-    } else {
-        this
-    }
-}
-
-inline fun <T> XContentParser.nullValueHandler(block: XContentParser.() -> T): T? {
-    return if (currentToken() == Token.VALUE_NULL) null else block()
-}
+inline fun <T> XContentParser.nullValueHandler(block: XContentParser.() -> T): T? = if (currentToken() == Token.VALUE_NULL) null else block()
 
 inline fun <T> XContentParser.parseArray(block: XContentParser.() -> T): List<T> {
     val resArr = mutableListOf<T>()
@@ -362,12 +346,10 @@ inline fun <T> XContentParser.parseArray(block: XContentParser.() -> T): List<T>
 }
 
 // similar to readOptionalWriteable
-fun <T> StreamInput.readOptionalValue(reader: Writeable.Reader<T>): T? {
-    return if (readBoolean()) {
-        reader.read(this)
-    } else {
-        null
-    }
+fun <T> StreamInput.readOptionalValue(reader: Writeable.Reader<T>): T? = if (readBoolean()) {
+    reader.read(this)
+} else {
+    null
 }
 
 fun <T> StreamOutput.writeOptionalValue(value: T, writer: Writeable.Writer<T>) {

--- a/src/main/kotlin/org/opensearch/indexmanagement/refreshanalyzer/RestRefreshSearchAnalyzerAction.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/refreshanalyzer/RestRefreshSearchAnalyzerAction.kt
@@ -20,22 +20,18 @@ import java.io.IOException
 class RestRefreshSearchAnalyzerAction : BaseRestHandler() {
     override fun getName(): String = "refresh_search_analyzer_action"
 
-    override fun routes(): List<Route> {
-        return emptyList()
-    }
+    override fun routes(): List<Route> = emptyList()
 
-    override fun replacedRoutes(): List<ReplacedRoute> {
-        return listOf(
-            ReplacedRoute(
-                POST, REFRESH_SEARCH_ANALYZER_BASE_URI,
-                POST, LEGACY_REFRESH_SEARCH_ANALYZER_BASE_URI,
-            ),
-            ReplacedRoute(
-                POST, "$REFRESH_SEARCH_ANALYZER_BASE_URI/{index}",
-                POST, "$LEGACY_REFRESH_SEARCH_ANALYZER_BASE_URI/{index}",
-            ),
-        )
-    }
+    override fun replacedRoutes(): List<ReplacedRoute> = listOf(
+        ReplacedRoute(
+            POST, REFRESH_SEARCH_ANALYZER_BASE_URI,
+            POST, LEGACY_REFRESH_SEARCH_ANALYZER_BASE_URI,
+        ),
+        ReplacedRoute(
+            POST, "$REFRESH_SEARCH_ANALYZER_BASE_URI/{index}",
+            POST, "$LEGACY_REFRESH_SEARCH_ANALYZER_BASE_URI/{index}",
+        ),
+    )
 
     // TODO: Add indicesOptions?
 

--- a/src/main/kotlin/org/opensearch/indexmanagement/refreshanalyzer/TransportRefreshSearchAnalyzerAction.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/refreshanalyzer/TransportRefreshSearchAnalyzerAction.kt
@@ -59,9 +59,7 @@ class TransportRefreshSearchAnalyzerAction :
     private val analysisRegistry: AnalysisRegistry
 
     @Throws(IOException::class)
-    override fun readShardResult(si: StreamInput): RefreshSearchAnalyzerShardResponse? {
-        return RefreshSearchAnalyzerShardResponse(si)
-    }
+    override fun readShardResult(si: StreamInput): RefreshSearchAnalyzerShardResponse? = RefreshSearchAnalyzerShardResponse(si)
 
     override fun newResponse(
         request: RefreshSearchAnalyzerRequest,
@@ -71,14 +69,10 @@ class TransportRefreshSearchAnalyzerAction :
         shardResponses: List<RefreshSearchAnalyzerShardResponse>,
         shardFailures: List<DefaultShardOperationFailedException>,
         clusterState: ClusterState,
-    ): RefreshSearchAnalyzerResponse {
-        return RefreshSearchAnalyzerResponse(totalShards, successfulShards, failedShards, shardFailures, shardResponses)
-    }
+    ): RefreshSearchAnalyzerResponse = RefreshSearchAnalyzerResponse(totalShards, successfulShards, failedShards, shardFailures, shardResponses)
 
     @Throws(IOException::class)
-    override fun readRequestFrom(si: StreamInput): RefreshSearchAnalyzerRequest {
-        return RefreshSearchAnalyzerRequest(si)
-    }
+    override fun readRequestFrom(si: StreamInput): RefreshSearchAnalyzerRequest = RefreshSearchAnalyzerRequest(si)
 
     @Throws(IOException::class)
     override fun shardOperation(request: RefreshSearchAnalyzerRequest, shardRouting: ShardRouting): RefreshSearchAnalyzerShardResponse {
@@ -94,15 +88,9 @@ class TransportRefreshSearchAnalyzerAction :
     /**
      * The refresh request works against *all* shards.
      */
-    override fun shards(clusterState: ClusterState, request: RefreshSearchAnalyzerRequest?, concreteIndices: Array<String?>?): ShardsIterator? {
-        return clusterState.routingTable().allShards(concreteIndices)
-    }
+    override fun shards(clusterState: ClusterState, request: RefreshSearchAnalyzerRequest?, concreteIndices: Array<String?>?): ShardsIterator? = clusterState.routingTable().allShards(concreteIndices)
 
-    override fun checkGlobalBlock(state: ClusterState, request: RefreshSearchAnalyzerRequest?): ClusterBlockException? {
-        return state.blocks().globalBlockedException(ClusterBlockLevel.METADATA_WRITE)
-    }
+    override fun checkGlobalBlock(state: ClusterState, request: RefreshSearchAnalyzerRequest?): ClusterBlockException? = state.blocks().globalBlockedException(ClusterBlockLevel.METADATA_WRITE)
 
-    override fun checkRequestBlock(state: ClusterState, request: RefreshSearchAnalyzerRequest?, concreteIndices: Array<String?>?): ClusterBlockException? {
-        return state.blocks().indicesBlockedException(ClusterBlockLevel.METADATA_WRITE, concreteIndices)
-    }
+    override fun checkRequestBlock(state: ClusterState, request: RefreshSearchAnalyzerRequest?, concreteIndices: Array<String?>?): ClusterBlockException? = state.blocks().indicesBlockedException(ClusterBlockLevel.METADATA_WRITE, concreteIndices)
 }

--- a/src/main/kotlin/org/opensearch/indexmanagement/refreshanalyzer/TransportRefreshSearchAnalyzerAction.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/refreshanalyzer/TransportRefreshSearchAnalyzerAction.kt
@@ -88,9 +88,12 @@ class TransportRefreshSearchAnalyzerAction :
     /**
      * The refresh request works against *all* shards.
      */
-    override fun shards(clusterState: ClusterState, request: RefreshSearchAnalyzerRequest?, concreteIndices: Array<String?>?): ShardsIterator? = clusterState.routingTable().allShards(concreteIndices)
+    override fun shards(clusterState: ClusterState, request: RefreshSearchAnalyzerRequest?, concreteIndices: Array<String?>?): ShardsIterator? =
+        clusterState.routingTable().allShards(concreteIndices)
 
-    override fun checkGlobalBlock(state: ClusterState, request: RefreshSearchAnalyzerRequest?): ClusterBlockException? = state.blocks().globalBlockedException(ClusterBlockLevel.METADATA_WRITE)
+    override fun checkGlobalBlock(state: ClusterState, request: RefreshSearchAnalyzerRequest?): ClusterBlockException? =
+        state.blocks().globalBlockedException(ClusterBlockLevel.METADATA_WRITE)
 
-    override fun checkRequestBlock(state: ClusterState, request: RefreshSearchAnalyzerRequest?, concreteIndices: Array<String?>?): ClusterBlockException? = state.blocks().indicesBlockedException(ClusterBlockLevel.METADATA_WRITE, concreteIndices)
+    override fun checkRequestBlock(state: ClusterState, request: RefreshSearchAnalyzerRequest?, concreteIndices: Array<String?>?): ClusterBlockException? =
+        state.blocks().indicesBlockedException(ClusterBlockLevel.METADATA_WRITE, concreteIndices)
 }

--- a/src/main/kotlin/org/opensearch/indexmanagement/rollup/RollupMetadataService.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/rollup/RollupMetadataService.kt
@@ -342,13 +342,14 @@ class RollupMetadataService(val client: Client, val xContentRegistry: NamedXCont
         return updateMetadata(updatedMetadata)
     }
 
-    suspend fun updateMetadata(metadata: RollupMetadata): RollupMetadata = when (val metadataUpdateResult = submitMetadataUpdate(metadata, metadata.id != NO_ID)) {
-        is MetadataResult.Success -> metadataUpdateResult.metadata
-        is MetadataResult.Failure ->
-            throw RollupMetadataException("Failed to update rollup metadata [${metadata.id}]", metadataUpdateResult.cause)
-        // NoMetadata is not expected from submitMetadataUpdate here
-        is MetadataResult.NoMetadata -> throw RollupMetadataException("Unexpected state when updating rollup metadata [${metadata.id}]", null)
-    }
+    suspend fun updateMetadata(metadata: RollupMetadata): RollupMetadata =
+        when (val metadataUpdateResult = submitMetadataUpdate(metadata, metadata.id != NO_ID)) {
+            is MetadataResult.Success -> metadataUpdateResult.metadata
+            is MetadataResult.Failure ->
+                throw RollupMetadataException("Failed to update rollup metadata [${metadata.id}]", metadataUpdateResult.cause)
+            // NoMetadata is not expected from submitMetadataUpdate here
+            is MetadataResult.NoMetadata -> throw RollupMetadataException("Unexpected state when updating rollup metadata [${metadata.id}]", null)
+        }
 
     /**
      * Sets a failure metadata for the rollup job with the given reason.

--- a/src/main/kotlin/org/opensearch/indexmanagement/rollup/RollupMetadataService.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/rollup/RollupMetadataService.kt
@@ -342,14 +342,12 @@ class RollupMetadataService(val client: Client, val xContentRegistry: NamedXCont
         return updateMetadata(updatedMetadata)
     }
 
-    suspend fun updateMetadata(metadata: RollupMetadata): RollupMetadata {
-        return when (val metadataUpdateResult = submitMetadataUpdate(metadata, metadata.id != NO_ID)) {
-            is MetadataResult.Success -> metadataUpdateResult.metadata
-            is MetadataResult.Failure ->
-                throw RollupMetadataException("Failed to update rollup metadata [${metadata.id}]", metadataUpdateResult.cause)
-            // NoMetadata is not expected from submitMetadataUpdate here
-            is MetadataResult.NoMetadata -> throw RollupMetadataException("Unexpected state when updating rollup metadata [${metadata.id}]", null)
-        }
+    suspend fun updateMetadata(metadata: RollupMetadata): RollupMetadata = when (val metadataUpdateResult = submitMetadataUpdate(metadata, metadata.id != NO_ID)) {
+        is MetadataResult.Success -> metadataUpdateResult.metadata
+        is MetadataResult.Failure ->
+            throw RollupMetadataException("Failed to update rollup metadata [${metadata.id}]", metadataUpdateResult.cause)
+        // NoMetadata is not expected from submitMetadataUpdate here
+        is MetadataResult.NoMetadata -> throw RollupMetadataException("Unexpected state when updating rollup metadata [${metadata.id}]", null)
     }
 
     /**

--- a/src/main/kotlin/org/opensearch/indexmanagement/rollup/RollupRunner.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/rollup/RollupRunner.kt
@@ -127,9 +127,7 @@ object RollupRunner :
         return this
     }
 
-    fun registerConsumers(): RollupRunner {
-        return this
-    }
+    fun registerConsumers(): RollupRunner = this
 
     @Suppress("ComplexMethod")
     override fun runJob(job: ScheduledJobParameter, context: JobExecutionContext) {

--- a/src/main/kotlin/org/opensearch/indexmanagement/rollup/RollupSearchService.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/rollup/RollupSearchService.kt
@@ -99,53 +99,51 @@ class RollupSearchService(
     }
 
     @Suppress("ComplexMethod")
-    suspend fun executeCompositeSearch(job: Rollup, metadata: RollupMetadata): RollupSearchResult {
-        return try {
-            var retryCount = 0
-            RollupSearchResult.Success(
-                retrySearchPolicy.retry(logger) {
-                    val decay = 2f.pow(retryCount++)
-                    client.suspendUntil { listener: ActionListener<SearchResponse> ->
-                        val pageSize = max(1, job.pageSize.div(decay.toInt()))
-                        if (decay > 1) {
-                            logger.warn(
-                                "Composite search failed for rollup, retrying [#${retryCount - 1}] -" +
-                                    " reducing page size of composite aggregation from ${job.pageSize} to $pageSize",
-                            )
-                        }
-
-                        val searchRequest = job.copy(pageSize = pageSize).getRollupSearchRequest(metadata)
-                        val cancelTimeoutTimeValue = TimeValue.timeValueMinutes(getCancelAfterTimeInterval(cancelAfterTimeInterval.minutes))
-                        searchRequest.cancelAfterTimeInterval = cancelTimeoutTimeValue
-
-                        search(searchRequest, listener)
+    suspend fun executeCompositeSearch(job: Rollup, metadata: RollupMetadata): RollupSearchResult = try {
+        var retryCount = 0
+        RollupSearchResult.Success(
+            retrySearchPolicy.retry(logger) {
+                val decay = 2f.pow(retryCount++)
+                client.suspendUntil { listener: ActionListener<SearchResponse> ->
+                    val pageSize = max(1, job.pageSize.div(decay.toInt()))
+                    if (decay > 1) {
+                        logger.warn(
+                            "Composite search failed for rollup, retrying [#${retryCount - 1}] -" +
+                                " reducing page size of composite aggregation from ${job.pageSize} to $pageSize",
+                        )
                     }
-                },
-            )
-        } catch (e: SearchPhaseExecutionException) {
-            logger.error(e.message, e.cause)
-            if (e.shardFailures().isEmpty()) {
-                RollupSearchResult.Failure(cause = ExceptionsHelper.unwrapCause(e) as Exception)
-            } else {
-                val shardFailure = e.shardFailures().reduce { s1, s2 -> if (s1.status().status > s2.status().status) s1 else s2 }
-                RollupSearchResult.Failure(cause = ExceptionsHelper.unwrapCause(shardFailure.cause) as Exception)
-            }
-        } catch (e: RemoteTransportException) {
-            logger.error(e.message, e.cause)
+
+                    val searchRequest = job.copy(pageSize = pageSize).getRollupSearchRequest(metadata)
+                    val cancelTimeoutTimeValue = TimeValue.timeValueMinutes(getCancelAfterTimeInterval(cancelAfterTimeInterval.minutes))
+                    searchRequest.cancelAfterTimeInterval = cancelTimeoutTimeValue
+
+                    search(searchRequest, listener)
+                }
+            },
+        )
+    } catch (e: SearchPhaseExecutionException) {
+        logger.error(e.message, e.cause)
+        if (e.shardFailures().isEmpty()) {
             RollupSearchResult.Failure(cause = ExceptionsHelper.unwrapCause(e) as Exception)
-        } catch (e: CircuitBreakingException) {
-            logger.error(e.message, e.cause)
-            RollupSearchResult.Failure(cause = e)
-        } catch (e: MultiBucketConsumerService.TooManyBucketsException) {
-            logger.error(e.message, e.cause)
-            RollupSearchResult.Failure(cause = e)
-        } catch (e: OpenSearchSecurityException) {
-            logger.error(e.message, e.cause)
-            RollupSearchResult.Failure("Cannot search data in source index/s - missing required index permissions: ${e.localizedMessage}", e)
-        } catch (e: Exception) {
-            logger.error(e.message, e.cause)
-            RollupSearchResult.Failure(cause = e)
+        } else {
+            val shardFailure = e.shardFailures().reduce { s1, s2 -> if (s1.status().status > s2.status().status) s1 else s2 }
+            RollupSearchResult.Failure(cause = ExceptionsHelper.unwrapCause(shardFailure.cause) as Exception)
         }
+    } catch (e: RemoteTransportException) {
+        logger.error(e.message, e.cause)
+        RollupSearchResult.Failure(cause = ExceptionsHelper.unwrapCause(e) as Exception)
+    } catch (e: CircuitBreakingException) {
+        logger.error(e.message, e.cause)
+        RollupSearchResult.Failure(cause = e)
+    } catch (e: MultiBucketConsumerService.TooManyBucketsException) {
+        logger.error(e.message, e.cause)
+        RollupSearchResult.Failure(cause = e)
+    } catch (e: OpenSearchSecurityException) {
+        logger.error(e.message, e.cause)
+        RollupSearchResult.Failure("Cannot search data in source index/s - missing required index permissions: ${e.localizedMessage}", e)
+    } catch (e: Exception) {
+        logger.error(e.message, e.cause)
+        RollupSearchResult.Failure(cause = e)
     }
 
     private fun getCancelAfterTimeInterval(givenInterval: Long): Long {

--- a/src/main/kotlin/org/opensearch/indexmanagement/rollup/action/explain/ExplainRollupResponse.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/rollup/action/explain/ExplainRollupResponse.kt
@@ -14,16 +14,16 @@ import org.opensearch.core.xcontent.XContentBuilder
 import org.opensearch.indexmanagement.rollup.model.ExplainRollup
 import java.io.IOException
 
-class ExplainRollupResponse : ActionResponse, ToXContentObject {
+class ExplainRollupResponse :
+    ActionResponse,
+    ToXContentObject {
     val idsToExplain: Map<String, ExplainRollup?>
 
     constructor(idsToExplain: Map<String, ExplainRollup?>) : super() {
         this.idsToExplain = idsToExplain
     }
 
-    internal fun getIdsToExplain(): Map<String, ExplainRollup?> {
-        return this.idsToExplain
-    }
+    internal fun getIdsToExplain(): Map<String, ExplainRollup?> = this.idsToExplain
 
     @Throws(IOException::class)
     constructor(sin: StreamInput) : this(

--- a/src/main/kotlin/org/opensearch/indexmanagement/rollup/action/explain/TransportExplainRollupAction.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/rollup/action/explain/TransportExplainRollupAction.kt
@@ -108,8 +108,9 @@ constructor(
                                             val metadata =
                                                 contentParser(it.sourceRef)
                                                     .parseWithType(it.id, it.seqNo, it.primaryTerm, RollupMetadata.Companion::parse)
-                                            idsToExplain.computeIfPresent(metadata.rollupID) { _,
-                                                                                               explainRollup,
+                                            idsToExplain.computeIfPresent(metadata.rollupID) {
+                                                    _,
+                                                    explainRollup,
                                                 ->
                                                 explainRollup.copy(metadata = metadata)
                                             }

--- a/src/main/kotlin/org/opensearch/indexmanagement/rollup/action/get/GetRollupResponse.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/rollup/action/get/GetRollupResponse.kt
@@ -21,7 +21,9 @@ import org.opensearch.indexmanagement.util._SEQ_NO
 import org.opensearch.indexmanagement.util._VERSION
 import java.io.IOException
 
-class GetRollupResponse : ActionResponse, ToXContentObject {
+class GetRollupResponse :
+    ActionResponse,
+    ToXContentObject {
     var id: String
     var version: Long
     var seqNo: Long

--- a/src/main/kotlin/org/opensearch/indexmanagement/rollup/action/get/GetRollupsResponse.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/rollup/action/get/GetRollupsResponse.kt
@@ -20,7 +20,9 @@ import org.opensearch.indexmanagement.util._PRIMARY_TERM
 import org.opensearch.indexmanagement.util._SEQ_NO
 import java.io.IOException
 
-class GetRollupsResponse : ActionResponse, ToXContentObject {
+class GetRollupsResponse :
+    ActionResponse,
+    ToXContentObject {
     val rollups: List<Rollup>
     val totalRollups: Int
     val status: RestStatus
@@ -50,21 +52,19 @@ class GetRollupsResponse : ActionResponse, ToXContentObject {
     }
 
     @Throws(IOException::class)
-    override fun toXContent(builder: XContentBuilder, params: ToXContent.Params): XContentBuilder {
-        return builder.startObject()
-            .field("total_rollups", totalRollups)
-            .startArray("rollups")
-            .apply {
-                for (rollup in rollups) {
-                    this.startObject()
-                        .field(_ID, rollup.id)
-                        .field(_SEQ_NO, rollup.seqNo)
-                        .field(_PRIMARY_TERM, rollup.primaryTerm)
-                        .field(ROLLUP_TYPE, rollup, XCONTENT_WITHOUT_TYPE_AND_USER)
-                        .endObject()
-                }
+    override fun toXContent(builder: XContentBuilder, params: ToXContent.Params): XContentBuilder = builder.startObject()
+        .field("total_rollups", totalRollups)
+        .startArray("rollups")
+        .apply {
+            for (rollup in rollups) {
+                this.startObject()
+                    .field(_ID, rollup.id)
+                    .field(_SEQ_NO, rollup.seqNo)
+                    .field(_PRIMARY_TERM, rollup.primaryTerm)
+                    .field(ROLLUP_TYPE, rollup, XCONTENT_WITHOUT_TYPE_AND_USER)
+                    .endObject()
             }
-            .endArray()
-            .endObject()
-    }
+        }
+        .endArray()
+        .endObject()
 }

--- a/src/main/kotlin/org/opensearch/indexmanagement/rollup/action/get/TransportGetRollupAction.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/rollup/action/get/TransportGetRollupAction.kt
@@ -38,7 +38,7 @@ constructor(
     val settings: Settings,
     val clusterService: ClusterService,
     val xContentRegistry: NamedXContentRegistry,
-) : HandledTransportAction<GetRollupRequest, GetRollupResponse> (
+) : HandledTransportAction<GetRollupRequest, GetRollupResponse>(
     GetRollupAction.NAME, transportService, actionFilters, ::GetRollupRequest,
 ) {
     @Volatile private var filterByEnabled = IndexManagementSettings.FILTER_BY_BACKEND_ROLES.get(settings)

--- a/src/main/kotlin/org/opensearch/indexmanagement/rollup/action/get/TransportGetRollupsAction.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/rollup/action/get/TransportGetRollupsAction.kt
@@ -45,7 +45,7 @@ constructor(
     val clusterService: ClusterService,
     val settings: Settings,
     val xContentRegistry: NamedXContentRegistry,
-) : HandledTransportAction<GetRollupsRequest, GetRollupsResponse> (
+) : HandledTransportAction<GetRollupsRequest, GetRollupsResponse>(
     GetRollupsAction.NAME, transportService, actionFilters, ::GetRollupsRequest,
 ) {
     @Volatile private var filterByEnabled = IndexManagementSettings.FILTER_BY_BACKEND_ROLES.get(settings)

--- a/src/main/kotlin/org/opensearch/indexmanagement/rollup/action/index/IndexRollupResponse.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/rollup/action/index/IndexRollupResponse.kt
@@ -21,7 +21,9 @@ import org.opensearch.indexmanagement.util._SEQ_NO
 import org.opensearch.indexmanagement.util._VERSION
 import java.io.IOException
 
-class IndexRollupResponse : ActionResponse, ToXContentObject {
+class IndexRollupResponse :
+    ActionResponse,
+    ToXContentObject {
     var id: String
     var version: Long
     var seqNo: Long
@@ -66,13 +68,11 @@ class IndexRollupResponse : ActionResponse, ToXContentObject {
     }
 
     @Throws(IOException::class)
-    override fun toXContent(builder: XContentBuilder, params: ToXContent.Params): XContentBuilder {
-        return builder.startObject()
-            .field(_ID, id)
-            .field(_VERSION, version)
-            .field(_SEQ_NO, seqNo)
-            .field(_PRIMARY_TERM, primaryTerm)
-            .field(ROLLUP_TYPE, rollup, XCONTENT_WITHOUT_TYPE_AND_USER)
-            .endObject()
-    }
+    override fun toXContent(builder: XContentBuilder, params: ToXContent.Params): XContentBuilder = builder.startObject()
+        .field(_ID, id)
+        .field(_VERSION, version)
+        .field(_SEQ_NO, seqNo)
+        .field(_PRIMARY_TERM, primaryTerm)
+        .field(ROLLUP_TYPE, rollup, XCONTENT_WITHOUT_TYPE_AND_USER)
+        .endObject()
 }

--- a/src/main/kotlin/org/opensearch/indexmanagement/rollup/action/mapping/UpdateRollupMappingRequest.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/rollup/action/mapping/UpdateRollupMappingRequest.kt
@@ -22,9 +22,7 @@ class UpdateRollupMappingRequest : AcknowledgedRequest<UpdateRollupMappingReques
         this.rollup = rollup
     }
 
-    override fun validate(): ActionRequestValidationException? {
-        return null
-    }
+    override fun validate(): ActionRequestValidationException? = null
 
     override fun writeTo(out: StreamOutput) {
         super.writeTo(out)

--- a/src/main/kotlin/org/opensearch/indexmanagement/rollup/actionfilter/FieldCapsFilter.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/rollup/actionfilter/FieldCapsFilter.kt
@@ -359,7 +359,5 @@ class FieldCapsFilter(
         return if (response.isEmpty()) null else response.toTypedArray()
     }
 
-    override fun order(): Int {
-        return Integer.MAX_VALUE
-    }
+    override fun order(): Int = Integer.MAX_VALUE
 }

--- a/src/main/kotlin/org/opensearch/indexmanagement/rollup/model/ExplainRollup.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/rollup/model/ExplainRollup.kt
@@ -16,7 +16,8 @@ import java.io.IOException
 data class ExplainRollup(
     val metadataID: String? = null,
     val metadata: RollupMetadata? = null,
-) : ToXContentObject, Writeable {
+) : ToXContentObject,
+    Writeable {
     @Throws(IOException::class)
     constructor(sin: StreamInput) : this(
         metadataID = sin.readOptionalString(),
@@ -31,10 +32,8 @@ data class ExplainRollup(
     }
 
     @Throws(IOException::class)
-    override fun toXContent(builder: XContentBuilder, params: ToXContent.Params): XContentBuilder {
-        return builder.startObject()
-            .field(Rollup.METADATA_ID_FIELD, metadataID)
-            .field(RollupMetadata.ROLLUP_METADATA_TYPE, metadata)
-            .endObject()
-    }
+    override fun toXContent(builder: XContentBuilder, params: ToXContent.Params): XContentBuilder = builder.startObject()
+        .field(Rollup.METADATA_ID_FIELD, metadataID)
+        .field(RollupMetadata.ROLLUP_METADATA_TYPE, metadata)
+        .endObject()
 }

--- a/src/main/kotlin/org/opensearch/indexmanagement/rollup/model/ISMRollup.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/rollup/model/ISMRollup.kt
@@ -32,7 +32,8 @@ data class ISMRollup(
     val pageSize: Int,
     val dimensions: List<Dimension>,
     val metrics: List<RollupMetrics>,
-) : ToXContentObject, Writeable {
+) : ToXContentObject,
+    Writeable {
     // TODO: This can be moved to a common place, since this is shared between Rollup and ISMRollup
     init {
         require(pageSize in Rollup.MINIMUM_PAGE_SIZE..Rollup.MAXIMUM_PAGE_SIZE) {

--- a/src/main/kotlin/org/opensearch/indexmanagement/rollup/model/Rollup.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/rollup/model/Rollup.kt
@@ -55,7 +55,8 @@ data class Rollup(
     val dimensions: List<Dimension>,
     val metrics: List<RollupMetrics>,
     val user: User? = null,
-) : ScheduledJobParameter, Writeable {
+) : ScheduledJobParameter,
+    Writeable {
     init {
         if (enabled) {
             requireNotNull(jobEnabledTime) { "Job enabled time must be present if the job is enabled" }

--- a/src/main/kotlin/org/opensearch/indexmanagement/rollup/model/RollupFieldMapping.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/rollup/model/RollupFieldMapping.kt
@@ -13,9 +13,7 @@ data class RollupFieldMapping(val fieldType: FieldType, val fieldName: String, v
         this.sourceType = type
     }
 
-    override fun toString(): String {
-        return "$fieldName.$mappingType"
-    }
+    override fun toString(): String = "$fieldName.$mappingType"
 
     fun toIssue(isFieldMissing: Boolean = false): String {
         return if (isFieldMissing || mappingType == UNKNOWN_MAPPING) {
@@ -36,9 +34,7 @@ data class RollupFieldMapping(val fieldType: FieldType, val fieldName: String, v
             METRIC(METRICS_FIELD),
             ;
 
-            override fun toString(): String {
-                return type
-            }
+            override fun toString(): String = type
         }
     }
 }

--- a/src/main/kotlin/org/opensearch/indexmanagement/rollup/model/RollupMetadata.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/rollup/model/RollupMetadata.kt
@@ -27,19 +27,18 @@ import java.util.Locale
 data class ContinuousMetadata(
     val nextWindowStartTime: Instant,
     val nextWindowEndTime: Instant,
-) : ToXContentObject, Writeable {
+) : ToXContentObject,
+    Writeable {
     @Throws(IOException::class)
     constructor(sin: StreamInput) : this(
         nextWindowStartTime = sin.readInstant(),
         nextWindowEndTime = sin.readInstant(),
     )
 
-    override fun toXContent(builder: XContentBuilder, params: ToXContent.Params): XContentBuilder {
-        return builder.startObject()
-            .timeField(NEXT_WINDOW_START_TIME_FIELD, NEXT_WINDOW_START_TIME_FIELD_IN_MILLIS, nextWindowStartTime.toEpochMilli())
-            .timeField(NEXT_WINDOW_END_TIME_FIELD, NEXT_WINDOW_END_TIME_FIELD_IN_MILLIS, nextWindowEndTime.toEpochMilli())
-            .endObject()
-    }
+    override fun toXContent(builder: XContentBuilder, params: ToXContent.Params): XContentBuilder = builder.startObject()
+        .timeField(NEXT_WINDOW_START_TIME_FIELD, NEXT_WINDOW_START_TIME_FIELD_IN_MILLIS, nextWindowStartTime.toEpochMilli())
+        .timeField(NEXT_WINDOW_END_TIME_FIELD, NEXT_WINDOW_END_TIME_FIELD_IN_MILLIS, nextWindowEndTime.toEpochMilli())
+        .endObject()
 
     override fun writeTo(out: StreamOutput) {
         out.writeInstant(nextWindowStartTime)
@@ -84,7 +83,8 @@ data class RollupStats(
     val rollupsIndexed: Long,
     val indexTimeInMillis: Long,
     val searchTimeInMillis: Long,
-) : ToXContentObject, Writeable {
+) : ToXContentObject,
+    Writeable {
     @Throws(IOException::class)
     constructor(sin: StreamInput) : this(
         pagesProcessed = sin.readLong(),
@@ -94,15 +94,13 @@ data class RollupStats(
         searchTimeInMillis = sin.readLong(),
     )
 
-    override fun toXContent(builder: XContentBuilder, params: ToXContent.Params): XContentBuilder {
-        return builder.startObject()
-            .field(PAGES_PROCESSED_FIELD, pagesProcessed)
-            .field(DOCUMENTS_PROCESSED_FIELD, documentsProcessed)
-            .field(ROLLUPS_INDEXED_FIELD, rollupsIndexed)
-            .field(INDEX_TIME_IN_MILLIS_FIELD, indexTimeInMillis)
-            .field(SEARCH_TIME_IN_MILLIS_FIELD, searchTimeInMillis)
-            .endObject()
-    }
+    override fun toXContent(builder: XContentBuilder, params: ToXContent.Params): XContentBuilder = builder.startObject()
+        .field(PAGES_PROCESSED_FIELD, pagesProcessed)
+        .field(DOCUMENTS_PROCESSED_FIELD, documentsProcessed)
+        .field(ROLLUPS_INDEXED_FIELD, rollupsIndexed)
+        .field(INDEX_TIME_IN_MILLIS_FIELD, indexTimeInMillis)
+        .field(SEARCH_TIME_IN_MILLIS_FIELD, searchTimeInMillis)
+        .endObject()
 
     override fun writeTo(out: StreamOutput) {
         out.writeLong(pagesProcessed)
@@ -165,7 +163,8 @@ data class RollupMetadata(
     val status: Status,
     val failureReason: String? = null,
     val stats: RollupStats,
-) : ToXContentObject, Writeable {
+) : ToXContentObject,
+    Writeable {
     enum class Status(val type: String) {
         INIT("init"),
         STARTED("started"),
@@ -175,9 +174,7 @@ data class RollupMetadata(
         RETRY("retry"),
         ;
 
-        override fun toString(): String {
-            return type
-        }
+        override fun toString(): String = type
     }
 
     @Throws(IOException::class)
@@ -289,28 +286,24 @@ data class RollupMetadata(
     }
 }
 
-fun RollupMetadata.incrementStats(response: SearchResponse, internalComposite: InternalComposite): RollupMetadata {
-    return this.copy(
-        stats =
-        this.stats.copy(
-            pagesProcessed = stats.pagesProcessed + 1L,
-            documentsProcessed =
-            stats.documentsProcessed +
-                internalComposite.buckets.fold(0L) { acc, internalBucket -> acc + internalBucket.docCount },
-            searchTimeInMillis = stats.searchTimeInMillis + response.took.millis,
-        ),
-    )
-}
+fun RollupMetadata.incrementStats(response: SearchResponse, internalComposite: InternalComposite): RollupMetadata = this.copy(
+    stats =
+    this.stats.copy(
+        pagesProcessed = stats.pagesProcessed + 1L,
+        documentsProcessed =
+        stats.documentsProcessed +
+            internalComposite.buckets.fold(0L) { acc, internalBucket -> acc + internalBucket.docCount },
+        searchTimeInMillis = stats.searchTimeInMillis + response.took.millis,
+    ),
+)
 
-fun RollupMetadata.mergeStats(stats: RollupStats): RollupMetadata {
-    return this.copy(
-        stats =
-        this.stats.copy(
-            pagesProcessed = this.stats.pagesProcessed + stats.pagesProcessed,
-            documentsProcessed = this.stats.documentsProcessed + stats.documentsProcessed,
-            rollupsIndexed = this.stats.rollupsIndexed + stats.rollupsIndexed,
-            indexTimeInMillis = this.stats.indexTimeInMillis + stats.indexTimeInMillis,
-            searchTimeInMillis = this.stats.searchTimeInMillis + stats.searchTimeInMillis,
-        ),
-    )
-}
+fun RollupMetadata.mergeStats(stats: RollupStats): RollupMetadata = this.copy(
+    stats =
+    this.stats.copy(
+        pagesProcessed = this.stats.pagesProcessed + stats.pagesProcessed,
+        documentsProcessed = this.stats.documentsProcessed + stats.documentsProcessed,
+        rollupsIndexed = this.stats.rollupsIndexed + stats.rollupsIndexed,
+        indexTimeInMillis = this.stats.indexTimeInMillis + stats.indexTimeInMillis,
+        searchTimeInMillis = this.stats.searchTimeInMillis + stats.searchTimeInMillis,
+    ),
+)

--- a/src/main/kotlin/org/opensearch/indexmanagement/rollup/model/RollupMetrics.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/rollup/model/RollupMetrics.kt
@@ -26,7 +26,8 @@ data class RollupMetrics(
     val sourceField: String,
     val targetField: String,
     val metrics: List<Metric>,
-) : ToXContentObject, Writeable {
+) : ToXContentObject,
+    Writeable {
     init {
         require(metrics.size == metrics.distinctBy { it.type }.size) {
             "Cannot have multiple metrics of the same type in a single rollup metric [$metrics]"
@@ -59,12 +60,10 @@ data class RollupMetrics(
         },
     )
 
-    override fun toXContent(builder: XContentBuilder, params: ToXContent.Params): XContentBuilder {
-        return builder.startObject()
-            .field(SOURCE_FIELD_FIELD, sourceField)
-            .field(METRICS_FIELD, metrics.toTypedArray())
-            .endObject()
-    }
+    override fun toXContent(builder: XContentBuilder, params: ToXContent.Params): XContentBuilder = builder.startObject()
+        .field(SOURCE_FIELD_FIELD, sourceField)
+        .field(METRICS_FIELD, metrics.toTypedArray())
+        .endObject()
 
     override fun writeTo(out: StreamOutput) {
         out.writeString(sourceField)
@@ -82,15 +81,13 @@ data class RollupMetrics(
         }
     }
 
-    fun targetFieldWithType(metric: Metric): String {
-        return when (metric) {
-            is Average -> "$targetField.avg"
-            is Sum -> "$targetField.sum"
-            is Max -> "$targetField.max"
-            is Min -> "$targetField.min"
-            is ValueCount -> "$targetField.value_count"
-            else -> throw IllegalArgumentException("Found unsupported metric aggregation ${metric.type.type}")
-        }
+    fun targetFieldWithType(metric: Metric): String = when (metric) {
+        is Average -> "$targetField.avg"
+        is Sum -> "$targetField.sum"
+        is Max -> "$targetField.max"
+        is Min -> "$targetField.min"
+        is ValueCount -> "$targetField.value_count"
+        else -> throw IllegalArgumentException("Found unsupported metric aggregation ${metric.type.type}")
     }
 
     companion object {

--- a/src/main/kotlin/org/opensearch/indexmanagement/rollup/model/metric/Average.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/rollup/model/metric/Average.kt
@@ -17,7 +17,8 @@ class Average() : Metric(Type.AVERAGE) {
     @Suppress("UNUSED_PARAMETER")
     constructor(sin: StreamInput) : this()
 
-    override fun toXContent(builder: XContentBuilder, params: ToXContent.Params): XContentBuilder = builder.startObject().startObject(Type.AVERAGE.type).endObject().endObject()
+    override fun toXContent(builder: XContentBuilder, params: ToXContent.Params): XContentBuilder =
+        builder.startObject().startObject(Type.AVERAGE.type).endObject().endObject()
 
     override fun writeTo(out: StreamOutput) { /* nothing to write */ }
 

--- a/src/main/kotlin/org/opensearch/indexmanagement/rollup/model/metric/Average.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/rollup/model/metric/Average.kt
@@ -17,9 +17,7 @@ class Average() : Metric(Type.AVERAGE) {
     @Suppress("UNUSED_PARAMETER")
     constructor(sin: StreamInput) : this()
 
-    override fun toXContent(builder: XContentBuilder, params: ToXContent.Params): XContentBuilder {
-        return builder.startObject().startObject(Type.AVERAGE.type).endObject().endObject()
-    }
+    override fun toXContent(builder: XContentBuilder, params: ToXContent.Params): XContentBuilder = builder.startObject().startObject(Type.AVERAGE.type).endObject().endObject()
 
     override fun writeTo(out: StreamOutput) { /* nothing to write */ }
 

--- a/src/main/kotlin/org/opensearch/indexmanagement/rollup/model/metric/Max.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/rollup/model/metric/Max.kt
@@ -17,9 +17,7 @@ class Max() : Metric(Type.MAX) {
     @Suppress("UNUSED_PARAMETER")
     constructor(sin: StreamInput) : this()
 
-    override fun toXContent(builder: XContentBuilder, params: ToXContent.Params): XContentBuilder {
-        return builder.startObject().startObject(Type.MAX.type).endObject().endObject()
-    }
+    override fun toXContent(builder: XContentBuilder, params: ToXContent.Params): XContentBuilder = builder.startObject().startObject(Type.MAX.type).endObject().endObject()
 
     override fun writeTo(out: StreamOutput) { /* nothing to write */ }
 

--- a/src/main/kotlin/org/opensearch/indexmanagement/rollup/model/metric/Max.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/rollup/model/metric/Max.kt
@@ -17,7 +17,8 @@ class Max() : Metric(Type.MAX) {
     @Suppress("UNUSED_PARAMETER")
     constructor(sin: StreamInput) : this()
 
-    override fun toXContent(builder: XContentBuilder, params: ToXContent.Params): XContentBuilder = builder.startObject().startObject(Type.MAX.type).endObject().endObject()
+    override fun toXContent(builder: XContentBuilder, params: ToXContent.Params): XContentBuilder =
+        builder.startObject().startObject(Type.MAX.type).endObject().endObject()
 
     override fun writeTo(out: StreamOutput) { /* nothing to write */ }
 

--- a/src/main/kotlin/org/opensearch/indexmanagement/rollup/model/metric/Metric.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/rollup/model/metric/Metric.kt
@@ -12,7 +12,9 @@ import org.opensearch.core.xcontent.XContentParser.Token
 import org.opensearch.core.xcontent.XContentParserUtils.ensureExpectedToken
 import java.io.IOException
 
-abstract class Metric(val type: Type) : ToXContentObject, Writeable {
+abstract class Metric(val type: Type) :
+    ToXContentObject,
+    Writeable {
     enum class Type(val type: String) {
         AVERAGE("avg"),
         SUM("sum"),
@@ -21,9 +23,7 @@ abstract class Metric(val type: Type) : ToXContentObject, Writeable {
         VALUE_COUNT("value_count"),
         ;
 
-        override fun toString(): String {
-            return type
-        }
+        override fun toString(): String = type
     }
 
     companion object {

--- a/src/main/kotlin/org/opensearch/indexmanagement/rollup/model/metric/Min.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/rollup/model/metric/Min.kt
@@ -17,7 +17,8 @@ class Min() : Metric(Type.MIN) {
     @Suppress("UNUSED_PARAMETER")
     constructor(sin: StreamInput) : this()
 
-    override fun toXContent(builder: XContentBuilder, params: ToXContent.Params): XContentBuilder = builder.startObject().startObject(Type.MIN.type).endObject().endObject()
+    override fun toXContent(builder: XContentBuilder, params: ToXContent.Params): XContentBuilder =
+        builder.startObject().startObject(Type.MIN.type).endObject().endObject()
 
     override fun writeTo(out: StreamOutput) { /* nothing to write */ }
 

--- a/src/main/kotlin/org/opensearch/indexmanagement/rollup/model/metric/Min.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/rollup/model/metric/Min.kt
@@ -17,9 +17,7 @@ class Min() : Metric(Type.MIN) {
     @Suppress("UNUSED_PARAMETER")
     constructor(sin: StreamInput) : this()
 
-    override fun toXContent(builder: XContentBuilder, params: ToXContent.Params): XContentBuilder {
-        return builder.startObject().startObject(Type.MIN.type).endObject().endObject()
-    }
+    override fun toXContent(builder: XContentBuilder, params: ToXContent.Params): XContentBuilder = builder.startObject().startObject(Type.MIN.type).endObject().endObject()
 
     override fun writeTo(out: StreamOutput) { /* nothing to write */ }
 

--- a/src/main/kotlin/org/opensearch/indexmanagement/rollup/model/metric/Sum.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/rollup/model/metric/Sum.kt
@@ -17,9 +17,7 @@ class Sum() : Metric(Type.SUM) {
     @Suppress("UNUSED_PARAMETER")
     constructor(sin: StreamInput) : this()
 
-    override fun toXContent(builder: XContentBuilder, params: ToXContent.Params): XContentBuilder {
-        return builder.startObject().startObject(Type.SUM.type).endObject().endObject()
-    }
+    override fun toXContent(builder: XContentBuilder, params: ToXContent.Params): XContentBuilder = builder.startObject().startObject(Type.SUM.type).endObject().endObject()
 
     override fun writeTo(out: StreamOutput) { /* nothing to write */ }
 

--- a/src/main/kotlin/org/opensearch/indexmanagement/rollup/model/metric/Sum.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/rollup/model/metric/Sum.kt
@@ -17,7 +17,8 @@ class Sum() : Metric(Type.SUM) {
     @Suppress("UNUSED_PARAMETER")
     constructor(sin: StreamInput) : this()
 
-    override fun toXContent(builder: XContentBuilder, params: ToXContent.Params): XContentBuilder = builder.startObject().startObject(Type.SUM.type).endObject().endObject()
+    override fun toXContent(builder: XContentBuilder, params: ToXContent.Params): XContentBuilder =
+        builder.startObject().startObject(Type.SUM.type).endObject().endObject()
 
     override fun writeTo(out: StreamOutput) { /* nothing to write */ }
 

--- a/src/main/kotlin/org/opensearch/indexmanagement/rollup/model/metric/ValueCount.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/rollup/model/metric/ValueCount.kt
@@ -17,7 +17,8 @@ class ValueCount() : Metric(Type.VALUE_COUNT) {
     @Suppress("UNUSED_PARAMETER")
     constructor(sin: StreamInput) : this()
 
-    override fun toXContent(builder: XContentBuilder, params: ToXContent.Params): XContentBuilder = builder.startObject().startObject(Type.VALUE_COUNT.type).endObject().endObject()
+    override fun toXContent(builder: XContentBuilder, params: ToXContent.Params): XContentBuilder =
+        builder.startObject().startObject(Type.VALUE_COUNT.type).endObject().endObject()
 
     override fun writeTo(out: StreamOutput) { /* nothing to write */ }
 

--- a/src/main/kotlin/org/opensearch/indexmanagement/rollup/model/metric/ValueCount.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/rollup/model/metric/ValueCount.kt
@@ -17,9 +17,7 @@ class ValueCount() : Metric(Type.VALUE_COUNT) {
     @Suppress("UNUSED_PARAMETER")
     constructor(sin: StreamInput) : this()
 
-    override fun toXContent(builder: XContentBuilder, params: ToXContent.Params): XContentBuilder {
-        return builder.startObject().startObject(Type.VALUE_COUNT.type).endObject().endObject()
-    }
+    override fun toXContent(builder: XContentBuilder, params: ToXContent.Params): XContentBuilder = builder.startObject().startObject(Type.VALUE_COUNT.type).endObject().endObject()
 
     override fun writeTo(out: StreamOutput) { /* nothing to write */ }
 

--- a/src/main/kotlin/org/opensearch/indexmanagement/rollup/resthandler/RestDeleteRollupAction.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/rollup/resthandler/RestDeleteRollupAction.kt
@@ -21,18 +21,14 @@ import org.opensearch.rest.action.RestToXContentListener
 import java.io.IOException
 
 class RestDeleteRollupAction : BaseRestHandler() {
-    override fun routes(): List<Route> {
-        return emptyList()
-    }
+    override fun routes(): List<Route> = emptyList()
 
-    override fun replacedRoutes(): List<ReplacedRoute> {
-        return listOf(
-            ReplacedRoute(
-                DELETE, "$ROLLUP_JOBS_BASE_URI/{rollupID}",
-                DELETE, "$LEGACY_ROLLUP_JOBS_BASE_URI/{rollupID}",
-            ),
-        )
-    }
+    override fun replacedRoutes(): List<ReplacedRoute> = listOf(
+        ReplacedRoute(
+            DELETE, "$ROLLUP_JOBS_BASE_URI/{rollupID}",
+            DELETE, "$LEGACY_ROLLUP_JOBS_BASE_URI/{rollupID}",
+        ),
+    )
 
     override fun getName(): String = "opendistro_delete_rollup_action"
 

--- a/src/main/kotlin/org/opensearch/indexmanagement/rollup/resthandler/RestExplainRollupAction.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/rollup/resthandler/RestExplainRollupAction.kt
@@ -19,18 +19,14 @@ import org.opensearch.rest.RestRequest.Method.GET
 import org.opensearch.rest.action.RestToXContentListener
 
 class RestExplainRollupAction : BaseRestHandler() {
-    override fun routes(): List<Route> {
-        return emptyList()
-    }
+    override fun routes(): List<Route> = emptyList()
 
-    override fun replacedRoutes(): List<ReplacedRoute> {
-        return listOf(
-            ReplacedRoute(
-                GET, "$ROLLUP_JOBS_BASE_URI/{rollupID}/_explain",
-                GET, "$LEGACY_ROLLUP_JOBS_BASE_URI/{rollupID}/_explain",
-            ),
-        )
-    }
+    override fun replacedRoutes(): List<ReplacedRoute> = listOf(
+        ReplacedRoute(
+            GET, "$ROLLUP_JOBS_BASE_URI/{rollupID}/_explain",
+            GET, "$LEGACY_ROLLUP_JOBS_BASE_URI/{rollupID}/_explain",
+        ),
+    )
 
     override fun getName(): String = "opendistro_explain_rollup_action"
 

--- a/src/main/kotlin/org/opensearch/indexmanagement/rollup/resthandler/RestGetRollupAction.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/rollup/resthandler/RestGetRollupAction.kt
@@ -27,30 +27,24 @@ import org.opensearch.rest.action.RestToXContentListener
 import org.opensearch.search.fetch.subphase.FetchSourceContext
 
 class RestGetRollupAction : BaseRestHandler() {
-    override fun routes(): List<Route> {
-        return emptyList()
-    }
+    override fun routes(): List<Route> = emptyList()
 
-    override fun replacedRoutes(): List<ReplacedRoute> {
-        return listOf(
-            ReplacedRoute(
-                GET, ROLLUP_JOBS_BASE_URI,
-                GET, LEGACY_ROLLUP_JOBS_BASE_URI,
-            ),
-            ReplacedRoute(
-                GET, "$ROLLUP_JOBS_BASE_URI/{rollupID}",
-                GET, "$LEGACY_ROLLUP_JOBS_BASE_URI/{rollupID}",
-            ),
-            ReplacedRoute(
-                HEAD, "$ROLLUP_JOBS_BASE_URI/{rollupID}",
-                HEAD, "$LEGACY_ROLLUP_JOBS_BASE_URI/{rollupID}",
-            ),
-        )
-    }
+    override fun replacedRoutes(): List<ReplacedRoute> = listOf(
+        ReplacedRoute(
+            GET, ROLLUP_JOBS_BASE_URI,
+            GET, LEGACY_ROLLUP_JOBS_BASE_URI,
+        ),
+        ReplacedRoute(
+            GET, "$ROLLUP_JOBS_BASE_URI/{rollupID}",
+            GET, "$LEGACY_ROLLUP_JOBS_BASE_URI/{rollupID}",
+        ),
+        ReplacedRoute(
+            HEAD, "$ROLLUP_JOBS_BASE_URI/{rollupID}",
+            HEAD, "$LEGACY_ROLLUP_JOBS_BASE_URI/{rollupID}",
+        ),
+    )
 
-    override fun getName(): String {
-        return "opendistro_get_rollup_action"
-    }
+    override fun getName(): String = "opendistro_get_rollup_action"
 
     override fun prepareRequest(request: RestRequest, client: NodeClient): RestChannelConsumer {
         val rollupID = request.param("rollupID")

--- a/src/main/kotlin/org/opensearch/indexmanagement/rollup/resthandler/RestIndexRollupAction.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/rollup/resthandler/RestIndexRollupAction.kt
@@ -35,26 +35,20 @@ import java.io.IOException
 import java.time.Instant
 
 class RestIndexRollupAction : BaseRestHandler() {
-    override fun routes(): List<Route> {
-        return emptyList()
-    }
+    override fun routes(): List<Route> = emptyList()
 
-    override fun replacedRoutes(): List<ReplacedRoute> {
-        return listOf(
-            ReplacedRoute(
-                PUT, ROLLUP_JOBS_BASE_URI,
-                PUT, LEGACY_ROLLUP_JOBS_BASE_URI,
-            ),
-            ReplacedRoute(
-                PUT, "$ROLLUP_JOBS_BASE_URI/{rollupID}",
-                PUT, "$LEGACY_ROLLUP_JOBS_BASE_URI/{rollupID}",
-            ),
-        )
-    }
+    override fun replacedRoutes(): List<ReplacedRoute> = listOf(
+        ReplacedRoute(
+            PUT, ROLLUP_JOBS_BASE_URI,
+            PUT, LEGACY_ROLLUP_JOBS_BASE_URI,
+        ),
+        ReplacedRoute(
+            PUT, "$ROLLUP_JOBS_BASE_URI/{rollupID}",
+            PUT, "$LEGACY_ROLLUP_JOBS_BASE_URI/{rollupID}",
+        ),
+    )
 
-    override fun getName(): String {
-        return "opendistro_index_rollup_action"
-    }
+    override fun getName(): String = "opendistro_index_rollup_action"
 
     @Throws(IOException::class)
     override fun prepareRequest(request: RestRequest, client: NodeClient): RestChannelConsumer {

--- a/src/main/kotlin/org/opensearch/indexmanagement/rollup/resthandler/RestStartRollupAction.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/rollup/resthandler/RestStartRollupAction.kt
@@ -21,22 +21,16 @@ import org.opensearch.rest.action.RestToXContentListener
 import java.io.IOException
 
 class RestStartRollupAction : BaseRestHandler() {
-    override fun routes(): List<Route> {
-        return emptyList()
-    }
+    override fun routes(): List<Route> = emptyList()
 
-    override fun replacedRoutes(): List<ReplacedRoute> {
-        return listOf(
-            ReplacedRoute(
-                POST, "$ROLLUP_JOBS_BASE_URI/{rollupID}/_start",
-                POST, "$LEGACY_ROLLUP_JOBS_BASE_URI/{rollupID}/_start",
-            ),
-        )
-    }
+    override fun replacedRoutes(): List<ReplacedRoute> = listOf(
+        ReplacedRoute(
+            POST, "$ROLLUP_JOBS_BASE_URI/{rollupID}/_start",
+            POST, "$LEGACY_ROLLUP_JOBS_BASE_URI/{rollupID}/_start",
+        ),
+    )
 
-    override fun getName(): String {
-        return "opendistro_start_rollup_action"
-    }
+    override fun getName(): String = "opendistro_start_rollup_action"
 
     @Throws(IOException::class)
     override fun prepareRequest(request: RestRequest, client: NodeClient): RestChannelConsumer {

--- a/src/main/kotlin/org/opensearch/indexmanagement/rollup/resthandler/RestStopRollupAction.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/rollup/resthandler/RestStopRollupAction.kt
@@ -21,22 +21,16 @@ import org.opensearch.rest.action.RestToXContentListener
 import java.io.IOException
 
 class RestStopRollupAction : BaseRestHandler() {
-    override fun routes(): List<Route> {
-        return emptyList()
-    }
+    override fun routes(): List<Route> = emptyList()
 
-    override fun replacedRoutes(): List<ReplacedRoute> {
-        return listOf(
-            ReplacedRoute(
-                POST, "$ROLLUP_JOBS_BASE_URI/{rollupID}/_stop",
-                POST, "$LEGACY_ROLLUP_JOBS_BASE_URI/{rollupID}/_stop",
-            ),
-        )
-    }
+    override fun replacedRoutes(): List<ReplacedRoute> = listOf(
+        ReplacedRoute(
+            POST, "$ROLLUP_JOBS_BASE_URI/{rollupID}/_stop",
+            POST, "$LEGACY_ROLLUP_JOBS_BASE_URI/{rollupID}/_stop",
+        ),
+    )
 
-    override fun getName(): String {
-        return "opendistro_stop_rollup_action"
-    }
+    override fun getName(): String = "opendistro_stop_rollup_action"
 
     @Throws(IOException::class)
     override fun prepareRequest(request: RestRequest, client: NodeClient): RestChannelConsumer {

--- a/src/main/kotlin/org/opensearch/indexmanagement/rollup/util/RollupFieldValueExpressionResolver.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/rollup/util/RollupFieldValueExpressionResolver.kt
@@ -65,16 +65,10 @@ object RollupFieldValueExpressionResolver {
             return false
         }
 
-        open fun isAlias(index: String): Boolean {
-            return this.clusterService.state().metadata().indicesLookup?.get(index) is IndexAbstraction.Alias
-        }
+        open fun isAlias(index: String): Boolean = this.clusterService.state().metadata().indicesLookup?.get(index) is IndexAbstraction.Alias
 
-        open fun getWriteIndexNameForAlias(alias: String): String? {
-            return this.clusterService.state().metadata().indicesLookup?.get(alias)?.writeIndex?.index?.name
-        }
+        open fun getWriteIndexNameForAlias(alias: String): String? = this.clusterService.state().metadata().indicesLookup?.get(alias)?.writeIndex?.index?.name
 
-        open fun getBackingIndicesForAlias(alias: String): MutableList<IndexMetadata>? {
-            return this.clusterService.state().metadata().indicesLookup?.get(alias)?.indices
-        }
+        open fun getBackingIndicesForAlias(alias: String): MutableList<IndexMetadata>? = this.clusterService.state().metadata().indicesLookup?.get(alias)?.indices
     }
 }

--- a/src/main/kotlin/org/opensearch/indexmanagement/rollup/util/RollupFieldValueExpressionResolver.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/rollup/util/RollupFieldValueExpressionResolver.kt
@@ -69,6 +69,7 @@ object RollupFieldValueExpressionResolver {
 
         open fun getWriteIndexNameForAlias(alias: String): String? = this.clusterService.state().metadata().indicesLookup?.get(alias)?.writeIndex?.index?.name
 
-        open fun getBackingIndicesForAlias(alias: String): MutableList<IndexMetadata>? = this.clusterService.state().metadata().indicesLookup?.get(alias)?.indices
+        open fun getBackingIndicesForAlias(alias: String): MutableList<IndexMetadata>? =
+            this.clusterService.state().metadata().indicesLookup?.get(alias)?.indices
     }
 }

--- a/src/main/kotlin/org/opensearch/indexmanagement/rollup/util/RollupUtils.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/rollup/util/RollupUtils.kt
@@ -79,9 +79,7 @@ fun isRollupIndex(index: String, clusterState: ClusterState): Boolean {
     return false
 }
 
-fun Rollup.isTargetIndexAlias(): Boolean {
-    return RollupFieldValueExpressionResolver.indexAliasUtils.isAlias(targetIndex)
-}
+fun Rollup.isTargetIndexAlias(): Boolean = RollupFieldValueExpressionResolver.indexAliasUtils.isAlias(targetIndex)
 
 fun Rollup.getRollupSearchRequest(metadata: RollupMetadata): SearchRequest {
     val query =
@@ -300,91 +298,89 @@ fun Rollup.rewriteQueryBuilder(
     queryBuilder: QueryBuilder,
     fieldNameMappingTypeMap: Map<String, String>,
     concreteIndexName: String = "",
-): QueryBuilder {
-    return when (queryBuilder) {
-        is TermQueryBuilder -> {
-            val updatedFieldName = queryBuilder.fieldName() + "." + Dimension.Type.TERMS.type
-            val updatedTermQueryBuilder = TermQueryBuilder(updatedFieldName, queryBuilder.value())
-            updatedTermQueryBuilder.boost(queryBuilder.boost())
-            updatedTermQueryBuilder.queryName(queryBuilder.queryName())
-        }
-        is TermsQueryBuilder -> {
-            val updatedFieldName = queryBuilder.fieldName() + "." + Dimension.Type.TERMS.type
-            val updatedTermsQueryBuilder = TermsQueryBuilder(updatedFieldName, queryBuilder.values())
-            updatedTermsQueryBuilder.boost(queryBuilder.boost())
-            updatedTermsQueryBuilder.queryName(queryBuilder.queryName())
-        }
-        is RangeQueryBuilder -> {
-            val updatedFieldName = queryBuilder.fieldName() + "." + fieldNameMappingTypeMap.getValue(queryBuilder.fieldName())
-            val updatedRangeQueryBuilder = RangeQueryBuilder(updatedFieldName)
-            updatedRangeQueryBuilder.includeLower(queryBuilder.includeLower())
-            updatedRangeQueryBuilder.includeUpper(queryBuilder.includeUpper())
-            updatedRangeQueryBuilder.from(queryBuilder.from())
-            updatedRangeQueryBuilder.to(queryBuilder.to())
-            if (queryBuilder.timeZone() != null) updatedRangeQueryBuilder.timeZone(queryBuilder.timeZone())
-            if (queryBuilder.format() != null) updatedRangeQueryBuilder.format(queryBuilder.format())
-            if (queryBuilder.relation()?.relationName != null) updatedRangeQueryBuilder.relation(queryBuilder.relation().relationName)
-            updatedRangeQueryBuilder.queryName(queryBuilder.queryName())
-            updatedRangeQueryBuilder.boost(queryBuilder.boost())
-        }
-        is BoolQueryBuilder -> {
-            val newBoolQueryBuilder = BoolQueryBuilder()
-            queryBuilder.must()?.forEach {
-                val newMustQueryBuilder = this.rewriteQueryBuilder(it, fieldNameMappingTypeMap, concreteIndexName)
-                newBoolQueryBuilder.must(newMustQueryBuilder)
-            }
-            queryBuilder.mustNot()?.forEach {
-                val newMustNotQueryBuilder = this.rewriteQueryBuilder(it, fieldNameMappingTypeMap, concreteIndexName)
-                newBoolQueryBuilder.mustNot(newMustNotQueryBuilder)
-            }
-            queryBuilder.should()?.forEach {
-                val newShouldQueryBuilder = this.rewriteQueryBuilder(it, fieldNameMappingTypeMap, concreteIndexName)
-                newBoolQueryBuilder.should(newShouldQueryBuilder)
-            }
-            queryBuilder.filter()?.forEach {
-                val newFilterQueryBuilder = this.rewriteQueryBuilder(it, fieldNameMappingTypeMap, concreteIndexName)
-                newBoolQueryBuilder.filter(newFilterQueryBuilder)
-            }
-            newBoolQueryBuilder.minimumShouldMatch(queryBuilder.minimumShouldMatch())
-            newBoolQueryBuilder.adjustPureNegative(queryBuilder.adjustPureNegative())
-            newBoolQueryBuilder.queryName(queryBuilder.queryName())
-            newBoolQueryBuilder.boost(queryBuilder.boost())
-        }
-        is BoostingQueryBuilder -> {
-            val newPositiveQueryBuilder = this.rewriteQueryBuilder(queryBuilder.positiveQuery(), fieldNameMappingTypeMap, concreteIndexName)
-            val newNegativeQueryBuilder = this.rewriteQueryBuilder(queryBuilder.negativeQuery(), fieldNameMappingTypeMap, concreteIndexName)
-            val newBoostingQueryBuilder = BoostingQueryBuilder(newPositiveQueryBuilder, newNegativeQueryBuilder)
-            if (queryBuilder.negativeBoost() >= 0) newBoostingQueryBuilder.negativeBoost(queryBuilder.negativeBoost())
-            newBoostingQueryBuilder.queryName(queryBuilder.queryName())
-            newBoostingQueryBuilder.boost(queryBuilder.boost())
-        }
-        is ConstantScoreQueryBuilder -> {
-            val newInnerQueryBuilder = this.rewriteQueryBuilder(queryBuilder.innerQuery(), fieldNameMappingTypeMap, concreteIndexName)
-            val newConstantScoreQueryBuilder = ConstantScoreQueryBuilder(newInnerQueryBuilder)
-            newConstantScoreQueryBuilder.boost(queryBuilder.boost())
-            newConstantScoreQueryBuilder.queryName(queryBuilder.queryName())
-        }
-        is DisMaxQueryBuilder -> {
-            val newDisMaxQueryBuilder = DisMaxQueryBuilder()
-            queryBuilder.innerQueries().forEach {
-                newDisMaxQueryBuilder.add(this.rewriteQueryBuilder(it, fieldNameMappingTypeMap, concreteIndexName))
-            }
-            newDisMaxQueryBuilder.tieBreaker(queryBuilder.tieBreaker())
-            newDisMaxQueryBuilder.queryName(queryBuilder.queryName())
-            newDisMaxQueryBuilder.boost(queryBuilder.boost())
-        }
-        is MatchPhraseQueryBuilder -> {
-            val newFieldName = queryBuilder.fieldName() + "." + Dimension.Type.TERMS.type
-            val newMatchPhraseQueryBuilder = MatchPhraseQueryBuilder(newFieldName, queryBuilder.value())
-            newMatchPhraseQueryBuilder.queryName(queryBuilder.queryName())
-            newMatchPhraseQueryBuilder.boost(queryBuilder.boost())
-        }
-        is QueryStringQueryBuilder -> {
-            QueryStringQueryUtil.rewriteQueryStringQuery(queryBuilder, concreteIndexName)
-        }
-        // We do nothing otherwise, the validation logic should have already verified so not throwing an exception
-        else -> queryBuilder
+): QueryBuilder = when (queryBuilder) {
+    is TermQueryBuilder -> {
+        val updatedFieldName = queryBuilder.fieldName() + "." + Dimension.Type.TERMS.type
+        val updatedTermQueryBuilder = TermQueryBuilder(updatedFieldName, queryBuilder.value())
+        updatedTermQueryBuilder.boost(queryBuilder.boost())
+        updatedTermQueryBuilder.queryName(queryBuilder.queryName())
     }
+    is TermsQueryBuilder -> {
+        val updatedFieldName = queryBuilder.fieldName() + "." + Dimension.Type.TERMS.type
+        val updatedTermsQueryBuilder = TermsQueryBuilder(updatedFieldName, queryBuilder.values())
+        updatedTermsQueryBuilder.boost(queryBuilder.boost())
+        updatedTermsQueryBuilder.queryName(queryBuilder.queryName())
+    }
+    is RangeQueryBuilder -> {
+        val updatedFieldName = queryBuilder.fieldName() + "." + fieldNameMappingTypeMap.getValue(queryBuilder.fieldName())
+        val updatedRangeQueryBuilder = RangeQueryBuilder(updatedFieldName)
+        updatedRangeQueryBuilder.includeLower(queryBuilder.includeLower())
+        updatedRangeQueryBuilder.includeUpper(queryBuilder.includeUpper())
+        updatedRangeQueryBuilder.from(queryBuilder.from())
+        updatedRangeQueryBuilder.to(queryBuilder.to())
+        if (queryBuilder.timeZone() != null) updatedRangeQueryBuilder.timeZone(queryBuilder.timeZone())
+        if (queryBuilder.format() != null) updatedRangeQueryBuilder.format(queryBuilder.format())
+        if (queryBuilder.relation()?.relationName != null) updatedRangeQueryBuilder.relation(queryBuilder.relation().relationName)
+        updatedRangeQueryBuilder.queryName(queryBuilder.queryName())
+        updatedRangeQueryBuilder.boost(queryBuilder.boost())
+    }
+    is BoolQueryBuilder -> {
+        val newBoolQueryBuilder = BoolQueryBuilder()
+        queryBuilder.must()?.forEach {
+            val newMustQueryBuilder = this.rewriteQueryBuilder(it, fieldNameMappingTypeMap, concreteIndexName)
+            newBoolQueryBuilder.must(newMustQueryBuilder)
+        }
+        queryBuilder.mustNot()?.forEach {
+            val newMustNotQueryBuilder = this.rewriteQueryBuilder(it, fieldNameMappingTypeMap, concreteIndexName)
+            newBoolQueryBuilder.mustNot(newMustNotQueryBuilder)
+        }
+        queryBuilder.should()?.forEach {
+            val newShouldQueryBuilder = this.rewriteQueryBuilder(it, fieldNameMappingTypeMap, concreteIndexName)
+            newBoolQueryBuilder.should(newShouldQueryBuilder)
+        }
+        queryBuilder.filter()?.forEach {
+            val newFilterQueryBuilder = this.rewriteQueryBuilder(it, fieldNameMappingTypeMap, concreteIndexName)
+            newBoolQueryBuilder.filter(newFilterQueryBuilder)
+        }
+        newBoolQueryBuilder.minimumShouldMatch(queryBuilder.minimumShouldMatch())
+        newBoolQueryBuilder.adjustPureNegative(queryBuilder.adjustPureNegative())
+        newBoolQueryBuilder.queryName(queryBuilder.queryName())
+        newBoolQueryBuilder.boost(queryBuilder.boost())
+    }
+    is BoostingQueryBuilder -> {
+        val newPositiveQueryBuilder = this.rewriteQueryBuilder(queryBuilder.positiveQuery(), fieldNameMappingTypeMap, concreteIndexName)
+        val newNegativeQueryBuilder = this.rewriteQueryBuilder(queryBuilder.negativeQuery(), fieldNameMappingTypeMap, concreteIndexName)
+        val newBoostingQueryBuilder = BoostingQueryBuilder(newPositiveQueryBuilder, newNegativeQueryBuilder)
+        if (queryBuilder.negativeBoost() >= 0) newBoostingQueryBuilder.negativeBoost(queryBuilder.negativeBoost())
+        newBoostingQueryBuilder.queryName(queryBuilder.queryName())
+        newBoostingQueryBuilder.boost(queryBuilder.boost())
+    }
+    is ConstantScoreQueryBuilder -> {
+        val newInnerQueryBuilder = this.rewriteQueryBuilder(queryBuilder.innerQuery(), fieldNameMappingTypeMap, concreteIndexName)
+        val newConstantScoreQueryBuilder = ConstantScoreQueryBuilder(newInnerQueryBuilder)
+        newConstantScoreQueryBuilder.boost(queryBuilder.boost())
+        newConstantScoreQueryBuilder.queryName(queryBuilder.queryName())
+    }
+    is DisMaxQueryBuilder -> {
+        val newDisMaxQueryBuilder = DisMaxQueryBuilder()
+        queryBuilder.innerQueries().forEach {
+            newDisMaxQueryBuilder.add(this.rewriteQueryBuilder(it, fieldNameMappingTypeMap, concreteIndexName))
+        }
+        newDisMaxQueryBuilder.tieBreaker(queryBuilder.tieBreaker())
+        newDisMaxQueryBuilder.queryName(queryBuilder.queryName())
+        newDisMaxQueryBuilder.boost(queryBuilder.boost())
+    }
+    is MatchPhraseQueryBuilder -> {
+        val newFieldName = queryBuilder.fieldName() + "." + Dimension.Type.TERMS.type
+        val newMatchPhraseQueryBuilder = MatchPhraseQueryBuilder(newFieldName, queryBuilder.value())
+        newMatchPhraseQueryBuilder.queryName(queryBuilder.queryName())
+        newMatchPhraseQueryBuilder.boost(queryBuilder.boost())
+    }
+    is QueryStringQueryBuilder -> {
+        QueryStringQueryUtil.rewriteQueryStringQuery(queryBuilder, concreteIndexName)
+    }
+    // We do nothing otherwise, the validation logic should have already verified so not throwing an exception
+    else -> queryBuilder
 }
 
 fun Set<Rollup>.buildRollupQuery(fieldNameMappingTypeMap: Map<String, String>, oldQuery: QueryBuilder, targetIndexName: String = ""): QueryBuilder {
@@ -453,9 +449,7 @@ fun SearchSourceBuilder.rewriteSearchSourceBuilder(
     job: Rollup,
     fieldNameMappingTypeMap: Map<String, String>,
     concreteIndexName: String,
-): SearchSourceBuilder {
-    return this.rewriteSearchSourceBuilder(setOf(job), fieldNameMappingTypeMap, concreteIndexName)
-}
+): SearchSourceBuilder = this.rewriteSearchSourceBuilder(setOf(job), fieldNameMappingTypeMap, concreteIndexName)
 
 fun Rollup.getInitialDocValues(docCount: Long): MutableMap<String, Any?> =
     mutableMapOf(

--- a/src/main/kotlin/org/opensearch/indexmanagement/snapshotmanagement/SMUtils.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/snapshotmanagement/SMUtils.kt
@@ -178,16 +178,14 @@ fun generateFormatDate(dateFormat: String, timezone: ZoneId = ZoneId.of("UTC")):
     return dateFormatter.format(now())
 }
 
-fun validateDateFormat(dateFormat: String): String? {
-    return try {
-        val timeZone = ZoneId.systemDefault()
-        val dateFormatter = DateFormatter.forPattern(dateFormat).withZone(timeZone)
-        val instant = dateFormatter.toDateMathParser().parse("now/s", System::currentTimeMillis, false, timeZone)
-        dateFormatter.format(instant)
-        null
-    } catch (e: Exception) {
-        e.message ?: "Invalid date format."
-    }
+fun validateDateFormat(dateFormat: String): String? = try {
+    val timeZone = ZoneId.systemDefault()
+    val dateFormatter = DateFormatter.forPattern(dateFormat).withZone(timeZone)
+    val instant = dateFormatter.toDateMathParser().parse("now/s", System::currentTimeMillis, false, timeZone)
+    dateFormatter.format(instant)
+    null
+} catch (e: Exception) {
+    e.message ?: "Invalid date format."
 }
 
 fun preFixTimeStamp(msg: String?): String {
@@ -208,9 +206,7 @@ fun addSMPolicyInSnapshotMetadata(snapshotConfig: Map<String, Any>, policyName: 
     return snapshotConfigWithSMPolicyMetadata
 }
 
-fun List<SnapshotInfo>.filterBySMPolicyInSnapshotMetadata(policyName: String): List<SnapshotInfo> {
-    return filter { it.userMetadata()?.get(SM_TYPE) == policyName }
-}
+fun List<SnapshotInfo>.filterBySMPolicyInSnapshotMetadata(policyName: String): List<SnapshotInfo> = filter { it.userMetadata()?.get(SM_TYPE) == policyName }
 
 /**
  * Get snapshots

--- a/src/main/kotlin/org/opensearch/indexmanagement/snapshotmanagement/api/resthandler/RestCreateSMPolicyHandler.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/snapshotmanagement/api/resthandler/RestCreateSMPolicyHandler.kt
@@ -11,15 +11,11 @@ import org.opensearch.rest.RestHandler.Route
 import org.opensearch.rest.RestRequest
 
 class RestCreateSMPolicyHandler : RestBaseIndexSMPolicyHandler() {
-    override fun getName(): String {
-        return "snapshot_management_create_policy_rest_handler"
-    }
+    override fun getName(): String = "snapshot_management_create_policy_rest_handler"
 
-    override fun routes(): List<Route> {
-        return listOf(
-            Route(RestRequest.Method.POST, "$SM_POLICIES_URI/{policyName}"),
-        )
-    }
+    override fun routes(): List<Route> = listOf(
+        Route(RestRequest.Method.POST, "$SM_POLICIES_URI/{policyName}"),
+    )
 
     override fun prepareRequest(request: RestRequest, client: NodeClient): RestChannelConsumer = prepareIndexRequest(request, client, true)
 }

--- a/src/main/kotlin/org/opensearch/indexmanagement/snapshotmanagement/api/resthandler/RestDeleteSMPolicyHandler.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/snapshotmanagement/api/resthandler/RestDeleteSMPolicyHandler.kt
@@ -18,15 +18,11 @@ import org.opensearch.rest.RestRequest
 import org.opensearch.rest.action.RestToXContentListener
 
 class RestDeleteSMPolicyHandler : BaseRestHandler() {
-    override fun getName(): String {
-        return "snapshot_management_delete_policy_rest_handler"
-    }
+    override fun getName(): String = "snapshot_management_delete_policy_rest_handler"
 
-    override fun routes(): List<Route> {
-        return listOf(
-            Route(RestRequest.Method.DELETE, "$SM_POLICIES_URI/{policyName}"),
-        )
-    }
+    override fun routes(): List<Route> = listOf(
+        Route(RestRequest.Method.DELETE, "$SM_POLICIES_URI/{policyName}"),
+    )
 
     override fun prepareRequest(request: RestRequest, client: NodeClient): RestChannelConsumer {
         val policyName = request.param("policyName", "")

--- a/src/main/kotlin/org/opensearch/indexmanagement/snapshotmanagement/api/resthandler/RestExplainSMPolicyHandler.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/snapshotmanagement/api/resthandler/RestExplainSMPolicyHandler.kt
@@ -20,15 +20,11 @@ import org.opensearch.rest.action.RestToXContentListener
 class RestExplainSMPolicyHandler : BaseRestHandler() {
     private val log = LogManager.getLogger(RestExplainSMPolicyHandler::class.java)
 
-    override fun getName(): String {
-        return "snapshot_management_explain_policy_rest_handler"
-    }
+    override fun getName(): String = "snapshot_management_explain_policy_rest_handler"
 
-    override fun routes(): List<Route> {
-        return listOf(
-            Route(GET, "$SM_POLICIES_URI/{policyName}/_explain"),
-        )
-    }
+    override fun routes(): List<Route> = listOf(
+        Route(GET, "$SM_POLICIES_URI/{policyName}/_explain"),
+    )
 
     override fun prepareRequest(request: RestRequest, client: NodeClient): RestChannelConsumer {
         var policyNames: Array<String> = Strings.splitStringByCommaToArray(request.param("policyName", ""))

--- a/src/main/kotlin/org/opensearch/indexmanagement/snapshotmanagement/api/resthandler/RestGetSMPolicyHandler.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/snapshotmanagement/api/resthandler/RestGetSMPolicyHandler.kt
@@ -21,16 +21,12 @@ import org.opensearch.rest.RestRequest.Method.GET
 import org.opensearch.rest.action.RestToXContentListener
 
 class RestGetSMPolicyHandler : BaseRestHandler() {
-    override fun getName(): String {
-        return "snapshot_management_get_policy_rest_handler"
-    }
+    override fun getName(): String = "snapshot_management_get_policy_rest_handler"
 
-    override fun routes(): List<Route> {
-        return listOf(
-            Route(GET, "$SM_POLICIES_URI/{policyName}"),
-            Route(GET, "$SM_POLICIES_URI/"),
-        )
-    }
+    override fun routes(): List<Route> = listOf(
+        Route(GET, "$SM_POLICIES_URI/{policyName}"),
+        Route(GET, "$SM_POLICIES_URI/"),
+    )
 
     override fun prepareRequest(request: RestRequest, client: NodeClient): RestChannelConsumer {
         val policyName = request.param("policyName", "")
@@ -41,10 +37,8 @@ class RestGetSMPolicyHandler : BaseRestHandler() {
         }
     }
 
-    private fun getSMPolicyByName(client: NodeClient, policyName: String): RestChannelConsumer {
-        return RestChannelConsumer {
-            client.execute(GET_SM_POLICY_ACTION_TYPE, GetSMPolicyRequest(smPolicyNameToDocId(policyName)), RestToXContentListener(it))
-        }
+    private fun getSMPolicyByName(client: NodeClient, policyName: String): RestChannelConsumer = RestChannelConsumer {
+        client.execute(GET_SM_POLICY_ACTION_TYPE, GetSMPolicyRequest(smPolicyNameToDocId(policyName)), RestToXContentListener(it))
     }
 
     private fun getAllPolicies(request: RestRequest, client: NodeClient): RestChannelConsumer {

--- a/src/main/kotlin/org/opensearch/indexmanagement/snapshotmanagement/api/resthandler/RestStartSMPolicyHandler.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/snapshotmanagement/api/resthandler/RestStartSMPolicyHandler.kt
@@ -20,15 +20,11 @@ import org.opensearch.rest.action.RestToXContentListener
 class RestStartSMPolicyHandler : BaseRestHandler() {
     private val log = LogManager.getLogger(RestStartSMPolicyHandler::class.java)
 
-    override fun getName(): String {
-        return "snapshot_management_start_policy_rest_handler"
-    }
+    override fun getName(): String = "snapshot_management_start_policy_rest_handler"
 
-    override fun routes(): List<Route> {
-        return listOf(
-            Route(RestRequest.Method.POST, "$SM_POLICIES_URI/{policyName}/_start"),
-        )
-    }
+    override fun routes(): List<Route> = listOf(
+        Route(RestRequest.Method.POST, "$SM_POLICIES_URI/{policyName}/_start"),
+    )
 
     override fun prepareRequest(request: RestRequest, client: NodeClient): RestChannelConsumer {
         val policyName = request.getValidSMPolicyName()

--- a/src/main/kotlin/org/opensearch/indexmanagement/snapshotmanagement/api/resthandler/RestStopSMPolicyHandler.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/snapshotmanagement/api/resthandler/RestStopSMPolicyHandler.kt
@@ -20,15 +20,11 @@ import org.opensearch.rest.action.RestToXContentListener
 class RestStopSMPolicyHandler : BaseRestHandler() {
     private val log = LogManager.getLogger(RestStopSMPolicyHandler::class.java)
 
-    override fun getName(): String {
-        return "snapshot_management_stop_policy_rest_handler"
-    }
+    override fun getName(): String = "snapshot_management_stop_policy_rest_handler"
 
-    override fun routes(): List<Route> {
-        return listOf(
-            Route(RestRequest.Method.POST, "$SM_POLICIES_URI/{policyName}/_stop"),
-        )
-    }
+    override fun routes(): List<Route> = listOf(
+        Route(RestRequest.Method.POST, "$SM_POLICIES_URI/{policyName}/_stop"),
+    )
 
     override fun prepareRequest(request: RestRequest, client: NodeClient): RestChannelConsumer {
         val policyName = request.getValidSMPolicyName()

--- a/src/main/kotlin/org/opensearch/indexmanagement/snapshotmanagement/api/resthandler/RestUpdateSMPolicyHandler.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/snapshotmanagement/api/resthandler/RestUpdateSMPolicyHandler.kt
@@ -11,15 +11,11 @@ import org.opensearch.rest.RestHandler.Route
 import org.opensearch.rest.RestRequest
 
 class RestUpdateSMPolicyHandler : RestBaseIndexSMPolicyHandler() {
-    override fun getName(): String {
-        return "snapshot_management_update_policy_rest_handler"
-    }
+    override fun getName(): String = "snapshot_management_update_policy_rest_handler"
 
-    override fun routes(): List<Route> {
-        return listOf(
-            Route(RestRequest.Method.PUT, "$SM_POLICIES_URI/{policyName}"),
-        )
-    }
+    override fun routes(): List<Route> = listOf(
+        Route(RestRequest.Method.PUT, "$SM_POLICIES_URI/{policyName}"),
+    )
 
     override fun prepareRequest(request: RestRequest, client: NodeClient): RestChannelConsumer = prepareIndexRequest(request, client, false)
 }

--- a/src/main/kotlin/org/opensearch/indexmanagement/snapshotmanagement/api/transport/delete/DeleteSMPolicyRequest.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/snapshotmanagement/api/transport/delete/DeleteSMPolicyRequest.kt
@@ -11,9 +11,7 @@ import org.opensearch.core.common.io.stream.StreamInput
 import org.opensearch.core.common.io.stream.StreamOutput
 
 class DeleteSMPolicyRequest : DeleteRequest {
-    override fun validate(): ActionRequestValidationException? {
-        return null
-    }
+    override fun validate(): ActionRequestValidationException? = null
 
     constructor(sin: StreamInput) : super(sin)
 

--- a/src/main/kotlin/org/opensearch/indexmanagement/snapshotmanagement/api/transport/explain/ExplainSMPolicyRequest.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/snapshotmanagement/api/transport/explain/ExplainSMPolicyRequest.kt
@@ -13,9 +13,7 @@ import org.opensearch.core.common.io.stream.StreamOutput
 class ExplainSMPolicyRequest(
     val policyNames: Array<String>,
 ) : ActionRequest() {
-    override fun validate(): ActionRequestValidationException? {
-        return null
-    }
+    override fun validate(): ActionRequestValidationException? = null
 
     constructor(sin: StreamInput) : this(policyNames = sin.readStringArray())
 

--- a/src/main/kotlin/org/opensearch/indexmanagement/snapshotmanagement/api/transport/explain/ExplainSMPolicyResponse.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/snapshotmanagement/api/transport/explain/ExplainSMPolicyResponse.kt
@@ -16,16 +16,16 @@ import org.opensearch.indexmanagement.snapshotmanagement.model.ExplainSMPolicy
 import org.opensearch.indexmanagement.snapshotmanagement.model.SMPolicy
 import java.io.IOException
 
-class ExplainSMPolicyResponse : ActionResponse, ToXContentObject {
+class ExplainSMPolicyResponse :
+    ActionResponse,
+    ToXContentObject {
     val policiesToExplain: Map<String, ExplainSMPolicy?>
 
     constructor(policiesToExplain: Map<String, ExplainSMPolicy?>) : super() {
         this.policiesToExplain = policiesToExplain
     }
 
-    internal fun getIdsToExplain(): Map<String, ExplainSMPolicy?> {
-        return this.policiesToExplain
-    }
+    internal fun getIdsToExplain(): Map<String, ExplainSMPolicy?> = this.policiesToExplain
 
     @Throws(IOException::class)
     constructor(sin: StreamInput) : this(
@@ -51,20 +51,18 @@ class ExplainSMPolicyResponse : ActionResponse, ToXContentObject {
     }
 
     @Throws(IOException::class)
-    override fun toXContent(builder: XContentBuilder, params: ToXContent.Params): XContentBuilder {
-        return builder.startObject()
-            .startArray(SM_POLICIES_FIELD)
-            .also {
-                policiesToExplain.entries.forEach { (name, explain) ->
-                    it.startObject().apply {
-                        this.field(SMPolicy.NAME_FIELD, name)
-                        explain?.toXContent(this, params)
-                    }.endObject()
-                }
+    override fun toXContent(builder: XContentBuilder, params: ToXContent.Params): XContentBuilder = builder.startObject()
+        .startArray(SM_POLICIES_FIELD)
+        .also {
+            policiesToExplain.entries.forEach { (name, explain) ->
+                it.startObject().apply {
+                    this.field(SMPolicy.NAME_FIELD, name)
+                    explain?.toXContent(this, params)
+                }.endObject()
             }
-            .endArray()
-            .endObject()
-    }
+        }
+        .endArray()
+        .endObject()
 
     companion object {
         const val SM_POLICIES_FIELD = "policies"

--- a/src/main/kotlin/org/opensearch/indexmanagement/snapshotmanagement/api/transport/get/GetSMPoliciesRequest.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/snapshotmanagement/api/transport/get/GetSMPoliciesRequest.kt
@@ -23,7 +23,5 @@ class GetSMPoliciesRequest(val searchParams: SearchParams) : ActionRequest() {
         searchParams.writeTo(out)
     }
 
-    override fun validate(): ActionRequestValidationException? {
-        return null
-    }
+    override fun validate(): ActionRequestValidationException? = null
 }

--- a/src/main/kotlin/org/opensearch/indexmanagement/snapshotmanagement/api/transport/get/GetSMPoliciesResponse.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/snapshotmanagement/api/transport/get/GetSMPoliciesResponse.kt
@@ -21,7 +21,8 @@ import org.opensearch.indexmanagement.util._SEQ_NO
 class GetSMPoliciesResponse(
     val policies: List<SMPolicy>,
     val totalPolicies: Long,
-) : ActionResponse(), ToXContentObject {
+) : ActionResponse(),
+    ToXContentObject {
     constructor(sin: StreamInput) : this(
         policies = sin.readList(::SMPolicy),
         totalPolicies = sin.readLong(),
@@ -32,21 +33,19 @@ class GetSMPoliciesResponse(
         out.writeLong(totalPolicies)
     }
 
-    override fun toXContent(builder: XContentBuilder, params: ToXContent.Params): XContentBuilder {
-        return builder.startObject()
-            .startArray("policies")
-            .apply {
-                for (policy in policies) {
-                    this.startObject()
-                        .field(_ID, policy.id)
-                        .field(_SEQ_NO, policy.seqNo)
-                        .field(_PRIMARY_TERM, policy.primaryTerm)
-                        .field(SMPolicy.SM_TYPE, policy, XCONTENT_WITHOUT_TYPE_AND_USER)
-                        .endObject()
-                }
+    override fun toXContent(builder: XContentBuilder, params: ToXContent.Params): XContentBuilder = builder.startObject()
+        .startArray("policies")
+        .apply {
+            for (policy in policies) {
+                this.startObject()
+                    .field(_ID, policy.id)
+                    .field(_SEQ_NO, policy.seqNo)
+                    .field(_PRIMARY_TERM, policy.primaryTerm)
+                    .field(SMPolicy.SM_TYPE, policy, XCONTENT_WITHOUT_TYPE_AND_USER)
+                    .endObject()
             }
-            .endArray()
-            .field("total_policies", totalPolicies)
-            .endObject()
-    }
+        }
+        .endArray()
+        .field("total_policies", totalPolicies)
+        .endObject()
 }

--- a/src/main/kotlin/org/opensearch/indexmanagement/snapshotmanagement/api/transport/get/GetSMPolicyRequest.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/snapshotmanagement/api/transport/get/GetSMPolicyRequest.kt
@@ -13,9 +13,7 @@ import org.opensearch.core.common.io.stream.StreamOutput
 class GetSMPolicyRequest(
     val policyID: String,
 ) : ActionRequest() {
-    override fun validate(): ActionRequestValidationException? {
-        return null
-    }
+    override fun validate(): ActionRequestValidationException? = null
 
     constructor(sin: StreamInput) : this(
         policyID = sin.readString(),

--- a/src/main/kotlin/org/opensearch/indexmanagement/snapshotmanagement/api/transport/get/GetSMPolicyResponse.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/snapshotmanagement/api/transport/get/GetSMPolicyResponse.kt
@@ -25,7 +25,8 @@ class GetSMPolicyResponse(
     val seqNo: Long,
     val primaryTerm: Long,
     val policy: SMPolicy,
-) : ActionResponse(), ToXContentObject {
+) : ActionResponse(),
+    ToXContentObject {
     constructor(sin: StreamInput) : this(
         id = sin.readString(),
         version = sin.readLong(),

--- a/src/main/kotlin/org/opensearch/indexmanagement/snapshotmanagement/api/transport/get/TransportGetSMPoliciesAction.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/snapshotmanagement/api/transport/get/TransportGetSMPoliciesAction.kt
@@ -110,15 +110,13 @@ constructor(
         return SearchRequest(IndexManagementPlugin.INDEX_MANAGEMENT_INDEX).source(searchSourceBuilder)
     }
 
-    private fun parseGetAllPoliciesResponse(searchResponse: SearchResponse): Pair<List<SMPolicy>, Long> {
-        return try {
-            val totalPolicies = searchResponse.hits.totalHits?.value ?: 0L
-            searchResponse.hits.hits.map {
-                contentParser(it.sourceRef).parseWithType(it.id, it.seqNo, it.primaryTerm, SMPolicy.Companion::parse)
-            } to totalPolicies
-        } catch (e: Exception) {
-            log.error("Failed to parse snapshot management policy in search response", e)
-            throw OpenSearchStatusException("Failed to parse snapshot management policy", RestStatus.NOT_FOUND)
-        }
+    private fun parseGetAllPoliciesResponse(searchResponse: SearchResponse): Pair<List<SMPolicy>, Long> = try {
+        val totalPolicies = searchResponse.hits.totalHits?.value ?: 0L
+        searchResponse.hits.hits.map {
+            contentParser(it.sourceRef).parseWithType(it.id, it.seqNo, it.primaryTerm, SMPolicy.Companion::parse)
+        } to totalPolicies
+    } catch (e: Exception) {
+        log.error("Failed to parse snapshot management policy in search response", e)
+        throw OpenSearchStatusException("Failed to parse snapshot management policy", RestStatus.NOT_FOUND)
     }
 }

--- a/src/main/kotlin/org/opensearch/indexmanagement/snapshotmanagement/api/transport/index/IndexSMPolicyResponse.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/snapshotmanagement/api/transport/index/IndexSMPolicyResponse.kt
@@ -27,7 +27,8 @@ class IndexSMPolicyResponse(
     val primaryTerm: Long,
     val policy: SMPolicy,
     val status: RestStatus,
-) : ActionResponse(), ToXContentObject {
+) : ActionResponse(),
+    ToXContentObject {
     constructor(sin: StreamInput) : this(
         id = sin.readString(),
         version = sin.readLong(),
@@ -46,13 +47,11 @@ class IndexSMPolicyResponse(
         out.writeEnum(status)
     }
 
-    override fun toXContent(builder: XContentBuilder, params: ToXContent.Params): XContentBuilder {
-        return builder.startObject()
-            .field(_ID, id)
-            .field(_VERSION, version)
-            .field(_SEQ_NO, seqNo)
-            .field(_PRIMARY_TERM, primaryTerm)
-            .field(SM_TYPE, policy, XCONTENT_WITHOUT_TYPE_AND_USER)
-            .endObject()
-    }
+    override fun toXContent(builder: XContentBuilder, params: ToXContent.Params): XContentBuilder = builder.startObject()
+        .field(_ID, id)
+        .field(_VERSION, version)
+        .field(_SEQ_NO, seqNo)
+        .field(_PRIMARY_TERM, primaryTerm)
+        .field(SM_TYPE, policy, XCONTENT_WITHOUT_TYPE_AND_USER)
+        .endObject()
 }

--- a/src/main/kotlin/org/opensearch/indexmanagement/snapshotmanagement/model/ExplainSMPolicy.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/snapshotmanagement/model/ExplainSMPolicy.kt
@@ -17,7 +17,8 @@ import java.io.IOException
 data class ExplainSMPolicy(
     val metadata: SMMetadata? = null,
     val enabled: Boolean? = null,
-) : ToXContentFragment, Writeable {
+) : ToXContentFragment,
+    Writeable {
     @Throws(IOException::class)
     constructor(sin: StreamInput) : this(
         metadata = if (sin.readBoolean()) SMMetadata(sin) else null,

--- a/src/main/kotlin/org/opensearch/indexmanagement/snapshotmanagement/model/NotificationConfig.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/snapshotmanagement/model/NotificationConfig.kt
@@ -28,13 +28,12 @@ import java.io.IOException
 data class NotificationConfig(
     val channel: Channel,
     val conditions: Conditions,
-) : ToXContentObject, Writeable {
-    override fun toXContent(builder: XContentBuilder, params: ToXContent.Params): XContentBuilder {
-        return builder.startObject()
-            .field(CHANNEL_FIELD, channel)
-            .field(CONDITIONS_FIELD, conditions)
-            .endObject()
-    }
+) : ToXContentObject,
+    Writeable {
+    override fun toXContent(builder: XContentBuilder, params: ToXContent.Params): XContentBuilder = builder.startObject()
+        .field(CHANNEL_FIELD, channel)
+        .field(CONDITIONS_FIELD, conditions)
+        .endObject()
 
     @Throws(IOException::class)
     constructor(sin: StreamInput) : this(
@@ -139,15 +138,14 @@ data class NotificationConfig(
         val deletion: Boolean = false,
         val failure: Boolean = false,
         val timeLimitExceeded: Boolean = false,
-    ) : Writeable, ToXContent {
-        override fun toXContent(builder: XContentBuilder, params: ToXContent.Params): XContentBuilder {
-            return builder.startObject()
-                .field(CREATION_FIELD, creation)
-                .field(DELETION_FIELD, deletion)
-                .field(FAILURE_FIELD, failure)
-                .field(TIME_LIMIT_EXCEEDED_FIELD, timeLimitExceeded)
-                .endObject()
-        }
+    ) : Writeable,
+        ToXContent {
+        override fun toXContent(builder: XContentBuilder, params: ToXContent.Params): XContentBuilder = builder.startObject()
+            .field(CREATION_FIELD, creation)
+            .field(DELETION_FIELD, deletion)
+            .field(FAILURE_FIELD, failure)
+            .field(TIME_LIMIT_EXCEEDED_FIELD, timeLimitExceeded)
+            .endObject()
 
         companion object {
             const val CREATION_FIELD = "creation"

--- a/src/main/kotlin/org/opensearch/indexmanagement/snapshotmanagement/model/SMMetadata.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/snapshotmanagement/model/SMMetadata.kt
@@ -43,7 +43,8 @@ data class SMMetadata(
     val id: String = NO_ID,
     val seqNo: Long = SequenceNumbers.UNASSIGNED_SEQ_NO,
     val primaryTerm: Long = SequenceNumbers.UNASSIGNED_PRIMARY_TERM,
-) : Writeable, ToXContentObject {
+) : Writeable,
+    ToXContentObject {
     override fun toXContent(builder: XContentBuilder, params: ToXContent.Params): XContentBuilder {
         builder.startObject()
         if (params.paramAsBoolean(WITH_TYPE, true)) builder.startObject(SM_METADATA_TYPE)
@@ -105,9 +106,7 @@ data class SMMetadata(
             return info
         }
 
-        fun InfoType?.remove(key: String): InfoType? {
-            return this?.toMutableMap().remove(key)
-        }
+        fun InfoType?.remove(key: String): InfoType? = this?.toMutableMap().remove(key)
     }
 
     constructor(sin: StreamInput) : this(
@@ -136,16 +135,15 @@ data class SMMetadata(
         val started: List<String>? = null,
         val latestExecution: LatestExecution? = null,
         val retry: Retry? = null,
-    ) : Writeable, ToXContentObject {
-        override fun toXContent(builder: XContentBuilder, params: ToXContent.Params): XContentBuilder {
-            return builder.startObject()
-                .field(CURRENT_STATE_FIELD, currentState.toString())
-                .field(TRIGGER_FIELD, trigger)
-                .optionalField(STARTED_FIELD, started)
-                .optionalField(LAST_EXECUTION_FIELD, latestExecution)
-                .optionalField(RETRY_FIELD, retry)
-                .endObject()
-        }
+    ) : Writeable,
+        ToXContentObject {
+        override fun toXContent(builder: XContentBuilder, params: ToXContent.Params): XContentBuilder = builder.startObject()
+            .field(CURRENT_STATE_FIELD, currentState.toString())
+            .field(TRIGGER_FIELD, trigger)
+            .optionalField(STARTED_FIELD, started)
+            .optionalField(LAST_EXECUTION_FIELD, latestExecution)
+            .optionalField(RETRY_FIELD, retry)
+            .endObject()
 
         companion object {
             const val CURRENT_STATE_FIELD = "current_state"
@@ -206,15 +204,14 @@ data class SMMetadata(
         val startTime: Instant,
         val endTime: Instant? = null,
         val info: Info? = null,
-    ) : Writeable, ToXContentObject {
-        override fun toXContent(builder: XContentBuilder, params: ToXContent.Params): XContentBuilder {
-            return builder.startObject()
-                .field(STATUS_FIELD, status.toString())
-                .optionalTimeField(START_TIME_FIELD, startTime)
-                .optionalTimeField(END_TIME_FIELD, endTime)
-                .optionalInfoField(INFO_FIELD, info)
-                .endObject()
-        }
+    ) : Writeable,
+        ToXContentObject {
+        override fun toXContent(builder: XContentBuilder, params: ToXContent.Params): XContentBuilder = builder.startObject()
+            .field(STATUS_FIELD, status.toString())
+            .optionalTimeField(START_TIME_FIELD, startTime)
+            .optionalTimeField(END_TIME_FIELD, endTime)
+            .optionalInfoField(INFO_FIELD, info)
+            .endObject()
 
         companion object {
             const val STATUS_FIELD = "status"
@@ -249,13 +246,11 @@ data class SMMetadata(
                 )
             }
 
-            fun init(status: Status, info: Info? = null): LatestExecution {
-                return LatestExecution(
-                    status = status,
-                    startTime = now(),
-                    info = info,
-                )
-            }
+            fun init(status: Status, info: Info? = null): LatestExecution = LatestExecution(
+                status = status,
+                startTime = now(),
+                info = info,
+            )
         }
 
         constructor(sin: StreamInput) : this(
@@ -284,13 +279,12 @@ data class SMMetadata(
     data class Info(
         val message: String? = null,
         val cause: String? = null,
-    ) : Writeable, ToXContentObject {
-        override fun toXContent(builder: XContentBuilder, params: ToXContent.Params): XContentBuilder {
-            return builder.startObject()
-                .optionalField(MESSAGE_FIELD, message)
-                .optionalField(CAUSE_FIELD, cause)
-                .endObject()
-        }
+    ) : Writeable,
+        ToXContentObject {
+        override fun toXContent(builder: XContentBuilder, params: ToXContent.Params): XContentBuilder = builder.startObject()
+            .optionalField(MESSAGE_FIELD, message)
+            .optionalField(CAUSE_FIELD, cause)
+            .endObject()
 
         companion object {
             const val MESSAGE_FIELD = "message"
@@ -337,12 +331,11 @@ data class SMMetadata(
      */
     data class Trigger(
         val time: Instant,
-    ) : Writeable, ToXContentObject {
-        override fun toXContent(builder: XContentBuilder, params: ToXContent.Params): XContentBuilder {
-            return builder.startObject()
-                .optionalTimeField(TIME_FIELD, time)
-                .endObject()
-        }
+    ) : Writeable,
+        ToXContentObject {
+        override fun toXContent(builder: XContentBuilder, params: ToXContent.Params): XContentBuilder = builder.startObject()
+            .optionalTimeField(TIME_FIELD, time)
+            .endObject()
 
         companion object {
             const val TIME_FIELD = "time"
@@ -377,12 +370,11 @@ data class SMMetadata(
 
     data class Retry(
         val count: Int,
-    ) : Writeable, ToXContentObject {
-        override fun toXContent(builder: XContentBuilder, params: ToXContent.Params): XContentBuilder {
-            return builder.startObject()
-                .field(COUNT_FIELD, count)
-                .endObject()
-        }
+    ) : Writeable,
+        ToXContentObject {
+        override fun toXContent(builder: XContentBuilder, params: ToXContent.Params): XContentBuilder = builder.startObject()
+            .field(COUNT_FIELD, count)
+            .endObject()
 
         companion object {
             const val RETRY_FIELD = "retry"
@@ -568,29 +560,23 @@ data class SMMetadata(
             return this
         }
 
-        fun getWorkflowMetadata(): WorkflowMetadata? {
-            return when (workflowType) {
-                WorkflowType.CREATION -> {
-                    metadata.creation
-                }
-                WorkflowType.DELETION -> {
-                    metadata.deletion
-                }
+        fun getWorkflowMetadata(): WorkflowMetadata? = when (workflowType) {
+            WorkflowType.CREATION -> {
+                metadata.creation
+            }
+            WorkflowType.DELETION -> {
+                metadata.deletion
             }
         }
 
-        fun getWorkflowType(): WorkflowType {
-            return workflowType
-        }
+        fun getWorkflowType(): WorkflowType = workflowType
 
-        fun getStartedSnapshots(): List<String>? {
-            return when (workflowType) {
-                WorkflowType.CREATION -> {
-                    metadata.creation.started
-                }
-                WorkflowType.DELETION -> {
-                    metadata.deletion?.started
-                }
+        fun getStartedSnapshots(): List<String>? = when (workflowType) {
+            WorkflowType.CREATION -> {
+                metadata.creation.started
+            }
+            WorkflowType.DELETION -> {
+                metadata.deletion?.started
             }
         }
 

--- a/src/main/kotlin/org/opensearch/indexmanagement/snapshotmanagement/model/SMPolicy.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/snapshotmanagement/model/SMPolicy.kt
@@ -52,7 +52,8 @@ data class SMPolicy(
     val primaryTerm: Long = SequenceNumbers.UNASSIGNED_PRIMARY_TERM,
     val notificationConfig: NotificationConfig? = null,
     val user: User? = null,
-) : ScheduledJobParameter, Writeable {
+) : ScheduledJobParameter,
+    Writeable {
     init {
         require(snapshotConfig["repository"] != null && snapshotConfig["repository"] != "") {
             "Must provide the repository in snapshot config."
@@ -252,13 +253,12 @@ data class SMPolicy(
     data class Creation(
         val schedule: Schedule,
         val timeLimit: TimeValue? = null,
-    ) : Writeable, ToXContent {
-        override fun toXContent(builder: XContentBuilder, params: ToXContent.Params): XContentBuilder {
-            return builder.startObject()
-                .field(SCHEDULE_FIELD, schedule)
-                .optionalField(TIME_LIMIT_FIELD, timeLimit)
-                .endObject()
-        }
+    ) : Writeable,
+        ToXContent {
+        override fun toXContent(builder: XContentBuilder, params: ToXContent.Params): XContentBuilder = builder.startObject()
+            .field(SCHEDULE_FIELD, schedule)
+            .optionalField(TIME_LIMIT_FIELD, timeLimit)
+            .endObject()
 
         companion object {
             const val SCHEDULE_FIELD = "schedule"
@@ -301,14 +301,13 @@ data class SMPolicy(
         val scheduleProvided: Boolean = true,
         val condition: DeleteCondition,
         val timeLimit: TimeValue? = null,
-    ) : Writeable, ToXContent {
-        override fun toXContent(builder: XContentBuilder, params: ToXContent.Params): XContentBuilder {
-            return builder.startObject()
-                .field(SCHEDULE_FIELD, schedule)
-                .field(CONDITION_FIELD, condition)
-                .optionalField(TIME_LIMIT_FIELD, timeLimit)
-                .endObject()
-        }
+    ) : Writeable,
+        ToXContent {
+        override fun toXContent(builder: XContentBuilder, params: ToXContent.Params): XContentBuilder = builder.startObject()
+            .field(SCHEDULE_FIELD, schedule)
+            .field(CONDITION_FIELD, condition)
+            .optionalField(TIME_LIMIT_FIELD, timeLimit)
+            .endObject()
 
         companion object {
             const val SCHEDULE_FIELD = "schedule"
@@ -364,20 +363,19 @@ data class SMPolicy(
         val maxAge: TimeValue? = null,
         val minCount: Int,
         val maxCount: Int? = null,
-    ) : Writeable, ToXContent {
+    ) : Writeable,
+        ToXContent {
         init {
             require(!(maxAge == null && maxCount == null)) { "Please provide $MAX_AGE_FIELD or $MAX_COUNT_FIELD." }
             require(minCount > 0) { "$MIN_COUNT_FIELD should be bigger than 0." }
             require(maxCount == null || maxCount - minCount > 0) { "$MAX_COUNT_FIELD should be bigger than $MIN_COUNT_FIELD." }
         }
 
-        override fun toXContent(builder: XContentBuilder, params: ToXContent.Params): XContentBuilder {
-            return builder.startObject()
-                .optionalField(MAX_AGE_FIELD, maxAge)
-                .field(MIN_COUNT_FIELD, minCount)
-                .optionalField(MAX_COUNT_FIELD, maxCount)
-                .endObject()
-        }
+        override fun toXContent(builder: XContentBuilder, params: ToXContent.Params): XContentBuilder = builder.startObject()
+            .optionalField(MAX_AGE_FIELD, maxAge)
+            .field(MIN_COUNT_FIELD, minCount)
+            .optionalField(MAX_COUNT_FIELD, maxCount)
+            .endObject()
 
         companion object {
             const val MAX_COUNT_FIELD = "max_count"

--- a/src/main/kotlin/org/opensearch/indexmanagement/transform/TargetIndexMappingService.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/transform/TargetIndexMappingService.kt
@@ -195,24 +195,22 @@ object TargetIndexMappingService {
     @Suppress("UNCHECKED_CAST")
     private fun mapCompositeAggregationToString(
         compositeAggregation: Map<String, Any>,
-    ): String {
-        return buildString {
-            var isFirst = true
-            val iterator = compositeAggregation.entries.iterator()
-            while (iterator.hasNext()) {
-                val it = iterator.next()
-                if (!isFirst) {
-                    append(",")
-                }
-                isFirst = false
-                if (it.value is Map<*, *>) {
-                    append("\"${it.key}\" : {")
-                    append(mapCompositeAggregationToString(it.value as Map<String, Any>))
-                    append("\n }")
-                } else {
-                    append("\n")
-                    append("\"${it.key}\" : \"${it.value}\"")
-                }
+    ): String = buildString {
+        var isFirst = true
+        val iterator = compositeAggregation.entries.iterator()
+        while (iterator.hasNext()) {
+            val it = iterator.next()
+            if (!isFirst) {
+                append(",")
+            }
+            isFirst = false
+            if (it.value is Map<*, *>) {
+                append("\"${it.key}\" : {")
+                append(mapCompositeAggregationToString(it.value as Map<String, Any>))
+                append("\n }")
+            } else {
+                append("\n")
+                append("\"${it.key}\" : \"${it.value}\"")
             }
         }
     }

--- a/src/main/kotlin/org/opensearch/indexmanagement/transform/TransformMetadataService.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/transform/TransformMetadataService.kt
@@ -39,26 +39,24 @@ class TransformMetadataService(private val client: Client, val xContentRegistry:
     private val logger = LogManager.getLogger(javaClass)
 
     @Suppress("BlockingMethodInNonBlockingContext")
-    suspend fun getMetadata(transform: Transform): TransformMetadata {
-        return if (transform.metadataId != null) {
-            // update metadata
-            val getRequest = GetRequest(IndexManagementPlugin.INDEX_MANAGEMENT_INDEX, transform.metadataId).routing(transform.id)
-            val response: GetResponse = client.suspendUntil { get(getRequest, it) }
-            val metadataSource = response.sourceAsBytesRef
-            val transformMetadata =
-                metadataSource?.let {
-                    withContext(Dispatchers.IO) {
-                        val xcp = XContentHelper.createParser(xContentRegistry, LoggingDeprecationHandler.INSTANCE, metadataSource, XContentType.JSON)
-                        xcp.parseWithType(response.id, response.seqNo, response.primaryTerm, TransformMetadata.Companion::parse)
-                    }
+    suspend fun getMetadata(transform: Transform): TransformMetadata = if (transform.metadataId != null) {
+        // update metadata
+        val getRequest = GetRequest(IndexManagementPlugin.INDEX_MANAGEMENT_INDEX, transform.metadataId).routing(transform.id)
+        val response: GetResponse = client.suspendUntil { get(getRequest, it) }
+        val metadataSource = response.sourceAsBytesRef
+        val transformMetadata =
+            metadataSource?.let {
+                withContext(Dispatchers.IO) {
+                    val xcp = XContentHelper.createParser(xContentRegistry, LoggingDeprecationHandler.INSTANCE, metadataSource, XContentType.JSON)
+                    xcp.parseWithType(response.id, response.seqNo, response.primaryTerm, TransformMetadata.Companion::parse)
                 }
-            // TODO: Should we attempt to create a new document instead if failed to parse, the only reason this can happen is if someone deleted
-            //  the metadata doc?
-            transformMetadata ?: throw TransformMetadataException("Failed to parse the existing metadata document")
-        } else {
-            logger.debug("Creating metadata doc as none exists at the moment for transform job [${transform.id}]")
-            createMetadata(transform)
-        }
+            }
+        // TODO: Should we attempt to create a new document instead if failed to parse, the only reason this can happen is if someone deleted
+        //  the metadata doc?
+        transformMetadata ?: throw TransformMetadataException("Failed to parse the existing metadata document")
+    } else {
+        logger.debug("Creating metadata doc as none exists at the moment for transform job [${transform.id}]")
+        createMetadata(transform)
     }
 
     private suspend fun createMetadata(transform: Transform): TransformMetadata {

--- a/src/main/kotlin/org/opensearch/indexmanagement/transform/TransformProcessedBucketLog.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/transform/TransformProcessedBucketLog.kt
@@ -27,9 +27,7 @@ class TransformProcessedBucketLog {
         processedBuckets.add(computeBucketHash(bucket))
     }
 
-    private fun isProcessed(bucket: Map<String, Any>): Boolean {
-        return processedBuckets.contains(computeBucketHash(bucket))
-    }
+    private fun isProcessed(bucket: Map<String, Any>): Boolean = processedBuckets.contains(computeBucketHash(bucket))
 
     fun isNotProcessed(bucket: Map<String, Any>) = !isProcessed(bucket)
 

--- a/src/main/kotlin/org/opensearch/indexmanagement/transform/TransformRunner.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/transform/TransformRunner.kt
@@ -344,9 +344,7 @@ object TransformRunner :
         return updatedMetadata
     }
 
-    private suspend fun <T> withTransformSecurityContext(transform: Transform, block: suspend CoroutineScope.() -> T): T {
-        return withClosableContext(IndexManagementSecurityContext(transform.id, settings, threadPool.threadContext, transform.user), block)
-    }
+    private suspend fun <T> withTransformSecurityContext(transform: Transform, block: suspend CoroutineScope.() -> T): T = withClosableContext(IndexManagementSecurityContext(transform.id, settings, threadPool.threadContext, transform.user), block)
 
     private suspend fun updateTransform(transform: Transform): Transform {
         val request =

--- a/src/main/kotlin/org/opensearch/indexmanagement/transform/TransformRunner.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/transform/TransformRunner.kt
@@ -344,7 +344,8 @@ object TransformRunner :
         return updatedMetadata
     }
 
-    private suspend fun <T> withTransformSecurityContext(transform: Transform, block: suspend CoroutineScope.() -> T): T = withClosableContext(IndexManagementSecurityContext(transform.id, settings, threadPool.threadContext, transform.user), block)
+    private suspend fun <T> withTransformSecurityContext(transform: Transform, block: suspend CoroutineScope.() -> T): T =
+        withClosableContext(IndexManagementSecurityContext(transform.id, settings, threadPool.threadContext, transform.user), block)
 
     private suspend fun updateTransform(transform: Transform): Transform {
         val request =

--- a/src/main/kotlin/org/opensearch/indexmanagement/transform/TransformSearchService.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/transform/TransformSearchService.kt
@@ -82,8 +82,7 @@ class TransformSearchService(
     @Volatile private var cancelAfterTimeInterval = SEARCH_CANCEL_AFTER_TIME_INTERVAL_SETTING.get(settings)
 
     init {
-        clusterService.clusterSettings.addSettingsUpdateConsumer(TRANSFORM_JOB_SEARCH_BACKOFF_MILLIS, TRANSFORM_JOB_SEARCH_BACKOFF_COUNT) {
-                millis, count ->
+        clusterService.clusterSettings.addSettingsUpdateConsumer(TRANSFORM_JOB_SEARCH_BACKOFF_MILLIS, TRANSFORM_JOB_SEARCH_BACKOFF_COUNT) { millis, count ->
             backoffPolicy = BackoffPolicy.constantBackoff(millis, count)
         }
 
@@ -174,9 +173,7 @@ class TransformSearchService(
      *   Apache Lucene has maxClauses limit which we could trip during recomputing of modified buckets(continuous transform)
      *   due to trying to match too many bucket fields. To avoid this, we control how many buckets we recompute at a time(pageSize)
      */
-    private fun calculateMaxPageSize(transform: Transform): Int {
-        return minOf(transform.pageSize, LUCENE_MAX_CLAUSES / (transform.groups.size + 1))
-    }
+    private fun calculateMaxPageSize(transform: Transform): Int = minOf(transform.pageSize, LUCENE_MAX_CLAUSES / (transform.groups.size + 1))
 
     @Suppress("RethrowCaughtException")
     suspend fun executeCompositeSearch(
@@ -414,35 +411,33 @@ class TransformSearchService(
             return BucketSearchResult(modifiedBuckets, aggs.afterKey(), searchResponse.took.millis)
         }
 
-        private fun getAggregationValue(aggregation: Aggregation, targetIndexDateFieldMappings: Map<String, Any>): Any {
-            return when (aggregation) {
-                is InternalSum, is InternalMin, is InternalMax, is InternalAvg, is InternalValueCount -> {
-                    val agg = aggregation as NumericMetricsAggregation.SingleValue
-                    /**
-                     * When date filed is used in transform aggregation (min, max avg), the value of the field is in exponential format
-                     * which is not allowed since the target index mapping for date field is strict_date_optional_time||epoch_millis
-                     * That's why the exponential value is transformed to long: agg.value().toLong()
-                     */
-                    if (aggregation is InternalValueCount || aggregation is InternalSum || !targetIndexDateFieldMappings.containsKey(agg.name)) {
-                        agg.value()
-                    } else {
-                        agg.value().toLong()
-                    }
+        private fun getAggregationValue(aggregation: Aggregation, targetIndexDateFieldMappings: Map<String, Any>): Any = when (aggregation) {
+            is InternalSum, is InternalMin, is InternalMax, is InternalAvg, is InternalValueCount -> {
+                val agg = aggregation as NumericMetricsAggregation.SingleValue
+                /**
+                 * When date filed is used in transform aggregation (min, max avg), the value of the field is in exponential format
+                 * which is not allowed since the target index mapping for date field is strict_date_optional_time||epoch_millis
+                 * That's why the exponential value is transformed to long: agg.value().toLong()
+                 */
+                if (aggregation is InternalValueCount || aggregation is InternalSum || !targetIndexDateFieldMappings.containsKey(agg.name)) {
+                    agg.value()
+                } else {
+                    agg.value().toLong()
                 }
-                is Percentiles -> {
-                    val percentiles = mutableMapOf<String, Double>()
-                    aggregation.forEach { percentile ->
-                        percentiles[percentile.percent.toString()] = percentile.value
-                    }
-                    percentiles
-                }
-                is ScriptedMetric -> {
-                    aggregation.aggregation()
-                }
-                else -> throw TransformSearchServiceException(
-                    "Found aggregation [${aggregation.name}] of type [${aggregation.type}] in composite result that is not currently supported",
-                )
             }
+            is Percentiles -> {
+                val percentiles = mutableMapOf<String, Double>()
+                aggregation.forEach { percentile ->
+                    percentiles[percentile.percent.toString()] = percentile.value
+                }
+                percentiles
+            }
+            is ScriptedMetric -> {
+                aggregation.aggregation()
+            }
+            else -> throw TransformSearchServiceException(
+                "Found aggregation [${aggregation.name}] of type [${aggregation.type}] in composite result that is not currently supported",
+            )
         }
 
         fun convertIndicesStatsResponse(response: IndicesStatsResponse): Map<ShardId, Long> {

--- a/src/main/kotlin/org/opensearch/indexmanagement/transform/action/explain/ExplainTransformResponse.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/transform/action/explain/ExplainTransformResponse.kt
@@ -17,10 +17,9 @@ import java.io.IOException
 class ExplainTransformResponse(
     val idsToExplain: Map<String, ExplainTransform?>,
     private val failedToExplain: Map<String, String>,
-) : ActionResponse(), ToXContentObject {
-    internal fun getIdsToExplain(): Map<String, ExplainTransform?> {
-        return this.idsToExplain
-    }
+) : ActionResponse(),
+    ToXContentObject {
+    internal fun getIdsToExplain(): Map<String, ExplainTransform?> = this.idsToExplain
 
     @Throws(IOException::class)
     constructor(sin: StreamInput) : this(

--- a/src/main/kotlin/org/opensearch/indexmanagement/transform/action/explain/TransportExplainTransformAction.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/transform/action/explain/TransportExplainTransformAction.kt
@@ -192,10 +192,8 @@ constructor(
         }
     }
 
-    private fun contentParser(bytesReference: BytesReference): XContentParser {
-        return XContentHelper.createParser(
-            xContentRegistry,
-            LoggingDeprecationHandler.INSTANCE, bytesReference, XContentType.JSON,
-        )
-    }
+    private fun contentParser(bytesReference: BytesReference): XContentParser = XContentHelper.createParser(
+        xContentRegistry,
+        LoggingDeprecationHandler.INSTANCE, bytesReference, XContentType.JSON,
+    )
 }

--- a/src/main/kotlin/org/opensearch/indexmanagement/transform/action/get/GetTransformResponse.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/transform/action/get/GetTransformResponse.kt
@@ -28,7 +28,8 @@ class GetTransformResponse(
     val primaryTerm: Long,
     val status: RestStatus,
     val transform: Transform?,
-) : ActionResponse(), ToXContentObject {
+) : ActionResponse(),
+    ToXContentObject {
     @Throws(IOException::class)
     constructor(sin: StreamInput) : this(
         id = sin.readString(),

--- a/src/main/kotlin/org/opensearch/indexmanagement/transform/action/get/GetTransformsResponse.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/transform/action/get/GetTransformsResponse.kt
@@ -24,7 +24,8 @@ class GetTransformsResponse(
     val transforms: List<Transform>,
     val totalTransforms: Int,
     val status: RestStatus,
-) : ActionResponse(), ToXContentObject {
+) : ActionResponse(),
+    ToXContentObject {
     @Throws(IOException::class)
     constructor(sin: StreamInput) : this(
         transforms = sin.readList(::Transform),
@@ -38,21 +39,19 @@ class GetTransformsResponse(
         out.writeEnum(status)
     }
 
-    override fun toXContent(builder: XContentBuilder, params: ToXContent.Params): XContentBuilder {
-        return builder.startObject()
-            .field("total_transforms", totalTransforms)
-            .startArray("transforms")
-            .apply {
-                for (transform in transforms) {
-                    this.startObject()
-                        .field(_ID, transform.id)
-                        .field(_SEQ_NO, transform.seqNo)
-                        .field(_PRIMARY_TERM, transform.primaryTerm)
-                        .field(TRANSFORM_TYPE, transform, XCONTENT_WITHOUT_TYPE_AND_USER)
-                        .endObject()
-                }
+    override fun toXContent(builder: XContentBuilder, params: ToXContent.Params): XContentBuilder = builder.startObject()
+        .field("total_transforms", totalTransforms)
+        .startArray("transforms")
+        .apply {
+            for (transform in transforms) {
+                this.startObject()
+                    .field(_ID, transform.id)
+                    .field(_SEQ_NO, transform.seqNo)
+                    .field(_PRIMARY_TERM, transform.primaryTerm)
+                    .field(TRANSFORM_TYPE, transform, XCONTENT_WITHOUT_TYPE_AND_USER)
+                    .endObject()
             }
-            .endArray()
-            .endObject()
-    }
+        }
+        .endArray()
+        .endObject()
 }

--- a/src/main/kotlin/org/opensearch/indexmanagement/transform/action/get/TransportGetTransformAction.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/transform/action/get/TransportGetTransformAction.kt
@@ -38,7 +38,7 @@ constructor(
     val clusterService: ClusterService,
     actionFilters: ActionFilters,
     val xContentRegistry: NamedXContentRegistry,
-) : HandledTransportAction<GetTransformRequest, GetTransformResponse> (
+) : HandledTransportAction<GetTransformRequest, GetTransformResponse>(
     GetTransformAction.NAME, transportService, actionFilters, ::GetTransformRequest,
 ) {
     @Volatile private var filterByEnabled = IndexManagementSettings.FILTER_BY_BACKEND_ROLES.get(settings)

--- a/src/main/kotlin/org/opensearch/indexmanagement/transform/action/get/TransportGetTransformsAction.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/transform/action/get/TransportGetTransformsAction.kt
@@ -43,7 +43,7 @@ constructor(
     val clusterService: ClusterService,
     actionFilters: ActionFilters,
     val xContentRegistry: NamedXContentRegistry,
-) : HandledTransportAction<GetTransformsRequest, GetTransformsResponse> (
+) : HandledTransportAction<GetTransformsRequest, GetTransformsResponse>(
     GetTransformsAction.NAME, transportService, actionFilters, ::GetTransformsRequest,
 ) {
     @Volatile private var filterByEnabled = IndexManagementSettings.FILTER_BY_BACKEND_ROLES.get(settings)
@@ -89,10 +89,8 @@ constructor(
         }
     }
 
-    private fun contentParser(bytesReference: BytesReference): XContentParser {
-        return XContentHelper.createParser(
-            xContentRegistry,
-            LoggingDeprecationHandler.INSTANCE, bytesReference, XContentType.JSON,
-        )
-    }
+    private fun contentParser(bytesReference: BytesReference): XContentParser = XContentHelper.createParser(
+        xContentRegistry,
+        LoggingDeprecationHandler.INSTANCE, bytesReference, XContentType.JSON,
+    )
 }

--- a/src/main/kotlin/org/opensearch/indexmanagement/transform/action/index/IndexTransformResponse.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/transform/action/index/IndexTransformResponse.kt
@@ -28,7 +28,8 @@ class IndexTransformResponse(
     val primaryTerm: Long,
     val status: RestStatus,
     val transform: Transform,
-) : ActionResponse(), ToXContentObject {
+) : ActionResponse(),
+    ToXContentObject {
     @Throws(IOException::class)
     constructor(sin: StreamInput) : this(
         id = sin.readString(),
@@ -50,13 +51,11 @@ class IndexTransformResponse(
     }
 
     @Throws(IOException::class)
-    override fun toXContent(builder: XContentBuilder, params: ToXContent.Params): XContentBuilder {
-        return builder.startObject()
-            .field(_ID, id)
-            .field(_VERSION, version)
-            .field(_SEQ_NO, seqNo)
-            .field(_PRIMARY_TERM, primaryTerm)
-            .field(TRANSFORM_TYPE, transform, XCONTENT_WITHOUT_TYPE_AND_USER)
-            .endObject()
-    }
+    override fun toXContent(builder: XContentBuilder, params: ToXContent.Params): XContentBuilder = builder.startObject()
+        .field(_ID, id)
+        .field(_VERSION, version)
+        .field(_SEQ_NO, seqNo)
+        .field(_PRIMARY_TERM, primaryTerm)
+        .field(TRANSFORM_TYPE, transform, XCONTENT_WITHOUT_TYPE_AND_USER)
+        .endObject()
 }

--- a/src/main/kotlin/org/opensearch/indexmanagement/transform/action/preview/PreviewTransformRequest.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/transform/action/preview/PreviewTransformRequest.kt
@@ -19,9 +19,7 @@ class PreviewTransformRequest(
         transform = Transform(sin),
     )
 
-    override fun validate(): ActionRequestValidationException? {
-        return null
-    }
+    override fun validate(): ActionRequestValidationException? = null
 
     @Throws(IOException::class)
     override fun writeTo(out: StreamOutput) {

--- a/src/main/kotlin/org/opensearch/indexmanagement/transform/action/preview/PreviewTransformResponse.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/transform/action/preview/PreviewTransformResponse.kt
@@ -16,7 +16,8 @@ import org.opensearch.core.xcontent.XContentBuilder
 class PreviewTransformResponse(
     val documents: List<Map<String, Any>>,
     val status: RestStatus,
-) : ActionResponse(), ToXContentObject {
+) : ActionResponse(),
+    ToXContentObject {
     constructor(sin: StreamInput) : this(
         documents =
         sin.let {
@@ -38,9 +39,7 @@ class PreviewTransformResponse(
         out.writeEnum(status)
     }
 
-    override fun toXContent(builder: XContentBuilder, params: ToXContent.Params): XContentBuilder {
-        return builder.startObject()
-            .field("documents", documents)
-            .endObject()
-    }
+    override fun toXContent(builder: XContentBuilder, params: ToXContent.Params): XContentBuilder = builder.startObject()
+        .field("documents", documents)
+        .endObject()
 }

--- a/src/main/kotlin/org/opensearch/indexmanagement/transform/model/ContinuousTransformStats.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/transform/model/ContinuousTransformStats.kt
@@ -20,7 +20,8 @@ import java.time.Instant
 data class ContinuousTransformStats(
     val lastTimestamp: Instant?,
     val documentsBehind: Map<String, Long>?,
-) : ToXContentObject, Writeable {
+) : ToXContentObject,
+    Writeable {
     @Throws(IOException::class)
     constructor(sin: StreamInput) : this(
         lastTimestamp = if (sin.readBoolean()) sin.readInstant() else null,

--- a/src/main/kotlin/org/opensearch/indexmanagement/transform/model/ExplainTransform.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/transform/model/ExplainTransform.kt
@@ -17,7 +17,8 @@ import java.io.IOException
 data class ExplainTransform(
     val metadataID: String? = null,
     val metadata: TransformMetadata? = null,
-) : ToXContentObject, Writeable {
+) : ToXContentObject,
+    Writeable {
     @Throws(IOException::class)
     constructor(sin: StreamInput) : this(
         metadataID = sin.readOptionalString(),
@@ -32,10 +33,8 @@ data class ExplainTransform(
     }
 
     @Throws(IOException::class)
-    override fun toXContent(builder: XContentBuilder, params: ToXContent.Params): XContentBuilder {
-        return builder.startObject()
-            .field(Transform.METADATA_ID_FIELD, metadataID)
-            .field(TransformMetadata.TRANSFORM_METADATA_TYPE, metadata, XCONTENT_WITHOUT_TYPE)
-            .endObject()
-    }
+    override fun toXContent(builder: XContentBuilder, params: ToXContent.Params): XContentBuilder = builder.startObject()
+        .field(Transform.METADATA_ID_FIELD, metadataID)
+        .field(TransformMetadata.TRANSFORM_METADATA_TYPE, metadata, XCONTENT_WITHOUT_TYPE)
+        .endObject()
 }

--- a/src/main/kotlin/org/opensearch/indexmanagement/transform/model/ISMTransform.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/transform/model/ISMTransform.kt
@@ -43,7 +43,8 @@ data class ISMTransform(
     val dataSelectionQuery: QueryBuilder = MatchAllQueryBuilder(),
     val groups: List<Dimension>,
     val aggregations: AggregatorFactories.Builder = AggregatorFactories.builder(),
-) : ToXContentObject, Writeable {
+) : ToXContentObject,
+    Writeable {
     init {
         require(pageSize in Transform.MINIMUM_PAGE_SIZE..Transform.MAXIMUM_PAGE_SIZE) {
             "Page size must be between ${Transform.MINIMUM_PAGE_SIZE} and ${Transform.MAXIMUM_PAGE_SIZE}"

--- a/src/main/kotlin/org/opensearch/indexmanagement/transform/model/Transform.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/transform/model/Transform.kt
@@ -71,7 +71,8 @@ data class Transform(
     val aggregations: AggregatorFactories.Builder = AggregatorFactories.builder(),
     val continuous: Boolean = false,
     val user: User? = null,
-) : ScheduledJobParameter, Writeable {
+) : ScheduledJobParameter,
+    Writeable {
     init {
         aggregations.aggregatorFactories.forEach {
             require(supportedAggregations.contains(it.type)) { "Unsupported aggregation [${it.type}]" }
@@ -168,19 +169,17 @@ data class Transform(
         user?.writeTo(out)
     }
 
-    fun convertToDoc(docCount: Long, includeId: Boolean = true): MutableMap<String, Any?> {
-        return if (includeId) {
-            mutableMapOf(
-                TRANSFORM_DOC_ID_FIELD to this.id,
-                DOC_COUNT to docCount,
-                TRANSFORM_DOC_COUNT_FIELD to docCount,
-            )
-        } else {
-            mutableMapOf(
-                DOC_COUNT to docCount,
-                TRANSFORM_DOC_COUNT_FIELD to docCount,
-            )
-        }
+    fun convertToDoc(docCount: Long, includeId: Boolean = true): MutableMap<String, Any?> = if (includeId) {
+        mutableMapOf(
+            TRANSFORM_DOC_ID_FIELD to this.id,
+            DOC_COUNT to docCount,
+            TRANSFORM_DOC_COUNT_FIELD to docCount,
+        )
+    } else {
+        mutableMapOf(
+            DOC_COUNT to docCount,
+            TRANSFORM_DOC_COUNT_FIELD to docCount,
+        )
     }
 
     suspend fun getContinuousStats(client: Client, metadata: TransformMetadata): ContinuousTransformStats? {

--- a/src/main/kotlin/org/opensearch/indexmanagement/transform/model/TransformMetadata.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/transform/model/TransformMetadata.kt
@@ -34,7 +34,8 @@ data class TransformMetadata(
     val stats: TransformStats,
     val shardIDToGlobalCheckpoint: Map<ShardId, Long>? = null,
     val continuousStats: ContinuousTransformStats? = null,
-) : ToXContentObject, Writeable {
+) : ToXContentObject,
+    Writeable {
     enum class Status(val type: String) {
         INIT("init"),
         STARTED("started"),
@@ -43,9 +44,7 @@ data class TransformMetadata(
         FAILED("failed"),
         ;
 
-        override fun toString(): String {
-            return type
-        }
+        override fun toString(): String = type
     }
 
     @Throws(IOException::class)
@@ -98,18 +97,16 @@ data class TransformMetadata(
         continuousStats?.let { it.writeTo(out) }
     }
 
-    fun mergeStats(stats: TransformStats): TransformMetadata {
-        return this.copy(
-            stats =
-            this.stats.copy(
-                pagesProcessed = this.stats.pagesProcessed + stats.pagesProcessed,
-                documentsIndexed = this.stats.documentsIndexed + stats.documentsIndexed,
-                documentsProcessed = this.stats.documentsProcessed + stats.documentsProcessed,
-                indexTimeInMillis = this.stats.indexTimeInMillis + stats.indexTimeInMillis,
-                searchTimeInMillis = this.stats.searchTimeInMillis + stats.searchTimeInMillis,
-            ),
-        )
-    }
+    fun mergeStats(stats: TransformStats): TransformMetadata = this.copy(
+        stats =
+        this.stats.copy(
+            pagesProcessed = this.stats.pagesProcessed + stats.pagesProcessed,
+            documentsIndexed = this.stats.documentsIndexed + stats.documentsIndexed,
+            documentsProcessed = this.stats.documentsProcessed + stats.documentsProcessed,
+            indexTimeInMillis = this.stats.indexTimeInMillis + stats.indexTimeInMillis,
+            searchTimeInMillis = this.stats.searchTimeInMillis + stats.searchTimeInMillis,
+        ),
+    )
 
     companion object {
         const val TRANSFORM_METADATA_TYPE = "transform_metadata"

--- a/src/main/kotlin/org/opensearch/indexmanagement/transform/model/TransformStats.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/transform/model/TransformStats.kt
@@ -21,7 +21,8 @@ data class TransformStats(
     val documentsIndexed: Long,
     val indexTimeInMillis: Long,
     val searchTimeInMillis: Long,
-) : ToXContentObject, Writeable {
+) : ToXContentObject,
+    Writeable {
     @Throws(IOException::class)
     constructor(sin: StreamInput) : this(
         pagesProcessed = sin.readLong(),
@@ -31,15 +32,13 @@ data class TransformStats(
         searchTimeInMillis = sin.readLong(),
     )
 
-    override fun toXContent(builder: XContentBuilder, params: ToXContent.Params): XContentBuilder {
-        return builder.startObject()
-            .field(PAGES_PROCESSED_FIELD, pagesProcessed)
-            .field(DOCUMENTS_PROCESSED_FIELD, documentsProcessed)
-            .field(DOCUMENTS_INDEXED_FIELD, documentsIndexed)
-            .field(INDEX_TIME_IN_MILLIS_FIELD, indexTimeInMillis)
-            .field(SEARCH_TIME_IN_MILLIS_FIELD, searchTimeInMillis)
-            .endObject()
-    }
+    override fun toXContent(builder: XContentBuilder, params: ToXContent.Params): XContentBuilder = builder.startObject()
+        .field(PAGES_PROCESSED_FIELD, pagesProcessed)
+        .field(DOCUMENTS_PROCESSED_FIELD, documentsProcessed)
+        .field(DOCUMENTS_INDEXED_FIELD, documentsIndexed)
+        .field(INDEX_TIME_IN_MILLIS_FIELD, indexTimeInMillis)
+        .field(SEARCH_TIME_IN_MILLIS_FIELD, searchTimeInMillis)
+        .endObject()
 
     override fun writeTo(out: StreamOutput) {
         out.writeLong(pagesProcessed)

--- a/src/main/kotlin/org/opensearch/indexmanagement/transform/resthandler/RestDeleteTransformAction.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/transform/resthandler/RestDeleteTransformAction.kt
@@ -20,11 +20,9 @@ import org.opensearch.rest.action.RestToXContentListener
 import java.io.IOException
 
 class RestDeleteTransformAction : BaseRestHandler() {
-    override fun routes(): List<RestHandler.Route> {
-        return listOf(
-            Route(DELETE, "$TRANSFORM_BASE_URI/{transformID}"),
-        )
-    }
+    override fun routes(): List<RestHandler.Route> = listOf(
+        Route(DELETE, "$TRANSFORM_BASE_URI/{transformID}"),
+    )
 
     override fun getName(): String = "opendistro_delete_transform_action"
 

--- a/src/main/kotlin/org/opensearch/indexmanagement/transform/resthandler/RestExplainTransformAction.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/transform/resthandler/RestExplainTransformAction.kt
@@ -18,9 +18,7 @@ import org.opensearch.rest.RestRequest.Method.GET
 import org.opensearch.rest.action.RestToXContentListener
 
 class RestExplainTransformAction : BaseRestHandler() {
-    override fun routes(): List<Route> {
-        return listOf(Route(GET, "$TRANSFORM_BASE_URI/{transformID}/_explain"))
-    }
+    override fun routes(): List<Route> = listOf(Route(GET, "$TRANSFORM_BASE_URI/{transformID}/_explain"))
 
     override fun getName(): String = "opendistro_explain_transform_action"
 

--- a/src/main/kotlin/org/opensearch/indexmanagement/transform/resthandler/RestGetTransformAction.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/transform/resthandler/RestGetTransformAction.kt
@@ -26,17 +26,13 @@ import org.opensearch.rest.action.RestToXContentListener
 import org.opensearch.search.fetch.subphase.FetchSourceContext
 
 class RestGetTransformAction : BaseRestHandler() {
-    override fun routes(): List<Route> {
-        return listOf(
-            Route(GET, TRANSFORM_BASE_URI),
-            Route(GET, "$TRANSFORM_BASE_URI/{transformID}"),
-            Route(HEAD, "$TRANSFORM_BASE_URI/{transformID}"),
-        )
-    }
+    override fun routes(): List<Route> = listOf(
+        Route(GET, TRANSFORM_BASE_URI),
+        Route(GET, "$TRANSFORM_BASE_URI/{transformID}"),
+        Route(HEAD, "$TRANSFORM_BASE_URI/{transformID}"),
+    )
 
-    override fun getName(): String {
-        return "opendistro_get_transform_action"
-    }
+    override fun getName(): String = "opendistro_get_transform_action"
 
     override fun prepareRequest(request: RestRequest, client: NodeClient): RestChannelConsumer {
         val transformID = request.param("transformID")

--- a/src/main/kotlin/org/opensearch/indexmanagement/transform/resthandler/RestIndexTransformAction.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/transform/resthandler/RestIndexTransformAction.kt
@@ -33,16 +33,12 @@ import java.io.IOException
 import java.time.Instant
 
 class RestIndexTransformAction : BaseRestHandler() {
-    override fun routes(): List<RestHandler.Route> {
-        return listOf(
-            RestHandler.Route(PUT, TRANSFORM_BASE_URI),
-            RestHandler.Route(PUT, "$TRANSFORM_BASE_URI/{transformID}"),
-        )
-    }
+    override fun routes(): List<RestHandler.Route> = listOf(
+        RestHandler.Route(PUT, TRANSFORM_BASE_URI),
+        RestHandler.Route(PUT, "$TRANSFORM_BASE_URI/{transformID}"),
+    )
 
-    override fun getName(): String {
-        return "opendistro_index_transform_action"
-    }
+    override fun getName(): String = "opendistro_index_transform_action"
 
     @Throws(IOException::class)
     override fun prepareRequest(request: RestRequest, client: NodeClient): RestChannelConsumer {

--- a/src/main/kotlin/org/opensearch/indexmanagement/transform/resthandler/RestPreviewTransformAction.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/transform/resthandler/RestPreviewTransformAction.kt
@@ -19,16 +19,12 @@ import org.opensearch.rest.RestRequest.Method.POST
 import org.opensearch.rest.action.RestToXContentListener
 
 class RestPreviewTransformAction : BaseRestHandler() {
-    override fun routes(): List<RestHandler.Route> {
-        return listOf(
-            RestHandler.Route(POST, TRANSFORM_BASE_URI),
-            RestHandler.Route(POST, "$TRANSFORM_BASE_URI/_preview"),
-        )
-    }
+    override fun routes(): List<RestHandler.Route> = listOf(
+        RestHandler.Route(POST, TRANSFORM_BASE_URI),
+        RestHandler.Route(POST, "$TRANSFORM_BASE_URI/_preview"),
+    )
 
-    override fun getName(): String {
-        return "opendistro_preview_transform_action"
-    }
+    override fun getName(): String = "opendistro_preview_transform_action"
 
     override fun prepareRequest(request: RestRequest, client: NodeClient): RestChannelConsumer {
         val xcp = request.contentParser()

--- a/src/main/kotlin/org/opensearch/indexmanagement/transform/resthandler/RestStartTransformAction.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/transform/resthandler/RestStartTransformAction.kt
@@ -19,15 +19,11 @@ import org.opensearch.rest.action.RestToXContentListener
 import java.io.IOException
 
 class RestStartTransformAction : BaseRestHandler() {
-    override fun routes(): List<Route> {
-        return listOf(
-            Route(POST, "$TRANSFORM_BASE_URI/{transformID}/_start"),
-        )
-    }
+    override fun routes(): List<Route> = listOf(
+        Route(POST, "$TRANSFORM_BASE_URI/{transformID}/_start"),
+    )
 
-    override fun getName(): String {
-        return "opendistro_start_transform_action"
-    }
+    override fun getName(): String = "opendistro_start_transform_action"
 
     @Throws(IOException::class)
     override fun prepareRequest(request: RestRequest, client: NodeClient): RestChannelConsumer {

--- a/src/main/kotlin/org/opensearch/indexmanagement/transform/resthandler/RestStopTransformAction.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/transform/resthandler/RestStopTransformAction.kt
@@ -19,15 +19,11 @@ import org.opensearch.rest.action.RestToXContentListener
 import java.io.IOException
 
 class RestStopTransformAction : BaseRestHandler() {
-    override fun routes(): List<Route> {
-        return listOf(
-            Route(POST, "$TRANSFORM_BASE_URI/{transformID}/_stop"),
-        )
-    }
+    override fun routes(): List<Route> = listOf(
+        Route(POST, "$TRANSFORM_BASE_URI/{transformID}/_stop"),
+    )
 
-    override fun getName(): String {
-        return "opendistro_stop_transform_action"
-    }
+    override fun getName(): String = "opendistro_stop_transform_action"
 
     @Throws(IOException::class)
     override fun prepareRequest(request: RestRequest, client: NodeClient): RestChannelConsumer {

--- a/src/main/kotlin/org/opensearch/indexmanagement/util/IndexManagementException.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/util/IndexManagementException.kt
@@ -14,9 +14,7 @@ import org.opensearch.index.IndexNotFoundException
 import java.lang.IllegalArgumentException
 
 class IndexManagementException(message: String, val status: RestStatus, ex: Exception) : OpenSearchException(message, ex) {
-    override fun status(): RestStatus {
-        return status
-    }
+    override fun status(): RestStatus = status
 
     companion object {
         @JvmStatic

--- a/src/main/kotlin/org/opensearch/indexmanagement/util/IndexUtils.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/util/IndexUtils.kt
@@ -27,6 +27,7 @@ import java.util.Base64
 class IndexUtils {
     companion object {
         @Suppress("ObjectPropertyNaming")
+        @Suppress("ktlint:standard:backing-property-naming")
         const val _META = "_meta"
         const val PROPERTIES = "properties"
         const val FIELDS = "fields"
@@ -196,13 +197,9 @@ class IndexUtils {
             return Base64.getUrlEncoder().withoutPadding().encodeToString(byteArray)
         }
 
-        fun isDataStream(name: String?, clusterState: ClusterState): Boolean {
-            return clusterState.metadata.dataStreams().containsKey(name)
-        }
+        fun isDataStream(name: String?, clusterState: ClusterState): Boolean = clusterState.metadata.dataStreams().containsKey(name)
 
-        fun isAlias(indexName: String?, clusterState: ClusterState): Boolean {
-            return clusterState.metadata.hasAlias(indexName)
-        }
+        fun isAlias(indexName: String?, clusterState: ClusterState): Boolean = clusterState.metadata.hasAlias(indexName)
 
         fun getWriteIndex(indexName: String?, clusterState: ClusterState): String? {
             if (isAlias(indexName, clusterState) || isDataStream(indexName, clusterState)) {
@@ -233,9 +230,7 @@ class IndexUtils {
             return newestIndex
         }
 
-        fun isConcreteIndex(indexName: String?, clusterState: ClusterState): Boolean {
-            return clusterState.metadata
-                .indicesLookup[indexName]!!.type == IndexAbstraction.Type.CONCRETE_INDEX
-        }
+        fun isConcreteIndex(indexName: String?, clusterState: ClusterState): Boolean = clusterState.metadata
+            .indicesLookup[indexName]!!.type == IndexAbstraction.Type.CONCRETE_INDEX
     }
 }

--- a/src/main/kotlin/org/opensearch/indexmanagement/util/IndexUtils.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/util/IndexUtils.kt
@@ -26,8 +26,7 @@ import java.util.Base64
 @Suppress("UtilityClassWithPublicConstructor", "TooManyFunctions")
 class IndexUtils {
     companion object {
-        @Suppress("ObjectPropertyNaming")
-        @Suppress("ktlint:standard:backing-property-naming")
+        @Suppress("ObjectPropertyNaming", "ktlint:standard:backing-property-naming")
         const val _META = "_meta"
         const val PROPERTIES = "properties"
         const val FIELDS = "fields"

--- a/src/main/kotlin/org/opensearch/indexmanagement/util/RestHandlerUtils.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/util/RestHandlerUtils.kt
@@ -4,6 +4,7 @@
  */
 
 @file:Suppress("TopLevelPropertyNaming", "MatchingDeclarationName")
+@file:Suppress("ktlint:standard:backing-property-naming")
 
 package org.opensearch.indexmanagement.util
 

--- a/src/main/kotlin/org/opensearch/indexmanagement/util/RestHandlerUtils.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/util/RestHandlerUtils.kt
@@ -3,8 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-@file:Suppress("TopLevelPropertyNaming", "MatchingDeclarationName")
-@file:Suppress("ktlint:standard:backing-property-naming")
+@file:Suppress("TopLevelPropertyNaming", "MatchingDeclarationName", "ktlint:standard:backing-property-naming")
 
 package org.opensearch.indexmanagement.util
 

--- a/src/main/kotlin/org/opensearch/indexmanagement/util/ScheduledJobUtils.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/util/ScheduledJobUtils.kt
@@ -73,29 +73,23 @@ private fun populateResponse(
     jobs: List<Any>,
     status: RestStatus,
     totalJobs: Int,
-): ActionResponse {
-    return when (jobType) {
-        Rollup.ROLLUP_TYPE -> GetRollupsResponse(jobs as List<Rollup>, totalJobs, status)
-        Transform.TRANSFORM_TYPE -> GetTransformsResponse(jobs as List<Transform>, totalJobs, status)
-        else -> {
-            throw OpenSearchStatusException("Unknown scheduled job type", RestStatus.INTERNAL_SERVER_ERROR)
-        }
+): ActionResponse = when (jobType) {
+    Rollup.ROLLUP_TYPE -> GetRollupsResponse(jobs as List<Rollup>, totalJobs, status)
+    Transform.TRANSFORM_TYPE -> GetTransformsResponse(jobs as List<Transform>, totalJobs, status)
+    else -> {
+        throw OpenSearchStatusException("Unknown scheduled job type", RestStatus.INTERNAL_SERVER_ERROR)
     }
 }
 
-private fun getParser(jobType: String): (XContentParser, String, Long, Long) -> Any {
-    return when (jobType) {
-        Transform.TRANSFORM_TYPE -> Transform.Companion::parse
-        Rollup.ROLLUP_TYPE -> Rollup.Companion::parse
-        else -> {
-            throw OpenSearchStatusException("Unknown scheduled job type", RestStatus.INTERNAL_SERVER_ERROR)
-        }
+private fun getParser(jobType: String): (XContentParser, String, Long, Long) -> Any = when (jobType) {
+    Transform.TRANSFORM_TYPE -> Transform.Companion::parse
+    Rollup.ROLLUP_TYPE -> Rollup.Companion::parse
+    else -> {
+        throw OpenSearchStatusException("Unknown scheduled job type", RestStatus.INTERNAL_SERVER_ERROR)
     }
 }
 
-private fun contentParser(bytesReference: BytesReference): XContentParser {
-    return XContentHelper.createParser(
-        NamedXContentRegistry.EMPTY,
-        LoggingDeprecationHandler.INSTANCE, bytesReference, XContentType.JSON,
-    )
-}
+private fun contentParser(bytesReference: BytesReference): XContentParser = XContentHelper.createParser(
+    NamedXContentRegistry.EMPTY,
+    LoggingDeprecationHandler.INSTANCE, bytesReference, XContentType.JSON,
+)

--- a/src/test/kotlin/org/opensearch/indexmanagement/IndexManagementRestTestCase.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/IndexManagementRestTestCase.kt
@@ -92,9 +92,7 @@ abstract class IndexManagementRestTestCase : ODFERestTestCase() {
 
     protected val isLocalTest = clusterName() == "integTest"
 
-    private fun clusterName(): String {
-        return System.getProperty("tests.clustername")
-    }
+    private fun clusterName(): String = System.getProperty("tests.clustername")
 
     fun Response.asMap(): Map<String, Any> = entityAsMap(this)
 

--- a/src/test/kotlin/org/opensearch/indexmanagement/IndexStateManagementSecurityBehaviorIT.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/IndexStateManagementSecurityBehaviorIT.kt
@@ -259,35 +259,33 @@ class IndexStateManagementSecurityBehaviorIT : SecurityRestTestCase() {
         return policy
     }
 
-    private fun createISMRollup(targetIdxRollup: String): ISMRollup {
-        return ISMRollup(
-            description = "basic search test",
-            targetIndex = targetIdxRollup,
-            pageSize = 100,
-            dimensions =
-            listOf(
-                DateHistogram(sourceField = "tpep_pickup_datetime", fixedInterval = "1h"),
-                Terms("RatecodeID", "RatecodeID"),
-                Terms("PULocationID", "PULocationID"),
-            ),
-            metrics =
-            listOf(
-                RollupMetrics(
-                    sourceField = "passenger_count", targetField = "passenger_count",
-                    metrics =
-                    listOf(
-                        Sum(), Min(), Max(),
-                        ValueCount(), Average(),
-                    ),
-                ),
-                RollupMetrics(
-                    sourceField = "total_amount",
-                    targetField = "total_amount",
-                    metrics = listOf(Max(), Min()),
+    private fun createISMRollup(targetIdxRollup: String): ISMRollup = ISMRollup(
+        description = "basic search test",
+        targetIndex = targetIdxRollup,
+        pageSize = 100,
+        dimensions =
+        listOf(
+            DateHistogram(sourceField = "tpep_pickup_datetime", fixedInterval = "1h"),
+            Terms("RatecodeID", "RatecodeID"),
+            Terms("PULocationID", "PULocationID"),
+        ),
+        metrics =
+        listOf(
+            RollupMetrics(
+                sourceField = "passenger_count", targetField = "passenger_count",
+                metrics =
+                listOf(
+                    Sum(), Min(), Max(),
+                    ValueCount(), Average(),
                 ),
             ),
-        )
-    }
+            RollupMetrics(
+                sourceField = "total_amount",
+                targetField = "total_amount",
+                metrics = listOf(Max(), Min()),
+            ),
+        ),
+    )
 
     private fun assertIndexRolledUp(indexName: String, policyId: String, ismRollup: ISMRollup) {
         val rollup = ismRollup.toRollup(indexName)

--- a/src/test/kotlin/org/opensearch/indexmanagement/ODFERestTestCase.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/ODFERestTestCase.kt
@@ -37,16 +37,14 @@ abstract class ODFERestTestCase : OpenSearchRestTestCase() {
         return mockSecureSettings
     }
 
-    override fun restAdminSettings(): Settings {
-        return Settings
-            .builder()
-            .put("http.port", 9200)
-            .put(OPENSEARCH_SECURITY_SSL_HTTP_ENABLED, isHttps())
-            .put(OPENSEARCH_SECURITY_SSL_HTTP_PEMCERT_FILEPATH, "sample.pem")
-            .put(OPENSEARCH_SECURITY_SSL_HTTP_KEYSTORE_FILEPATH, "test-kirk.jks")
-            .setSecureSettings(createSecureSettings())
-            .build()
-    }
+    override fun restAdminSettings(): Settings = Settings
+        .builder()
+        .put("http.port", 9200)
+        .put(OPENSEARCH_SECURITY_SSL_HTTP_ENABLED, isHttps())
+        .put(OPENSEARCH_SECURITY_SSL_HTTP_PEMCERT_FILEPATH, "sample.pem")
+        .put(OPENSEARCH_SECURITY_SSL_HTTP_KEYSTORE_FILEPATH, "test-kirk.jks")
+        .setSecureSettings(createSecureSettings())
+        .build()
 
     @Throws(IOException::class)
     override fun buildClient(settings: Settings, hosts: Array<HttpHost>): RestClient {

--- a/src/test/kotlin/org/opensearch/indexmanagement/SecurityRestTestCase.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/SecurityRestTestCase.kt
@@ -95,13 +95,9 @@ abstract class SecurityRestTestCase : IndexManagementRestTestCase() {
             shards: String? = null,
             mapping: String = "",
             settings: Settings? = null,
-        ): Pair<String, String?> {
-            return super.createIndex(index, policyID, alias, replicas, shards, mapping, settings)
-        }
+        ): Pair<String, String?> = super.createIndex(index, policyID, alias, replicas, shards, mapping, settings)
 
-        fun getExplainManagedIndexMetaDataExt(indexName: String, userClient: RestClient? = null): ManagedIndexMetaData {
-            return super.getExplainManagedIndexMetaData(indexName, userClient)
-        }
+        fun getExplainManagedIndexMetaDataExt(indexName: String, userClient: RestClient? = null): ManagedIndexMetaData = super.getExplainManagedIndexMetaData(indexName, userClient)
     }
 
     private object TransformRestTestCaseExt : TransformRestTestCase() {
@@ -142,9 +138,7 @@ abstract class SecurityRestTestCase : IndexManagementRestTestCase() {
     protected fun createRollup(
         rollup: Rollup,
         client: RestClient,
-    ): Rollup {
-        return RollupRestTestCaseSecurityExtension.createRollupExt(rollup, rollup.id, true, client)
-    }
+    ): Rollup = RollupRestTestCaseSecurityExtension.createRollupExt(rollup, rollup.id, true, client)
 
     protected fun createRollupAndCheckStatus(
         rollup: Rollup,
@@ -160,16 +154,12 @@ abstract class SecurityRestTestCase : IndexManagementRestTestCase() {
         metadataId: String,
         refresh: Boolean = true,
         header: BasicHeader = BasicHeader(HttpHeaders.CONTENT_TYPE, "application/json"),
-    ): RollupMetadata {
-        return RollupRestTestCaseSecurityExtension.getRollupMetadataExt(metadataId, refresh, header)
-    }
+    ): RollupMetadata = RollupRestTestCaseSecurityExtension.getRollupMetadataExt(metadataId, refresh, header)
 
     protected fun getRollup(
         rollupId: String,
         header: BasicHeader = BasicHeader(HttpHeaders.CONTENT_TYPE, "application/json"),
-    ): Rollup {
-        return RollupRestTestCaseSecurityExtension.getRollupExt(rollupId, header)
-    }
+    ): Rollup = RollupRestTestCaseSecurityExtension.getRollupExt(rollupId, header)
 
     protected fun deleteRollup(rollupId: String, client: RestClient, expectedStatus: RestStatus) {
         val request = Request(RestRequest.Method.DELETE.name, "${IndexManagementPlugin.ROLLUP_JOBS_BASE_URI}/$rollupId")
@@ -184,22 +174,16 @@ abstract class SecurityRestTestCase : IndexManagementRestTestCase() {
         RollupRestTestCaseSecurityExtension.putDateDocumentInSourceIndexExt(rollup)
     }
 
-    private fun createRollupMappingString(rollup: Rollup): String {
-        return RollupRestTestCaseSecurityExtension.createRollupMappingStringExt(rollup)
-    }
+    private fun createRollupMappingString(rollup: Rollup): String = RollupRestTestCaseSecurityExtension.createRollupMappingStringExt(rollup)
 
-    protected fun updateManagedIndexConfigStartTime(update: ManagedIndexConfig, desiredStartTimeMillis: Long? = null, retryOnConflict: Int = 0) {
-        return IndexStateManagementRestTestCaseExt.updateManagedIndexConfigStartTimeExt(update, desiredStartTimeMillis, retryOnConflict)
-    }
+    protected fun updateManagedIndexConfigStartTime(update: ManagedIndexConfig, desiredStartTimeMillis: Long? = null, retryOnConflict: Int = 0) = IndexStateManagementRestTestCaseExt.updateManagedIndexConfigStartTimeExt(update, desiredStartTimeMillis, retryOnConflict)
 
     protected fun createPolicy(
         policy: Policy,
         policyId: String = OpenSearchTestCase.randomAlphaOfLength(10),
         refresh: Boolean = true,
         client: RestClient?,
-    ): Policy {
-        return IndexStateManagementRestTestCaseExt.createPolicyExt(policy, policyId, refresh, client)
-    }
+    ): Policy = IndexStateManagementRestTestCaseExt.createPolicyExt(policy, policyId, refresh, client)
 
     protected fun managedIndexExplainAllAsMap(
         client: RestClient?,
@@ -215,9 +199,7 @@ abstract class SecurityRestTestCase : IndexManagementRestTestCase() {
         policyId: String,
         refresh: Boolean = true,
         client: RestClient,
-    ): Response {
-        return IndexStateManagementRestTestCaseExt.createPolicyJsonExt(policyString, policyId, refresh, client)
-    }
+    ): Response = IndexStateManagementRestTestCaseExt.createPolicyJsonExt(policyString, policyId, refresh, client)
 
     protected fun deletePolicy(policyId: String, client: RestClient, expectedStatus: RestStatus) {
         val request = Request("DELETE", "${IndexManagementPlugin.POLICY_BASE_URI}/$policyId")
@@ -236,9 +218,7 @@ abstract class SecurityRestTestCase : IndexManagementRestTestCase() {
         executeRequest(request, expectedStatus, client)
     }
 
-    protected fun getExplainManagedIndexMetaData(indexName: String, userClient: RestClient? = null): ManagedIndexMetaData {
-        return IndexStateManagementRestTestCaseExt.getExplainManagedIndexMetaDataExt(indexName, userClient)
-    }
+    protected fun getExplainManagedIndexMetaData(indexName: String, userClient: RestClient? = null): ManagedIndexMetaData = IndexStateManagementRestTestCaseExt.getExplainManagedIndexMetaDataExt(indexName, userClient)
 
     protected fun createIndex(indexName: String, sourceIndexMappingString: String?, client: RestClient) {
         val waitForActiveShards = if (isMultiNode) "all" else "1"
@@ -269,9 +249,7 @@ abstract class SecurityRestTestCase : IndexManagementRestTestCase() {
         shards: String? = null,
         mapping: String = "",
         settings: Settings? = null,
-    ): Pair<String, String?> {
-        return IndexStateManagementRestTestCaseExt.createIndexExt(index, policyID, alias, replicas, shards, mapping, settings)
-    }
+    ): Pair<String, String?> = IndexStateManagementRestTestCaseExt.createIndexExt(index, policyID, alias, replicas, shards, mapping, settings)
 
     protected fun checkPolicies(
         userClient: RestClient,
@@ -502,8 +480,7 @@ abstract class SecurityRestTestCase : IndexManagementRestTestCase() {
         }
     }
 
-    protected fun createReplicaCountTestPolicyRequest(priority: Int, indexPattern: String?): String {
-        return """
+    protected fun createReplicaCountTestPolicyRequest(priority: Int, indexPattern: String?): String = """
             {
                 "policy": {
                     "description": "test policy",
@@ -527,8 +504,7 @@ abstract class SecurityRestTestCase : IndexManagementRestTestCase() {
                     }
                 }
             }
-        """.trimIndent()
-    }
+    """.trimIndent()
 
     companion object {
         const val AIRLINE_POLICY = "airline-policy"

--- a/src/test/kotlin/org/opensearch/indexmanagement/TestHelpers.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/TestHelpers.kt
@@ -56,9 +56,7 @@ private fun randomStringList(): List<String> {
     return data
 }
 
-fun randomUser(): User {
-    return User(OpenSearchRestTestCase.randomAlphaOfLength(10), randomStringList(), randomStringList(), randomStringList())
-}
+fun randomUser(): User = User(OpenSearchRestTestCase.randomAlphaOfLength(10), randomStringList(), randomStringList(), randomStringList())
 
 /**
 * Wrapper for [RestClient.performRequest] which was deprecated in ES 6.5 and is used in tests. This provides

--- a/src/test/kotlin/org/opensearch/indexmanagement/TransformSecurityBehaviorIT.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/TransformSecurityBehaviorIT.kt
@@ -270,26 +270,24 @@ class TransformSecurityBehaviorIT : SecurityRestTestCase() {
     private fun createSimpleTransform(
         sourceIndex: String,
         targetIndex: String,
-    ): Transform {
-        return Transform(
-            id = "id_1",
-            schemaVersion = 1L,
-            enabled = true,
-            enabledAt = Instant.now(),
-            updatedAt = Instant.now(),
-            jobSchedule = IntervalSchedule(Instant.now(), 1, ChronoUnit.MINUTES),
-            description = "test transform",
-            metadataId = null,
-            sourceIndex = sourceIndex,
-            targetIndex = targetIndex,
-            roles = emptyList(),
-            pageSize = 100,
-            groups =
-            listOf(
-                Terms(sourceField = "store_and_fwd_flag", targetField = "flag"),
-            ),
-        )
-    }
+    ): Transform = Transform(
+        id = "id_1",
+        schemaVersion = 1L,
+        enabled = true,
+        enabledAt = Instant.now(),
+        updatedAt = Instant.now(),
+        jobSchedule = IntervalSchedule(Instant.now(), 1, ChronoUnit.MINUTES),
+        description = "test transform",
+        metadataId = null,
+        sourceIndex = sourceIndex,
+        targetIndex = targetIndex,
+        roles = emptyList(),
+        pageSize = 100,
+        groups =
+        listOf(
+            Terms(sourceField = "store_and_fwd_flag", targetField = "flag"),
+        ),
+    )
 
     private fun createTestUserWithRole(clusterPermissions: List<String>, indexPermissions: List<String>) {
         val testBackendRole = testRole + "_backend"

--- a/src/test/kotlin/org/opensearch/indexmanagement/bwc/ISMBackwardsCompatibilityIT.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/bwc/ISMBackwardsCompatibilityIT.kt
@@ -25,29 +25,25 @@ class ISMBackwardsCompatibilityIT : IndexStateManagementRestTestCase() {
         ;
 
         companion object {
-            fun parse(value: String): ClusterType {
-                return when (value) {
-                    "old_cluster" -> OLD
-                    "mixed_cluster" -> MIXED
-                    "upgraded_cluster" -> UPGRADED
-                    else -> throw AssertionError("Unknown cluster type: $value")
-                }
+            fun parse(value: String): ClusterType = when (value) {
+                "old_cluster" -> OLD
+                "mixed_cluster" -> MIXED
+                "upgraded_cluster" -> UPGRADED
+                else -> throw AssertionError("Unknown cluster type: $value")
             }
         }
     }
 
-    private fun getPluginUri(): String {
-        return when (CLUSTER_TYPE) {
-            ClusterType.OLD -> "_nodes/$CLUSTER_NAME-0/plugins"
-            ClusterType.MIXED -> {
-                when (System.getProperty("tests.rest.bwcsuite_round")) {
-                    "second" -> "_nodes/$CLUSTER_NAME-1/plugins"
-                    "third" -> "_nodes/$CLUSTER_NAME-2/plugins"
-                    else -> "_nodes/$CLUSTER_NAME-0/plugins"
-                }
+    private fun getPluginUri(): String = when (CLUSTER_TYPE) {
+        ClusterType.OLD -> "_nodes/$CLUSTER_NAME-0/plugins"
+        ClusterType.MIXED -> {
+            when (System.getProperty("tests.rest.bwcsuite_round")) {
+                "second" -> "_nodes/$CLUSTER_NAME-1/plugins"
+                "third" -> "_nodes/$CLUSTER_NAME-2/plugins"
+                else -> "_nodes/$CLUSTER_NAME-0/plugins"
             }
-            ClusterType.UPGRADED -> "_nodes/plugins"
         }
+        ClusterType.UPGRADED -> "_nodes/plugins"
     }
 
     companion object {
@@ -61,15 +57,13 @@ class ISMBackwardsCompatibilityIT : IndexStateManagementRestTestCase() {
 
     override fun preserveTemplatesUponCompletion(): Boolean = true
 
-    override fun restClientSettings(): Settings {
-        return Settings.builder()
-            .put(super.restClientSettings())
-            // increase the timeout here to 90 seconds to handle long waits for a green
-            // cluster health. the waits for green need to be longer than a minute to
-            // account for delayed shards
-            .put(CLIENT_SOCKET_TIMEOUT, "90s")
-            .build()
-    }
+    override fun restClientSettings(): Settings = Settings.builder()
+        .put(super.restClientSettings())
+        // increase the timeout here to 90 seconds to handle long waits for a green
+        // cluster health. the waits for green need to be longer than a minute to
+        // account for delayed shards
+        .put(CLIENT_SOCKET_TIMEOUT, "90s")
+        .build()
 
     @Throws(Exception::class)
     @Suppress("UNCHECKED_CAST")

--- a/src/test/kotlin/org/opensearch/indexmanagement/bwc/IndexManagementBackwardsCompatibilityIT.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/bwc/IndexManagementBackwardsCompatibilityIT.kt
@@ -36,15 +36,13 @@ class IndexManagementBackwardsCompatibilityIT : IndexManagementRestTestCase() {
 
     override fun preserveTemplatesUponCompletion(): Boolean = true
 
-    override fun restClientSettings(): Settings {
-        return Settings.builder()
-            .put(super.restClientSettings())
-            // increase the timeout here to 90 seconds to handle long waits for a green
-            // cluster health. the waits for green need to be longer than a minute to
-            // account for delayed shards
-            .put(CLIENT_SOCKET_TIMEOUT, "90s")
-            .build()
-    }
+    override fun restClientSettings(): Settings = Settings.builder()
+        .put(super.restClientSettings())
+        // increase the timeout here to 90 seconds to handle long waits for a green
+        // cluster health. the waits for green need to be longer than a minute to
+        // account for delayed shards
+        .put(CLIENT_SOCKET_TIMEOUT, "90s")
+        .build()
 
     @Throws(Exception::class)
     @Suppress("UNCHECKED_CAST")
@@ -85,29 +83,25 @@ class IndexManagementBackwardsCompatibilityIT : IndexManagementRestTestCase() {
         ;
 
         companion object {
-            fun parse(value: String): ClusterType {
-                return when (value) {
-                    "old_cluster" -> OLD
-                    "mixed_cluster" -> MIXED
-                    "upgraded_cluster" -> UPGRADED
-                    else -> throw AssertionError("Unknown cluster type: $value")
-                }
+            fun parse(value: String): ClusterType = when (value) {
+                "old_cluster" -> OLD
+                "mixed_cluster" -> MIXED
+                "upgraded_cluster" -> UPGRADED
+                else -> throw AssertionError("Unknown cluster type: $value")
             }
         }
     }
 
-    private fun getPluginUri(): String {
-        return when (CLUSTER_TYPE) {
-            ClusterType.OLD -> "_nodes/$CLUSTER_NAME-0/plugins"
-            ClusterType.MIXED -> {
-                when (System.getProperty("tests.rest.bwcsuite_round")) {
-                    "second" -> "_nodes/$CLUSTER_NAME-1/plugins"
-                    "third" -> "_nodes/$CLUSTER_NAME-2/plugins"
-                    else -> "_nodes/$CLUSTER_NAME-0/plugins"
-                }
+    private fun getPluginUri(): String = when (CLUSTER_TYPE) {
+        ClusterType.OLD -> "_nodes/$CLUSTER_NAME-0/plugins"
+        ClusterType.MIXED -> {
+            when (System.getProperty("tests.rest.bwcsuite_round")) {
+                "second" -> "_nodes/$CLUSTER_NAME-1/plugins"
+                "third" -> "_nodes/$CLUSTER_NAME-2/plugins"
+                else -> "_nodes/$CLUSTER_NAME-0/plugins"
             }
-            ClusterType.UPGRADED -> "_nodes/plugins"
         }
+        ClusterType.UPGRADED -> "_nodes/plugins"
     }
 
     @Throws(Exception::class)

--- a/src/test/kotlin/org/opensearch/indexmanagement/controlcenter/notification/SerializationTests.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/controlcenter/notification/SerializationTests.kt
@@ -74,7 +74,5 @@ class SerializationTests : OpenSearchTestCase() {
 
     private fun buildMessage(
         itemType: String,
-    ): String {
-        return "$itemType serialization test failed. "
-    }
+    ): String = "$itemType serialization test failed. "
 }

--- a/src/test/kotlin/org/opensearch/indexmanagement/controlcenter/notification/TestHelpers.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/controlcenter/notification/TestHelpers.kt
@@ -62,20 +62,14 @@ fun randomLRONConfig(
 fun randomLRONCondition(
     success: Boolean = randomBoolean(),
     failure: Boolean = randomBoolean(),
-): LRONCondition {
-    return LRONCondition(success, failure)
-}
+): LRONCondition = LRONCondition(success, failure)
 
 fun randomTaskId(
     nodeId: String = UUIDs.randomBase64UUID(),
     id: Long = randomLong(),
-): TaskId {
-    return TaskId(nodeId, id)
-}
+): TaskId = TaskId(nodeId, id)
 
-fun randomActionName(): String {
-    return supportedActions.random()
-}
+fun randomActionName(): String = supportedActions.random()
 
 fun randomLRONConfigResponse(
     lronConfig: LRONConfig = randomLRONConfig(),
@@ -89,18 +83,14 @@ fun randomLRONConfigResponse(
 
 fun randomGetLRONConfigResponse(
     size: Int = 10,
-): GetLRONConfigResponse {
-    return GetLRONConfigResponse(
-        lronConfigResponses = List(size) { randomLRONConfigResponse() },
-        size,
-    )
-}
+): GetLRONConfigResponse = GetLRONConfigResponse(
+    lronConfigResponses = List(size) { randomLRONConfigResponse() },
+    size,
+)
 
 fun LRONConfig.toJsonString(params: ToXContent.Params = ToXContent.EMPTY_PARAMS): String =
     this.toXContent(
         XContentFactory.jsonBuilder(), params,
     ).string()
 
-fun getResourceURI(taskId: TaskId?, actionName: String?): String {
-    return "${IndexManagementPlugin.LRON_BASE_URI}/${getDocID(taskId, actionName)}"
-}
+fun getResourceURI(taskId: TaskId?, actionName: String?): String = "${IndexManagementPlugin.LRON_BASE_URI}/${getDocID(taskId, actionName)}"

--- a/src/test/kotlin/org/opensearch/indexmanagement/controlcenter/notification/XContentTests.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/controlcenter/notification/XContentTests.kt
@@ -146,9 +146,7 @@ class XContentTests : OpenSearchTestCase() {
     private fun buildMessage(
         itemType: String,
         xContentType: XContentType,
-    ): String {
-        return "$itemType toXContent test failed. xContentType: ${xContentType.subtype()}. "
-    }
+    ): String = "$itemType toXContent test failed. xContentType: ${xContentType.subtype()}. "
 
     private fun <T : ToXContent> parsedItem(
         item: T,

--- a/src/test/kotlin/org/opensearch/indexmanagement/controlcenter/notification/resthandler/LRONConfigRestTestCase.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/controlcenter/notification/resthandler/LRONConfigRestTestCase.kt
@@ -44,9 +44,7 @@ abstract class LRONConfigRestTestCase : IndexManagementRestTestCase() {
         }
     }
 
-    fun createLRONConfig(lronConfig: LRONConfig): Response {
-        return client().makeRequest("POST", IndexManagementPlugin.LRON_BASE_URI, emptyMap(), lronConfig.toHttpEntity())
-    }
+    fun createLRONConfig(lronConfig: LRONConfig): Response = client().makeRequest("POST", IndexManagementPlugin.LRON_BASE_URI, emptyMap(), lronConfig.toHttpEntity())
 
     protected fun LRONConfig.toHttpEntity(): HttpEntity = StringEntity(toJsonString(), ContentType.APPLICATION_JSON)
 

--- a/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/IndexStateManagementRestTestCase.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/IndexStateManagementRestTestCase.kt
@@ -438,12 +438,10 @@ abstract class IndexStateManagementRestTestCase : IndexManagementRestTestCase() 
         }
     }
 
-    protected fun getExistingManagedIndexConfig(index: String): ManagedIndexConfig {
-        return waitFor {
-            val config = getManagedIndexConfig(index)
-            assertNotNull("ManagedIndexConfig is null", config)
-            config!!
-        }
+    protected fun getExistingManagedIndexConfig(index: String): ManagedIndexConfig = waitFor {
+        val config = getManagedIndexConfig(index)
+        assertNotNull("ManagedIndexConfig is null", config)
+        config!!
     }
 
     protected fun updateManagedIndexConfigStartTime(update: ManagedIndexConfig, desiredStartTimeMillis: Long? = null, retryOnConflict: Int = 0) {
@@ -510,14 +508,12 @@ abstract class IndexStateManagementRestTestCase : IndexManagementRestTestCase() 
     }
 
     // Useful settings when debugging to prevent timeouts
-    override fun restClientSettings(): Settings {
-        return if (isDebuggingTest || isDebuggingRemoteCluster) {
-            Settings.builder()
-                .put(CLIENT_SOCKET_TIMEOUT, TimeValue.timeValueMinutes(10))
-                .build()
-        } else {
-            super.restClientSettings()
-        }
+    override fun restClientSettings(): Settings = if (isDebuggingTest || isDebuggingRemoteCluster) {
+        Settings.builder()
+            .put(CLIENT_SOCKET_TIMEOUT, TimeValue.timeValueMinutes(10))
+            .build()
+    } else {
+        super.restClientSettings()
     }
 
     // Validate segment count per shard by specifying the min and max it should be
@@ -642,14 +638,10 @@ abstract class IndexStateManagementRestTestCase : IndexManagementRestTestCase() 
     }
 
     @Suppress("UNCHECKED_CAST")
-    protected fun getIndexShardNodes(indexName: String): List<Any> {
-        return getIndexShards(indexName).map { element -> (element as Map<String, String>)["node"]!! }
-    }
+    protected fun getIndexShardNodes(indexName: String): List<Any> = getIndexShards(indexName).map { element -> (element as Map<String, String>)["node"]!! }
 
     @Suppress("UNCHECKED_CAST")
-    protected fun getIndexShards(indexName: String): List<Any> {
-        return getShardsList().filter { element -> (element as Map<String, String>)["index"]!!.contains(indexName) }
-    }
+    protected fun getIndexShards(indexName: String): List<Any> = getShardsList().filter { element -> (element as Map<String, String>)["index"]!!.contains(indexName) }
 
     @Suppress("UNCHECKED_CAST")
     protected fun getNodes(): MutableSet<String> {
@@ -1177,12 +1169,10 @@ abstract class IndexStateManagementRestTestCase : IndexManagementRestTestCase() 
         }
     }
 
-    override fun xContentRegistry(): NamedXContentRegistry {
-        return NamedXContentRegistry(
-            listOf(
-                ClusterModule.getNamedXWriteables(),
-                SearchModule(Settings.EMPTY, emptyList()).namedXContents,
-            ).flatten(),
-        )
-    }
+    override fun xContentRegistry(): NamedXContentRegistry = NamedXContentRegistry(
+        listOf(
+            ClusterModule.getNamedXWriteables(),
+            SearchModule(Settings.EMPTY, emptyList()).namedXContents,
+        ).flatten(),
+    )
 }

--- a/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/ManagedIndexConfigTests.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/ManagedIndexConfigTests.kt
@@ -42,7 +42,5 @@ class ManagedIndexConfigTests : OpenSearchTestCase() {
         }
     }
 
-    private fun parserWithType(xc: String): XContentParser {
-        return XContentType.JSON.xContent().createParser(xContentRegistry(), LoggingDeprecationHandler.INSTANCE, xc)
-    }
+    private fun parserWithType(xc: String): XContentParser = XContentType.JSON.xContent().createParser(xContentRegistry(), LoggingDeprecationHandler.INSTANCE, xc)
 }

--- a/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/TestHelpers.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/TestHelpers.kt
@@ -76,27 +76,21 @@ fun randomPolicy(
     errorNotification: ErrorNotification? = randomErrorNotification(),
     states: List<State> = List(OpenSearchRestTestCase.randomIntBetween(1, 10)) { randomState() },
     ismTemplate: List<ISMTemplate>? = null,
-): Policy {
-    return Policy(
-        id = id, schemaVersion = schemaVersion, lastUpdatedTime = lastUpdatedTime,
-        errorNotification = errorNotification, defaultState = states[0].name, states = states, description = description, ismTemplate = ismTemplate,
-    )
-}
+): Policy = Policy(
+    id = id, schemaVersion = schemaVersion, lastUpdatedTime = lastUpdatedTime,
+    errorNotification = errorNotification, defaultState = states[0].name, states = states, description = description, ismTemplate = ismTemplate,
+)
 
 fun randomState(
     name: String = OpenSearchRestTestCase.randomAlphaOfLength(10),
     actions: List<Action> = listOf(),
     transitions: List<Transition> = listOf(),
-): State {
-    return State(name = name, actions = actions, transitions = transitions)
-}
+): State = State(name = name, actions = actions, transitions = transitions)
 
 fun randomTransition(
     stateName: String = OpenSearchRestTestCase.randomAlphaOfLength(10),
     conditions: Conditions? = randomConditions(),
-): Transition {
-    return Transition(stateName = stateName, conditions = conditions)
-}
+): Transition = Transition(stateName = stateName, conditions = conditions)
 
 /**
  * TODO: Excluded randomCronSchedule being included in randomConditions as two issues need to be resolved first:
@@ -126,24 +120,20 @@ fun randomConditions(
 fun nonNullRandomConditions(): Conditions =
     randomConditions(OpenSearchRestTestCase.randomFrom(listOf(randomIndexAge(), randomDocCount(), randomSize())))!!
 
-fun randomDeleteActionConfig(): DeleteAction {
-    return DeleteAction(index = 0)
-}
+fun randomDeleteActionConfig(): DeleteAction = DeleteAction(index = 0)
 
 fun randomRolloverActionConfig(
     minSize: ByteSizeValue = randomByteSizeValue(),
     minDocs: Long = OpenSearchRestTestCase.randomLongBetween(1, 1000),
     minAge: TimeValue = randomTimeValueObject(),
     minPrimaryShardSize: ByteSizeValue = randomByteSizeValue(),
-): RolloverAction {
-    return RolloverAction(
-        minSize = minSize,
-        minDocs = minDocs,
-        minAge = minAge,
-        minPrimaryShardSize = minPrimaryShardSize,
-        index = 0,
-    )
-}
+): RolloverAction = RolloverAction(
+    minSize = minSize,
+    minDocs = minDocs,
+    minAge = minAge,
+    minPrimaryShardSize = minPrimaryShardSize,
+    index = 0,
+)
 
 @Suppress("ReturnCount")
 fun randomShrinkAction(
@@ -165,55 +155,33 @@ fun randomShrinkAction(
     return ShrinkAction(numNewShards, maxShardSize, percentageOfSourceShards, targetIndexTemplate, aliases, switchAliases, forceUnsafe, 0)
 }
 
-fun randomReadOnlyActionConfig(): ReadOnlyAction {
-    return ReadOnlyAction(index = 0)
-}
+fun randomReadOnlyActionConfig(): ReadOnlyAction = ReadOnlyAction(index = 0)
 
-fun randomReadWriteActionConfig(): ReadWriteAction {
-    return ReadWriteAction(index = 0)
-}
+fun randomReadWriteActionConfig(): ReadWriteAction = ReadWriteAction(index = 0)
 
-fun randomReplicaCountActionConfig(numOfReplicas: Int = OpenSearchRestTestCase.randomIntBetween(0, 200)): ReplicaCountAction {
-    return ReplicaCountAction(index = 0, numOfReplicas = numOfReplicas)
-}
+fun randomReplicaCountActionConfig(numOfReplicas: Int = OpenSearchRestTestCase.randomIntBetween(0, 200)): ReplicaCountAction = ReplicaCountAction(index = 0, numOfReplicas = numOfReplicas)
 
-fun randomIndexPriorityActionConfig(indexPriority: Int = OpenSearchRestTestCase.randomIntBetween(0, 100)): IndexPriorityAction {
-    return IndexPriorityAction(index = 0, indexPriority = indexPriority)
-}
+fun randomIndexPriorityActionConfig(indexPriority: Int = OpenSearchRestTestCase.randomIntBetween(0, 100)): IndexPriorityAction = IndexPriorityAction(index = 0, indexPriority = indexPriority)
 
 fun randomForceMergeActionConfig(
     maxNumSegments: Int = OpenSearchRestTestCase.randomIntBetween(1, 50),
-): ForceMergeAction {
-    return ForceMergeAction(maxNumSegments = maxNumSegments, index = 0)
-}
+): ForceMergeAction = ForceMergeAction(maxNumSegments = maxNumSegments, index = 0)
 
 fun randomNotificationActionConfig(
     destination: Destination = randomDestination(),
     messageTemplate: Script = randomTemplateScript("random message"),
     index: Int = 0,
-): NotificationAction {
-    return NotificationAction(destination, null, messageTemplate, index)
-}
+): NotificationAction = NotificationAction(destination, null, messageTemplate, index)
 
-fun randomAllocationActionConfig(require: Map<String, String> = emptyMap(), exclude: Map<String, String> = emptyMap(), include: Map<String, String> = emptyMap()): AllocationAction {
-    return AllocationAction(require, include, exclude, index = 0)
-}
+fun randomAllocationActionConfig(require: Map<String, String> = emptyMap(), exclude: Map<String, String> = emptyMap(), include: Map<String, String> = emptyMap()): AllocationAction = AllocationAction(require, include, exclude, index = 0)
 
-fun randomRollupActionConfig(): RollupAction {
-    return RollupAction(ismRollup = randomISMRollup(), index = 0)
-}
+fun randomRollupActionConfig(): RollupAction = RollupAction(ismRollup = randomISMRollup(), index = 0)
 
-fun randomTransformActionConfig(): TransformAction {
-    return TransformAction(ismTransform = randomISMTransform(), index = 0)
-}
+fun randomTransformActionConfig(): TransformAction = TransformAction(ismTransform = randomISMTransform(), index = 0)
 
-fun randomCloseActionConfig(): CloseAction {
-    return CloseAction(index = 0)
-}
+fun randomCloseActionConfig(): CloseAction = CloseAction(index = 0)
 
-fun randomOpenActionConfig(): OpenAction {
-    return OpenAction(index = 0)
-}
+fun randomOpenActionConfig(): OpenAction = OpenAction(index = 0)
 
 fun randomAliasAction(includeIndices: Boolean = false): AliasAction {
     val actions = List(OpenSearchRestTestCase.randomIntBetween(1, 10)) { if (includeIndices) randomAliasActionWithIndices() else randomAliasActions() }
@@ -233,41 +201,33 @@ fun randomAliasActionWithIndices(): IndicesAliasesRequest.AliasActions {
         .indices(OpenSearchRestTestCase.randomAlphaOfLength(10))
 }
 
-fun randomDestination(type: DestinationType = randomDestinationType()): Destination {
-    return Destination(
-        type = type,
-        chime = if (type == DestinationType.CHIME) randomChime() else null,
-        slack = if (type == DestinationType.SLACK) randomSlack() else null,
-        customWebhook = if (type == DestinationType.CUSTOM_WEBHOOK) randomCustomWebhook() else null,
-    )
-}
+fun randomDestination(type: DestinationType = randomDestinationType()): Destination = Destination(
+    type = type,
+    chime = if (type == DestinationType.CHIME) randomChime() else null,
+    slack = if (type == DestinationType.SLACK) randomSlack() else null,
+    customWebhook = if (type == DestinationType.CUSTOM_WEBHOOK) randomCustomWebhook() else null,
+)
 
 fun randomDestinationType(): DestinationType {
     val types = listOf(DestinationType.SLACK, DestinationType.CHIME, DestinationType.CUSTOM_WEBHOOK)
     return OpenSearchRestTestCase.randomSubsetOf(1, types).first()
 }
 
-fun randomChime(): Chime {
-    return Chime("https://www.amazon.com")
-}
+fun randomChime(): Chime = Chime("https://www.amazon.com")
 
-fun randomSlack(): Slack {
-    return Slack("https://www.amazon.com")
-}
+fun randomSlack(): Slack = Slack("https://www.amazon.com")
 
-fun randomCustomWebhook(): CustomWebhook {
-    return CustomWebhook(
-        url = "https://www.amazon.com",
-        scheme = null,
-        host = null,
-        port = -1,
-        path = null,
-        queryParams = emptyMap(),
-        headerParams = emptyMap(),
-        username = null,
-        password = null,
-    )
-}
+fun randomCustomWebhook(): CustomWebhook = CustomWebhook(
+    url = "https://www.amazon.com",
+    scheme = null,
+    host = null,
+    port = -1,
+    path = null,
+    queryParams = emptyMap(),
+    headerParams = emptyMap(),
+    username = null,
+    password = null,
+)
 
 fun randomTemplateScript(
     source: String = OpenSearchRestTestCase.randomAlphaOfLength(10),
@@ -276,9 +236,7 @@ fun randomTemplateScript(
     lang: String = Script.DEFAULT_TEMPLATE_LANG,
 ): Script = Script(scriptType, lang, source, params)
 
-fun randomSnapshotActionConfig(repository: String = "repo", snapshot: String = "sp"): SnapshotAction {
-    return SnapshotAction(repository, snapshot, index = 0)
-}
+fun randomSnapshotActionConfig(repository: String = "repo", snapshot: String = "sp"): SnapshotAction = SnapshotAction(repository, snapshot, index = 0)
 
 /**
  * Helper functions for creating a random Conditions object
@@ -311,18 +269,14 @@ fun randomExplainFilter(
     state: String? = if (OpenSearchRestTestCase.randomBoolean()) OpenSearchRestTestCase.randomAlphaOfLength(10) else null,
     actionType: String? = if (OpenSearchRestTestCase.randomBoolean()) OpenSearchRestTestCase.randomAlphaOfLength(10) else null,
     failed: Boolean? = if (OpenSearchRestTestCase.randomBoolean()) OpenSearchRestTestCase.randomBoolean() else null,
-): ExplainFilter {
-    return ExplainFilter(policyID, state, actionType, failed)
-}
+): ExplainFilter = ExplainFilter(policyID, state, actionType, failed)
 
 fun randomChangePolicy(
     policyID: String = OpenSearchRestTestCase.randomAlphaOfLength(10),
     state: String? = if (OpenSearchRestTestCase.randomBoolean()) OpenSearchRestTestCase.randomAlphaOfLength(10) else null,
     include: List<StateFilter> = emptyList(),
     isSafe: Boolean = false,
-): ChangePolicy {
-    return ChangePolicy(policyID, state, include, isSafe)
-}
+): ChangePolicy = ChangePolicy(policyID, state, include, isSafe)
 
 // will only return null since we dont want to send actual notifications during integ tests
 @Suppress("FunctionOnlyReturningConstant")
@@ -339,23 +293,21 @@ fun randomManagedIndexConfig(
     policy: Policy = randomPolicy(),
     changePolicy: ChangePolicy? = randomChangePolicy(),
     jitter: Double? = 0.0,
-): ManagedIndexConfig {
-    return ManagedIndexConfig(
-        jobName = name,
-        index = index,
-        indexUuid = uuid,
-        enabled = enabled,
-        jobSchedule = schedule,
-        jobLastUpdatedTime = lastUpdatedTime,
-        jobEnabledTime = enabledTime,
-        policyID = policy.id,
-        policySeqNo = policy.seqNo,
-        policyPrimaryTerm = policy.primaryTerm,
-        policy = policy.copy(seqNo = SequenceNumbers.UNASSIGNED_SEQ_NO, primaryTerm = SequenceNumbers.UNASSIGNED_PRIMARY_TERM),
-        changePolicy = changePolicy,
-        jobJitter = jitter,
-    )
-}
+): ManagedIndexConfig = ManagedIndexConfig(
+    jobName = name,
+    index = index,
+    indexUuid = uuid,
+    enabled = enabled,
+    jobSchedule = schedule,
+    jobLastUpdatedTime = lastUpdatedTime,
+    jobEnabledTime = enabledTime,
+    policyID = policy.id,
+    policySeqNo = policy.seqNo,
+    policyPrimaryTerm = policy.primaryTerm,
+    policy = policy.copy(seqNo = SequenceNumbers.UNASSIGNED_SEQ_NO, primaryTerm = SequenceNumbers.UNASSIGNED_PRIMARY_TERM),
+    changePolicy = changePolicy,
+    jobJitter = jitter,
+)
 
 fun randomClusterStateManagedIndexConfig(
     index: String = OpenSearchRestTestCase.randomAlphaOfLength(10),
@@ -363,15 +315,13 @@ fun randomClusterStateManagedIndexConfig(
     policyID: String = OpenSearchRestTestCase.randomAlphaOfLength(10),
     seqNo: Long = SequenceNumbers.UNASSIGNED_SEQ_NO,
     primaryTerm: Long = SequenceNumbers.UNASSIGNED_PRIMARY_TERM,
-): ClusterStateManagedIndexConfig {
-    return ClusterStateManagedIndexConfig(
-        index = index,
-        uuid = uuid,
-        policyID = policyID,
-        seqNo = seqNo,
-        primaryTerm = primaryTerm,
-    )
-}
+): ClusterStateManagedIndexConfig = ClusterStateManagedIndexConfig(
+    index = index,
+    uuid = uuid,
+    policyID = policyID,
+    seqNo = seqNo,
+    primaryTerm = primaryTerm,
+)
 
 fun randomSweptManagedIndexConfig(
     index: String = OpenSearchRestTestCase.randomAlphaOfLength(10),
@@ -381,33 +331,27 @@ fun randomSweptManagedIndexConfig(
     primaryTerm: Long = SequenceNumbers.UNASSIGNED_PRIMARY_TERM,
     changePolicy: ChangePolicy? = null,
     policy: Policy? = null,
-): SweptManagedIndexConfig {
-    return SweptManagedIndexConfig(
-        index = index,
-        uuid = uuid,
-        policyID = policyID,
-        seqNo = seqNo,
-        primaryTerm = primaryTerm,
-        policy = policy,
-        changePolicy = changePolicy,
-    )
-}
+): SweptManagedIndexConfig = SweptManagedIndexConfig(
+    index = index,
+    uuid = uuid,
+    policyID = policyID,
+    seqNo = seqNo,
+    primaryTerm = primaryTerm,
+    policy = policy,
+    changePolicy = changePolicy,
+)
 
 fun randomISMTemplate(
     indexPatterns: List<String> = listOf(OpenSearchRestTestCase.randomAlphaOfLength(10) + "*"),
     priority: Int = OpenSearchRestTestCase.randomIntBetween(0, 100),
     lastUpdatedTime: Instant = Instant.now().truncatedTo(ChronoUnit.MILLIS),
-): ISMTemplate {
-    return ISMTemplate(
-        indexPatterns = indexPatterns,
-        priority = priority,
-        lastUpdatedTime = lastUpdatedTime,
-    )
-}
+): ISMTemplate = ISMTemplate(
+    indexPatterns = indexPatterns,
+    priority = priority,
+    lastUpdatedTime = lastUpdatedTime,
+)
 
-fun randomChannel(id: String = OpenSearchRestTestCase.randomAlphaOfLength(10)): Channel {
-    return Channel(id = id)
-}
+fun randomChannel(id: String = OpenSearchRestTestCase.randomAlphaOfLength(10)): Channel = Channel(id = id)
 
 fun Policy.toJsonString(): String {
     val builder = XContentFactory.jsonBuilder()

--- a/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/action/TransformActionIT.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/action/TransformActionIT.kt
@@ -170,26 +170,24 @@ class TransformActionIT : IndexStateManagementRestTestCase() {
     }
 
     // create an ISMTransform that matches SOURCE_INDEX_MAPPING
-    private fun prepareISMTransform(targetIndex: String): ISMTransform {
-        return ISMTransform(
-            description = "test transform",
-            targetIndex = targetIndex,
-            pageSize = 100,
-            dataSelectionQuery = MatchAllQueryBuilder(),
-            groups =
-            listOf(
-                DateHistogram(sourceField = "timestamp", fixedInterval = "1d"),
-                Terms(sourceField = "category", targetField = "category"),
-            ),
-            aggregations =
-            AggregatorFactories.builder()
-                .addAggregator(sumAggregation())
-                .addAggregator(maxAggregation())
-                .addAggregator(minAggregation())
-                .addAggregator(avgAggregation())
-                .addAggregator(valueCountAggregation()),
-        )
-    }
+    private fun prepareISMTransform(targetIndex: String): ISMTransform = ISMTransform(
+        description = "test transform",
+        targetIndex = targetIndex,
+        pageSize = 100,
+        dataSelectionQuery = MatchAllQueryBuilder(),
+        groups =
+        listOf(
+            DateHistogram(sourceField = "timestamp", fixedInterval = "1d"),
+            Terms(sourceField = "category", targetField = "category"),
+        ),
+        aggregations =
+        AggregatorFactories.builder()
+            .addAggregator(sumAggregation())
+            .addAggregator(maxAggregation())
+            .addAggregator(minAggregation())
+            .addAggregator(avgAggregation())
+            .addAggregator(valueCountAggregation()),
+    )
 
     private fun preparePolicyContainingTransform(indexName: String, ismTransform: ISMTransform, policyId: String, retry: Long = 0): Policy {
         val actionConfig = TransformAction(ismTransform, 0)

--- a/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/extension/SampleCustomActionParser.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/extension/SampleCustomActionParser.kt
@@ -41,9 +41,7 @@ class SampleCustomActionParser : ActionParser() {
         return SampleCustomAction(someInt = requireNotNull(someInt) { "SomeInt field must be specified" }, index)
     }
 
-    override fun getActionType(): String {
-        return SampleCustomAction.name
-    }
+    override fun getActionType(): String = SampleCustomAction.name
 
     class SampleCustomAction(val someInt: Int, index: Int) : Action(name, index) {
         private val sampleCustomStep = SampleCustomStep()
@@ -78,13 +76,11 @@ class SampleCustomActionParser : ActionParser() {
             return this
         }
 
-        override fun getUpdatedManagedIndexMetadata(currentMetadata: ManagedIndexMetaData): ManagedIndexMetaData {
-            return currentMetadata.copy(
-                stepMetaData = StepMetaData(name, getStepStartTime(currentMetadata).toEpochMilli(), stepStatus),
-                transitionTo = null,
-                info = null,
-            )
-        }
+        override fun getUpdatedManagedIndexMetadata(currentMetadata: ManagedIndexMetaData): ManagedIndexMetaData = currentMetadata.copy(
+            stepMetaData = StepMetaData(name, getStepStartTime(currentMetadata).toEpochMilli(), stepStatus),
+            transitionTo = null,
+            info = null,
+        )
 
         override fun isIdempotent(): Boolean = true
 

--- a/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/model/XContentTests.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/model/XContentTests.kt
@@ -308,7 +308,5 @@ class XContentTests : OpenSearchTestCase() {
         return parser
     }
 
-    private fun parserWithType(xc: String): XContentParser {
-        return XContentType.JSON.xContent().createParser(xContentRegistry(), LoggingDeprecationHandler.INSTANCE, xc)
-    }
+    private fun parserWithType(xc: String): XContentParser = XContentType.JSON.xContent().createParser(xContentRegistry(), LoggingDeprecationHandler.INSTANCE, xc)
 }

--- a/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/util/ManagedIndexUtilsTests.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/util/ManagedIndexUtilsTests.kt
@@ -289,28 +289,22 @@ class ManagedIndexUtilsTests : OpenSearchTestCase() {
         )
     }
 
-    private fun contentParser(bytesReference: BytesReference): XContentParser {
-        return XContentHelper.createParser(
-            xContentRegistry(), LoggingDeprecationHandler.INSTANCE,
-            bytesReference, XContentType.JSON,
-        )
-    }
+    private fun contentParser(bytesReference: BytesReference): XContentParser = XContentHelper.createParser(
+        xContentRegistry(), LoggingDeprecationHandler.INSTANCE,
+        bytesReference, XContentType.JSON,
+    )
 
-    private fun createMessageWithHost(host: String): LegacyBaseMessage {
-        return LegacyCustomWebhookMessage.Builder("abc")
-            .withHost(host)
-            .withPath("incomingwebhooks/383c0e2b-d028-44f4-8d38-696754bc4574")
-            .withMessage("{\"Content\":\"Message test\"}")
-            .withMethod("POST")
-            .withQueryParams(HashMap<String, String>()).build()
-    }
+    private fun createMessageWithHost(host: String): LegacyBaseMessage = LegacyCustomWebhookMessage.Builder("abc")
+        .withHost(host)
+        .withPath("incomingwebhooks/383c0e2b-d028-44f4-8d38-696754bc4574")
+        .withMessage("{\"Content\":\"Message test\"}")
+        .withMethod("POST")
+        .withQueryParams(HashMap<String, String>()).build()
 
-    private fun createMessageWithURl(url: String): LegacyBaseMessage {
-        return LegacyCustomWebhookMessage.Builder("abc")
-            .withUrl(url)
-            .withPath("incomingwebhooks/383c0e2b-d028-44f4-8d38-696754bc4574")
-            .withMessage("{\"Content\":\"Message test\"}")
-            .withMethod("POST")
-            .withQueryParams(HashMap<String, String>()).build()
-    }
+    private fun createMessageWithURl(url: String): LegacyBaseMessage = LegacyCustomWebhookMessage.Builder("abc")
+        .withUrl(url)
+        .withPath("incomingwebhooks/383c0e2b-d028-44f4-8d38-696754bc4574")
+        .withMessage("{\"Content\":\"Message test\"}")
+        .withMethod("POST")
+        .withQueryParams(HashMap<String, String>()).build()
 }

--- a/src/test/kotlin/org/opensearch/indexmanagement/refreshanalyzer/RefreshSearchAnalyzerActionIT.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/refreshanalyzer/RefreshSearchAnalyzerActionIT.kt
@@ -212,8 +212,7 @@ class RefreshSearchAnalyzerActionIT : IndexManagementRestTestCase() {
             client().performRequest(request)
         }
 
-        fun getSearchAnalyzerSettings(): String {
-            return """
+        fun getSearchAnalyzerSettings(): String = """
                 {
                     "index" : {
                         "analysis" : {
@@ -233,11 +232,9 @@ class RefreshSearchAnalyzerActionIT : IndexManagementRestTestCase() {
                         }
                     }
                 }
-            """.trimIndent()
-        }
+        """.trimIndent()
 
-        fun getIndexAnalyzerSettings(): String {
-            return """
+        fun getIndexAnalyzerSettings(): String = """
                 {
                     "index" : {
                         "analysis" : {
@@ -256,11 +253,9 @@ class RefreshSearchAnalyzerActionIT : IndexManagementRestTestCase() {
                         }
                     }
                 }
-            """.trimIndent()
-        }
+        """.trimIndent()
 
-        fun getAnalyzerMapping(): String {
-            return """
+        fun getAnalyzerMapping(): String = """
                 "properties": {
                         "title": {
                             "type": "text",
@@ -268,7 +263,6 @@ class RefreshSearchAnalyzerActionIT : IndexManagementRestTestCase() {
                             "search_analyzer": "my_synonyms"
                         }
                     }
-            """.trimIndent()
-        }
+        """.trimIndent()
     }
 }

--- a/src/test/kotlin/org/opensearch/indexmanagement/rollup/TestHelpers.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/rollup/TestHelpers.kt
@@ -123,19 +123,15 @@ fun randomRollup(): Rollup {
     )
 }
 
-fun randomRollupStats(): RollupStats {
-    return RollupStats(
-        pagesProcessed = OpenSearchRestTestCase.randomNonNegativeLong(),
-        documentsProcessed = OpenSearchRestTestCase.randomNonNegativeLong(),
-        rollupsIndexed = OpenSearchRestTestCase.randomNonNegativeLong(),
-        indexTimeInMillis = OpenSearchRestTestCase.randomNonNegativeLong(),
-        searchTimeInMillis = OpenSearchRestTestCase.randomNonNegativeLong(),
-    )
-}
+fun randomRollupStats(): RollupStats = RollupStats(
+    pagesProcessed = OpenSearchRestTestCase.randomNonNegativeLong(),
+    documentsProcessed = OpenSearchRestTestCase.randomNonNegativeLong(),
+    rollupsIndexed = OpenSearchRestTestCase.randomNonNegativeLong(),
+    indexTimeInMillis = OpenSearchRestTestCase.randomNonNegativeLong(),
+    searchTimeInMillis = OpenSearchRestTestCase.randomNonNegativeLong(),
+)
 
-fun randomRollupMetadataStatus(): RollupMetadata.Status {
-    return OpenSearchRestTestCase.randomFrom(RollupMetadata.Status.values().toList())
-}
+fun randomRollupMetadataStatus(): RollupMetadata.Status = OpenSearchRestTestCase.randomFrom(RollupMetadata.Status.values().toList())
 
 fun randomContinuousMetadata(): ContinuousMetadata {
     val one = randomInstant()
@@ -146,12 +142,10 @@ fun randomContinuousMetadata(): ContinuousMetadata {
     )
 }
 
-fun randomAfterKey(): Map<String, Any>? {
-    return if (OpenSearchRestTestCase.randomBoolean()) {
-        null
-    } else {
-        mapOf("test" to 17)
-    }
+fun randomAfterKey(): Map<String, Any>? = if (OpenSearchRestTestCase.randomBoolean()) {
+    null
+} else {
+    mapOf("test" to 17)
 }
 
 fun randomRollupMetadata(): RollupMetadata {
@@ -175,63 +169,51 @@ fun randomExplainRollup(): ExplainRollup {
     return ExplainRollup(metadataID = metadata.id, metadata = metadata)
 }
 
-fun randomISMRollup(): ISMRollup {
-    return ISMRollup(
-        description = OpenSearchRestTestCase.randomAlphaOfLength(10),
-        targetIndex = OpenSearchRestTestCase.randomAlphaOfLength(10).lowercase(Locale.ROOT),
-        pageSize = OpenSearchRestTestCase.randomIntBetween(1, 10000),
-        dimensions = randomRollupDimensions(),
-        metrics = OpenSearchRestTestCase.randomList(20, ::randomRollupMetrics).distinctBy { it.targetField },
-    )
-}
+fun randomISMRollup(): ISMRollup = ISMRollup(
+    description = OpenSearchRestTestCase.randomAlphaOfLength(10),
+    targetIndex = OpenSearchRestTestCase.randomAlphaOfLength(10).lowercase(Locale.ROOT),
+    pageSize = OpenSearchRestTestCase.randomIntBetween(1, 10000),
+    dimensions = randomRollupDimensions(),
+    metrics = OpenSearchRestTestCase.randomList(20, ::randomRollupMetrics).distinctBy { it.targetField },
+)
 
-fun randomISMFieldCapabilities(): ISMFieldCapabilities {
-    return ISMFieldCapabilities(
-        name = OpenSearchRestTestCase.randomAlphaOfLength(10),
-        type = OpenSearchRestTestCase.randomAlphaOfLength(10),
-        isSearchable = OpenSearchRestTestCase.randomBoolean(),
-        isAggregatable = OpenSearchRestTestCase.randomBoolean(),
-        indices = OpenSearchRestTestCase.generateRandomStringArray(10, 10, true, true),
-        nonSearchableIndices = OpenSearchRestTestCase.generateRandomStringArray(10, 10, true, true),
-        nonAggregatableIndices = OpenSearchRestTestCase.generateRandomStringArray(10, 10, true, true),
-        meta = mapOf(OpenSearchRestTestCase.randomAlphaOfLength(10) to setOf(OpenSearchRestTestCase.randomAlphaOfLength(10))),
-    )
-}
+fun randomISMFieldCapabilities(): ISMFieldCapabilities = ISMFieldCapabilities(
+    name = OpenSearchRestTestCase.randomAlphaOfLength(10),
+    type = OpenSearchRestTestCase.randomAlphaOfLength(10),
+    isSearchable = OpenSearchRestTestCase.randomBoolean(),
+    isAggregatable = OpenSearchRestTestCase.randomBoolean(),
+    indices = OpenSearchRestTestCase.generateRandomStringArray(10, 10, true, true),
+    nonSearchableIndices = OpenSearchRestTestCase.generateRandomStringArray(10, 10, true, true),
+    nonAggregatableIndices = OpenSearchRestTestCase.generateRandomStringArray(10, 10, true, true),
+    meta = mapOf(OpenSearchRestTestCase.randomAlphaOfLength(10) to setOf(OpenSearchRestTestCase.randomAlphaOfLength(10))),
+)
 
-fun randomISMIndexFieldCapabilities(): ISMIndexFieldCapabilities {
-    return ISMIndexFieldCapabilities(
-        name = OpenSearchRestTestCase.randomAlphaOfLength(10),
-        type = OpenSearchRestTestCase.randomAlphaOfLength(10),
-        isSearchable = OpenSearchRestTestCase.randomBoolean(),
-        isAggregatable = OpenSearchRestTestCase.randomBoolean(),
-        meta = mapOf(OpenSearchRestTestCase.randomAlphaOfLength(10) to OpenSearchRestTestCase.randomAlphaOfLength(10)),
-    )
-}
+fun randomISMIndexFieldCapabilities(): ISMIndexFieldCapabilities = ISMIndexFieldCapabilities(
+    name = OpenSearchRestTestCase.randomAlphaOfLength(10),
+    type = OpenSearchRestTestCase.randomAlphaOfLength(10),
+    isSearchable = OpenSearchRestTestCase.randomBoolean(),
+    isAggregatable = OpenSearchRestTestCase.randomBoolean(),
+    meta = mapOf(OpenSearchRestTestCase.randomAlphaOfLength(10) to OpenSearchRestTestCase.randomAlphaOfLength(10)),
+)
 
-fun randomISMFieldCapabilitiesIndexResponse(): ISMFieldCapabilitiesIndexResponse {
-    return ISMFieldCapabilitiesIndexResponse(
-        indexName = OpenSearchRestTestCase.randomAlphaOfLength(10),
-        responseMap = mapOf(OpenSearchRestTestCase.randomAlphaOfLength(10) to randomISMIndexFieldCapabilities()),
-        canMatch = OpenSearchRestTestCase.randomBoolean(),
-    )
-}
+fun randomISMFieldCapabilitiesIndexResponse(): ISMFieldCapabilitiesIndexResponse = ISMFieldCapabilitiesIndexResponse(
+    indexName = OpenSearchRestTestCase.randomAlphaOfLength(10),
+    responseMap = mapOf(OpenSearchRestTestCase.randomAlphaOfLength(10) to randomISMIndexFieldCapabilities()),
+    canMatch = OpenSearchRestTestCase.randomBoolean(),
+)
 
-fun randomISMFieldCaps(): ISMFieldCapabilitiesResponse {
-    return ISMFieldCapabilitiesResponse(
-        indices = OpenSearchRestTestCase.generateRandomStringArray(10, 10, false),
-        responseMap = mapOf(OpenSearchRestTestCase.randomAlphaOfLength(10) to mapOf(OpenSearchRestTestCase.randomAlphaOfLength(10) to randomISMFieldCapabilities())),
-        indexResponses = OpenSearchRestTestCase.randomList(4, ::randomISMFieldCapabilitiesIndexResponse),
-    )
-}
+fun randomISMFieldCaps(): ISMFieldCapabilitiesResponse = ISMFieldCapabilitiesResponse(
+    indices = OpenSearchRestTestCase.generateRandomStringArray(10, 10, false),
+    responseMap = mapOf(OpenSearchRestTestCase.randomAlphaOfLength(10) to mapOf(OpenSearchRestTestCase.randomAlphaOfLength(10) to randomISMFieldCapabilities())),
+    indexResponses = OpenSearchRestTestCase.randomList(4, ::randomISMFieldCapabilitiesIndexResponse),
+)
 
 fun randomDimension(): Dimension {
     val dimensions = listOf(randomTerms(), randomHistogram(), randomDateHistogram())
     return OpenSearchRestTestCase.randomSubsetOf(1, dimensions).first()
 }
 
-fun randomTermQuery(): TermQueryBuilder {
-    return TermQueryBuilder(OpenSearchRestTestCase.randomAlphaOfLength(5), OpenSearchRestTestCase.randomAlphaOfLength(5))
-}
+fun randomTermQuery(): TermQueryBuilder = TermQueryBuilder(OpenSearchRestTestCase.randomAlphaOfLength(5), OpenSearchRestTestCase.randomAlphaOfLength(5))
 
 fun DateHistogram.toJsonString(): String = this.toXContent(XContentFactory.jsonBuilder(), ToXContent.EMPTY_PARAMS).string()
 

--- a/src/test/kotlin/org/opensearch/indexmanagement/rollup/model/XContentTests.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/rollup/model/XContentTests.kt
@@ -133,7 +133,5 @@ class XContentTests : OpenSearchTestCase() {
         return parser
     }
 
-    private fun parserWithType(xc: String): XContentParser {
-        return XContentType.JSON.xContent().createParser(xContentRegistry(), LoggingDeprecationHandler.INSTANCE, xc)
-    }
+    private fun parserWithType(xc: String): XContentParser = XContentType.JSON.xContent().createParser(xContentRegistry(), LoggingDeprecationHandler.INSTANCE, xc)
 }

--- a/src/test/kotlin/org/opensearch/indexmanagement/snapshotmanagement/TestUtils.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/snapshotmanagement/TestUtils.kt
@@ -59,34 +59,32 @@ fun randomSMMetadata(
     deletionLatestExecution: SMMetadata.LatestExecution? = null,
     creationRetryCount: Int? = null,
     deletionRetryCount: Int? = null,
-): SMMetadata {
-    return SMMetadata(
-        policySeqNo = policySeqNo,
-        policyPrimaryTerm = policyPrimaryTerm,
-        creation =
-        SMMetadata.WorkflowMetadata(
-            currentState = creationCurrentState,
-            trigger =
-            SMMetadata.Trigger(
-                time = nextCreationTime,
-            ),
-            started = if (startedCreation != null) listOf(startedCreation) else null,
-            latestExecution = creationLatestExecution,
-            retry = creationRetryCount?.let { SMMetadata.Retry(it) },
+): SMMetadata = SMMetadata(
+    policySeqNo = policySeqNo,
+    policyPrimaryTerm = policyPrimaryTerm,
+    creation =
+    SMMetadata.WorkflowMetadata(
+        currentState = creationCurrentState,
+        trigger =
+        SMMetadata.Trigger(
+            time = nextCreationTime,
         ),
-        deletion =
-        SMMetadata.WorkflowMetadata(
-            currentState = deletionCurrentState,
-            trigger =
-            SMMetadata.Trigger(
-                time = nextDeletionTime,
-            ),
-            started = startedDeletion,
-            latestExecution = deletionLatestExecution,
-            retry = deletionRetryCount?.let { SMMetadata.Retry(it) },
+        started = if (startedCreation != null) listOf(startedCreation) else null,
+        latestExecution = creationLatestExecution,
+        retry = creationRetryCount?.let { SMMetadata.Retry(it) },
+    ),
+    deletion =
+    SMMetadata.WorkflowMetadata(
+        currentState = deletionCurrentState,
+        trigger =
+        SMMetadata.Trigger(
+            time = nextDeletionTime,
         ),
-    )
-}
+        started = startedDeletion,
+        latestExecution = deletionLatestExecution,
+        retry = deletionRetryCount?.let { SMMetadata.Retry(it) },
+    ),
+)
 
 fun randomLatestExecution(
     status: SMMetadata.LatestExecution.Status = SMMetadata.LatestExecution.Status.IN_PROGRESS,
@@ -270,14 +268,12 @@ fun mockInProgressSnapshotInfo(
 fun mockSnapshotInfo(
     name: String = randomAlphaOfLength(10),
     snapshotState: SnapshotState,
-): SnapshotInfo {
-    return SnapshotInfo(
-        SnapshotId(name, UUIDs.randomBase64UUID()),
-        emptyList(),
-        emptyList(),
-        snapshotState,
-    )
-}
+): SnapshotInfo = SnapshotInfo(
+    SnapshotId(name, UUIDs.randomBase64UUID()),
+    emptyList(),
+    emptyList(),
+    snapshotState,
+)
 
 fun mockGetSnapshotResponse(num: Int): GetSnapshotsResponse {
     val getSnapshotsRes: GetSnapshotsResponse = mock()

--- a/src/test/kotlin/org/opensearch/indexmanagement/transform/TestHelpers.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/transform/TestHelpers.kt
@@ -124,15 +124,13 @@ fun randomTransformMetadata(): TransformMetadata {
     )
 }
 
-fun randomTransformStats(): TransformStats {
-    return TransformStats(
-        pagesProcessed = OpenSearchRestTestCase.randomNonNegativeLong(),
-        documentsProcessed = OpenSearchRestTestCase.randomNonNegativeLong(),
-        documentsIndexed = OpenSearchRestTestCase.randomNonNegativeLong(),
-        indexTimeInMillis = OpenSearchRestTestCase.randomNonNegativeLong(),
-        searchTimeInMillis = OpenSearchRestTestCase.randomNonNegativeLong(),
-    )
-}
+fun randomTransformStats(): TransformStats = TransformStats(
+    pagesProcessed = OpenSearchRestTestCase.randomNonNegativeLong(),
+    documentsProcessed = OpenSearchRestTestCase.randomNonNegativeLong(),
+    documentsIndexed = OpenSearchRestTestCase.randomNonNegativeLong(),
+    indexTimeInMillis = OpenSearchRestTestCase.randomNonNegativeLong(),
+    searchTimeInMillis = OpenSearchRestTestCase.randomNonNegativeLong(),
+)
 
 fun randomShardIDToGlobalCheckpoint(): Map<ShardId, Long> {
     val numIndices = OpenSearchRestTestCase.randomIntBetween(1, 10)
@@ -148,12 +146,10 @@ fun randomShardID(): ShardId {
     return ShardId(testIndex, shardNumber)
 }
 
-fun randomContinuousStats(): ContinuousTransformStats {
-    return ContinuousTransformStats(
-        lastTimestamp = randomInstant(),
-        documentsBehind = randomDocumentsBehind(),
-    )
-}
+fun randomContinuousStats(): ContinuousTransformStats = ContinuousTransformStats(
+    lastTimestamp = randomInstant(),
+    documentsBehind = randomDocumentsBehind(),
+)
 
 fun randomDocumentsBehind(): Map<String, Long> {
     val numIndices = OpenSearchRestTestCase.randomIntBetween(1, 10)
@@ -161,25 +157,21 @@ fun randomDocumentsBehind(): Map<String, Long> {
     return randomIndices.associateWith { OpenSearchRestTestCase.randomNonNegativeLong() }
 }
 
-fun randomTransformMetadataStatus(): TransformMetadata.Status {
-    return OpenSearchRestTestCase.randomFrom(TransformMetadata.Status.values().toList())
-}
+fun randomTransformMetadataStatus(): TransformMetadata.Status = OpenSearchRestTestCase.randomFrom(TransformMetadata.Status.values().toList())
 
 fun randomExplainTransform(): ExplainTransform {
     val metadata = randomTransformMetadata()
     return ExplainTransform(metadataID = metadata.id, metadata = metadata)
 }
 
-fun randomISMTransform(): ISMTransform {
-    return ISMTransform(
-        description = OpenSearchRestTestCase.randomAlphaOfLength(10),
-        targetIndex = OpenSearchRestTestCase.randomAlphaOfLength(10).lowercase(Locale.ROOT),
-        pageSize = OpenSearchRestTestCase.randomIntBetween(1, 10000),
-        groups = randomGroups(),
-        dataSelectionQuery = randomTermQuery(),
-        aggregations = randomAggregationFactories(),
-    )
-}
+fun randomISMTransform(): ISMTransform = ISMTransform(
+    description = OpenSearchRestTestCase.randomAlphaOfLength(10),
+    targetIndex = OpenSearchRestTestCase.randomAlphaOfLength(10).lowercase(Locale.ROOT),
+    pageSize = OpenSearchRestTestCase.randomIntBetween(1, 10000),
+    groups = randomGroups(),
+    dataSelectionQuery = randomTermQuery(),
+    aggregations = randomAggregationFactories(),
+)
 
 fun Transform.toJsonString(params: ToXContent.Params = ToXContent.EMPTY_PARAMS): String = this.toXContent(XContentFactory.jsonBuilder(), params).string()
 

--- a/src/test/kotlin/org/opensearch/indexmanagement/transform/TransformRestTestCase.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/transform/TransformRestTestCase.kt
@@ -222,7 +222,5 @@ abstract class TransformRestTestCase : IndexManagementRestTestCase() {
 
     protected fun Transform.toHttpEntity(): HttpEntity = StringEntity(toJsonString(), ContentType.APPLICATION_JSON)
 
-    override fun xContentRegistry(): NamedXContentRegistry {
-        return NamedXContentRegistry(SearchModule(Settings.EMPTY, emptyList()).namedXContents)
-    }
+    override fun xContentRegistry(): NamedXContentRegistry = NamedXContentRegistry(SearchModule(Settings.EMPTY, emptyList()).namedXContents)
 }

--- a/src/test/kotlin/org/opensearch/indexmanagement/transform/TransformRunnerIT.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/transform/TransformRunnerIT.kt
@@ -1499,16 +1499,14 @@ class TransformRunnerIT : TransformRestTestCase() {
         disableTransform(transform.id)
     }
 
-    private fun getStrictMappings(): String {
-        return """
+    private fun getStrictMappings(): String = """
             "dynamic": "strict",
             "properties": {
                 "some-column": {
                     "type": "keyword"
                 }
             }
-        """.trimIndent()
-    }
+    """.trimIndent()
 
     private fun validateSourceIndex(indexName: String) {
         if (!indexExists(indexName)) {

--- a/src/test/kotlin/org/opensearch/indexmanagement/transform/model/XContentTests.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/transform/model/XContentTests.kt
@@ -70,11 +70,7 @@ class XContentTests : OpenSearchTestCase() {
         return parser
     }
 
-    private fun parserWithType(xc: String): XContentParser {
-        return XContentType.JSON.xContent().createParser(xContentRegistry(), LoggingDeprecationHandler.INSTANCE, xc)
-    }
+    private fun parserWithType(xc: String): XContentParser = XContentType.JSON.xContent().createParser(xContentRegistry(), LoggingDeprecationHandler.INSTANCE, xc)
 
-    override fun xContentRegistry(): NamedXContentRegistry {
-        return NamedXContentRegistry(SearchModule(Settings.EMPTY, emptyList()).namedXContents)
-    }
+    override fun xContentRegistry(): NamedXContentRegistry = NamedXContentRegistry(SearchModule(Settings.EMPTY, emptyList()).namedXContents)
 }


### PR DESCRIPTION
### Description
Bumps [com.pinterest.ktlint:ktlint-cli](https://github.com/pinterest/ktlint) from 1.1.0 to 1.5.0.

Build was failing in #1317 because of newly introduced rules between this upgrade. Ran `ktlint --format` to apply these rules.

Suppresses backing property naming in IndexUtil.kt and RestHandlerUtil.kt files as this will require renaming the constant variable names and usage across files. Suppressing them in these files so that these rules are being followed following merge of this PR.
