### PR TITLE
Removed unnecessary user notifications for version conflict exceptions in Snapshot Management

### DIFF
--- a/src/main/kotlin/org/opensearch/indexmanagement/snapshotmanagement/engine/SMStateMachine.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/snapshotmanagement/engine/SMStateMachine.kt
@@ -123,6 +123,7 @@ class SMStateMachine(
                 }
             } while (currentState.instance.continuous && result is SMResult.Next)
         } catch (ex: Exception) {
+            //
             @Suppress("InstanceOfCheckForException")
             if (ex !is VersionConflictEngineException) {
                 val message = "There was an exception at ${now()} while executing Snapshot Management policy ${job.policyName}, please check logs."

--- a/src/main/kotlin/org/opensearch/indexmanagement/snapshotmanagement/engine/SMStateMachine.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/snapshotmanagement/engine/SMStateMachine.kt
@@ -123,7 +123,6 @@ class SMStateMachine(
                 }
             } while (currentState.instance.continuous && result is SMResult.Next)
         } catch (ex: Exception) {
-            //
             @Suppress("InstanceOfCheckForException")
             if (ex !is VersionConflictEngineException) {
                 val message = "There was an exception at ${now()} while executing Snapshot Management policy ${job.policyName}, please check logs."


### PR DESCRIPTION
### Description
The manual snapshot policy management system needs modification to prevent false alarm notifications caused by internal version conflict exceptions during concurrent snapshot operations.
[GitHub Issue Reference](https://github.com/opensearch-project/index-management/issues/1371)
Current Behavior:

- Snapshot policy creates/deletes snapshots via cron jobs
- State updates are made to .ism-config system index
- Race conditions occur during concurrent operations which cause VersionConflictEngineException
- Manual snapshot happens as expected from users.
- Users receive notifications for all exceptions, including internal version conflicts
- False alarms are triggered for non-user-impacting issues

Proposed Changes:
Modify exception handling to suppress notifications for VersionConflictEngineException just log this as error message. 
Maintain notifications for all other exception type

### Related Issues

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/index-management/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
