### PR TITLE
Fix Integration test and lint errors

### DIFF
--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/validation/ValidateRollover.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/validation/ValidateRollover.kt
@@ -31,8 +31,7 @@ class ValidateRollover(
         if (skipRollover(indexName) || alreadyRolledOver(rolloverTarget, indexName)) return this
 
         if (!isDataStream) {
-            if (!hasAlias(rolloverTarget, indexName) || !isWriteIndex(rolloverTarget, indexName)
-            ) {
+            if (!hasAlias(rolloverTarget, indexName) || !isWriteIndex(rolloverTarget, indexName)) {
                 return this
             }
         }

--- a/src/main/kotlin/org/opensearch/indexmanagement/transform/util/TransformLockManager.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/transform/util/TransformLockManager.kt
@@ -104,8 +104,7 @@ class TransformLockManager(
      */
     suspend fun renewLockForLongSearch(timeSpentOnSearch: Long) {
         // If the request was longer than 10 minutes and lock expires in less than 20 minutes, renew the lock just in case
-        if (timeSpentOnSearch > TIMEOUT_UPPER_BOUND_IN_SECONDS && lockExpirationInSeconds() ?: 0 < MAXIMUM_LOCK_EXPIRATION_IN_SECONDS
-        ) {
+        if (timeSpentOnSearch > TIMEOUT_UPPER_BOUND_IN_SECONDS && lockExpirationInSeconds() ?: 0 < MAXIMUM_LOCK_EXPIRATION_IN_SECONDS) {
             this.renewLockForScheduledJob()
         }
     }

--- a/src/test/kotlin/org/opensearch/indexmanagement/rollup/interceptor/RollupInterceptorIT.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/rollup/interceptor/RollupInterceptorIT.kt
@@ -392,11 +392,13 @@ class RollupInterceptorIT : RollupRestTestCase() {
             client().makeRequest("POST", "/target_rollup_search/_search", emptyMap(), StringEntity(req, ContentType.APPLICATION_JSON))
             fail("Expected 400 Method BAD_REQUEST response")
         } catch (e: ResponseException) {
-            assertEquals(
+            val errorMessage = (e.response.asMap() as Map<String, Map<String, Map<String, String>>>)["error"]!!["caused_by"]!!["reason"]!!
+            assertTrue(
                 "Wrong error message",
-                "Could not find a rollup job that can answer this query because [missing field RateCodeID, missing field timestamp, " +
-                    "missing sum aggregation on total_amount]",
-                (e.response.asMap() as Map<String, Map<String, Map<String, String>>>)["error"]!!["caused_by"]!!["reason"],
+                errorMessage.startsWith("Could not find a rollup job that can answer this query because") == true &&
+                    errorMessage.contains("missing field RateCodeID") == true &&
+                    errorMessage.contains("missing field timestamp") == true &&
+                    errorMessage.contains("missing sum aggregation on total_amount") == true,
             )
             assertEquals("Unexpected status", RestStatus.BAD_REQUEST, e.response.restStatus())
         }


### PR DESCRIPTION
### Description

This PR fixes a failure in the `RollupInterceptorIT.test roll up search` integration test.

The test was asserting the exact error message returned when no suitable rollup job was found for a query. However, the list of missing fields in the error message is unordered, resulting in non-deterministic string output (`"missing field timestamp"` appearing before or after `"missing field RateCodeID"`).
![image](https://github.com/user-attachments/assets/97f560f4-891c-4fa6-b421-836afb3ee7a2)



This caused the test to fail intermittently due to strict string comparison.

This PR also fixes some `ktlint` errors by running `ktlint --format`

---

### Fix

- Updated the test assertion to validate the **presence** of expected substrings individually using `assertTrue()` instead of relying on exact ordering via `assertEquals()`.
- Ensures test stability while preserving correctness.

---

### Testing

- Ran `RollupInterceptorIT` locally to confirm consistent pass.
- Verified that error message contains all expected fields:
  - `missing field RateCodeID`
  - `missing field timestamp`
  - `missing sum aggregation on total_amount`
  
![image](https://github.com/user-attachments/assets/61d4206e-2031-482b-9d34-399b5fdfa029)


---


### Related Issues
Resolves #1441 
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/index-management/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
