### PR TITLE
Fix build due to phasing off SecurityManager usage in favor of Java Agent

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -208,6 +208,29 @@ ext {
 allprojects {
     group = "org.opensearch"
     version = "${opensearch_build}"
+
+    configurations {
+        agent
+    }
+
+    dependencies {
+    }
+
+    task prepareAgent(type: Copy) {
+        from(configurations.agent)
+        into "$buildDir/agent"
+    }
+
+    dependencies {
+        agent "org.opensearch:opensearch-agent-bootstrap:${opensearch_version}"
+        agent "org.opensearch:opensearch-agent:${opensearch_version}"
+        agent "net.bytebuddy:byte-buddy:${versions.bytebuddy}"
+    }
+
+    tasks.withType(Test) {
+        dependsOn prepareAgent
+        jvmArgs += ["-javaagent:" + project.layout.buildDirectory.file("agent/opensearch-agent-${opensearch_version}.jar").get()]
+    }
 }
 
 configurations {


### PR DESCRIPTION
### Description
Fix build due to phasing off SecurityManager usage in favor of Java Agent

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/index-management/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
