### PR TITLE
do not include global state in snapshot step

### DIFF
--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/snapshot/AttemptSnapshotStep.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/snapshot/AttemptSnapshotStep.kt
@@ -69,6 +69,7 @@ class AttemptSnapshotStep(private val action: SnapshotAction) : Step(name) {
                 CreateSnapshotRequest()
                     .userMetadata(mapOf("snapshot_created" to "Open Distro for Elasticsearch Index Management"))
                     .indices(indexName)
+                    .includeGlobalState(false)
                     .snapshot(snapshotName)
                     .repository(repository)
                     .waitForCompletion(false)


### PR DESCRIPTION
### Description
This PR should adjust the *snapshot* step within ISM actions to *not* include the *global state*

### Related Issues
Resolves #1479

<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/index-management/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
