### PR TITLE
Use adminClient when deleting history index in IndexStateManagementHistoryIT

### DIFF
--- a/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/action/IndexStateManagementHistoryIT.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/action/IndexStateManagementHistoryIT.kt
@@ -6,7 +6,9 @@
 package org.opensearch.indexmanagement.indexstatemanagement.action
 
 import org.opensearch.action.search.SearchResponse
+import org.opensearch.client.Request
 import org.opensearch.indexmanagement.IndexManagementIndices
+import org.opensearch.indexmanagement.IndexManagementIndices.Companion.HISTORY_ALL
 import org.opensearch.indexmanagement.indexstatemanagement.IndexStateManagementRestTestCase
 import org.opensearch.indexmanagement.indexstatemanagement.model.Policy
 import org.opensearch.indexmanagement.indexstatemanagement.model.State
@@ -164,7 +166,8 @@ class IndexStateManagementHistoryIT : IndexStateManagementRestTestCase() {
     }
 
     fun `test history shard settings`() {
-        deleteIndex(IndexManagementIndices.HISTORY_ALL)
+        val deleteISMHistoryIndexRequest = Request("DELETE", "/$HISTORY_ALL")
+        adminClient().performRequest(deleteISMHistoryIndexRequest)
         val indexName = "${testIndexName}_shard_settings"
         val policyID = "${testIndexName}_shard_settings_1"
         val actionConfig = ReadOnlyAction(0)


### PR DESCRIPTION
### Description

Use adminClient when deleting history index in IndexStateManagementHistoryIT

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/index-management/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
