### PR TITLE
Add write permissions to delete_backport_branch workflow

### DIFF
--- a/.github/workflows/delete_backport_branch.yml
+++ b/.github/workflows/delete_backport_branch.yml
@@ -7,6 +7,8 @@ on:
 jobs:
   delete-branch:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     if: startsWith(github.event.pull_request.head.ref,'backport/') || startsWith(github.event.pull_request.head.ref,'release-chores/')
     steps:
       - name: Delete merged branch


### PR DESCRIPTION
This PR adds write permissions to the delete_backport_branch workflow to ensure it has the necessary permissions to delete branches.