### PR TITLE
Fix issue in Docker Security Tests where qualifier is not being parsed correctly

### DIFF
--- a/.github/workflows/docker-security-test-workflow.yml
+++ b/.github/workflows/docker-security-test-workflow.yml
@@ -30,7 +30,7 @@ jobs:
           plugin_version=`echo $plugin|awk -F- '{print $4}'| cut -d. -f 1-4`
           qualifier=`echo $plugin|awk -F- '{print $5}'| cut -d. -f 1-1`
           candidate_version=`echo $plugin|awk -F- '{print $5}'| cut -d. -f 1-1`
-          if qualifier
+          if [ -n "$qualifier" ]; then
           then
             docker_version=$version-$qualifier
           else

--- a/.github/workflows/docker-security-test-workflow.yml
+++ b/.github/workflows/docker-security-test-workflow.yml
@@ -31,7 +31,6 @@ jobs:
           qualifier=`echo $plugin|awk -F- '{print $5}'| cut -d. -f 1-1`
           candidate_version=`echo $plugin|awk -F- '{print $5}'| cut -d. -f 1-1`
           if [ -n "$qualifier" ]; then
-          then
             docker_version=$version-$qualifier
           else
             docker_version=$version

--- a/.github/workflows/docker-security-test-workflow.yml
+++ b/.github/workflows/docker-security-test-workflow.yml
@@ -28,7 +28,7 @@ jobs:
           list_of_all_files=`ls build/distributions/`
           version=`echo $plugin|awk -F- '{print $4}'| cut -d. -f 1-3`
           plugin_version=`echo $plugin|awk -F- '{print $4}'| cut -d. -f 1-4`
-          qualifier=`echo $plugin|awk -F- '{print $4}'| cut -d. -f 1-1`
+          qualifier=`echo $plugin|awk -F- '{print $5}'| cut -d. -f 1-1`
           candidate_version=`echo $plugin|awk -F- '{print $5}'| cut -d. -f 1-1`
           if qualifier
           then

--- a/build.gradle
+++ b/build.gradle
@@ -26,8 +26,8 @@ import java.util.concurrent.TimeUnit
 buildscript {
     ext {
         isSnapshot = "true" == System.getProperty("build.snapshot", "true")
-        opensearch_version = System.getProperty("opensearch.version", "3.0.0-alpha1-SNAPSHOT")
-        buildVersionQualifier = System.getProperty("build.version_qualifier", "alpha1")
+        opensearch_version = System.getProperty("opensearch.version", "3.0.0-beta1-SNAPSHOT")
+        buildVersionQualifier = System.getProperty("build.version_qualifier", "beta1")
         // 2.2.0-SNAPSHOT -> 2.2.0.0-SNAPSHOT
         version_tokens = opensearch_version.tokenize('-')
         opensearch_build = version_tokens[0] + '.0'


### PR DESCRIPTION
### Description

This PR fixes the Docker Security Test CI Check which is failing due to incorrect parsing logic to get the qualifier from the jar name.

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/index-management/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
