### PR TITLE
fix: don't call Alias API if aliasActions are empty

### DIFF
--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/rollover/AttemptRolloverStep.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/rollover/AttemptRolloverStep.kt
@@ -349,6 +349,17 @@ class AttemptRolloverStep(private val action: RolloverAction) : Step(name) {
                     .isHidden(aliasMetadata.isHidden)
             aliasActions.add(aliasAction)
         }
+
+        if (aliasActions.isEmpty()) {
+            stepStatus = StepStatus.COMPLETED
+            info =
+                listOfNotNull(
+                    "message" to getSuccessNoAliasesToCopyMessage(indexName, rolledOverIndexName),
+                    if (conditions != null) "conditions" to conditions else null,
+                ).toMap()
+            return
+        }
+
         val aliasReq = IndicesAliasesRequest()
         aliasActions.forEach { aliasReq.addAliasAction(it) }
 
@@ -433,6 +444,9 @@ class AttemptRolloverStep(private val action: RolloverAction) : Step(name) {
 
         fun getSuccessCopyAliasMessage(index: String, newIndex: String) =
             "Successfully rolled over and copied alias from [index=$index] to [index=$newIndex]"
+
+        fun getSuccessNoAliasesToCopyMessage(index: String, newIndex: String) =
+            "Successfully rolled over index [index=$index] to [index=$newIndex], no additional aliases to copy"
 
         fun getFailedCopyAliasMessage(index: String, newIndex: String) =
             "Successfully rolled over but failed to copy alias from [index=$index] to [index=$newIndex]"

--- a/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/AttemptRolloverStepTests.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/AttemptRolloverStepTests.kt
@@ -18,6 +18,7 @@ import org.mockito.ArgumentMatchers.eq
 import org.opensearch.action.admin.indices.rollover.RolloverResponse
 import org.opensearch.action.support.clustermanager.AcknowledgedResponse
 import org.opensearch.cluster.ClusterState
+import org.opensearch.cluster.metadata.AliasMetadata
 import org.opensearch.cluster.metadata.IndexMetadata
 import org.opensearch.cluster.metadata.Metadata
 import org.opensearch.cluster.service.ClusterService
@@ -53,6 +54,7 @@ class AttemptRolloverStepTests : OpenSearchTestCase() {
     private val oldIndexName = "old_index"
     private val newIndexName = "new_index"
     val alias = "alias"
+    val additionalAlias = "additional_alias"
     private lateinit var metricsRegistry: MetricsRegistry
     private lateinit var rolloverActionMetrics: RolloverActionMetrics
 
@@ -85,6 +87,14 @@ class AttemptRolloverStepTests : OpenSearchTestCase() {
 
         // mock rolloverInfos
         whenever(metadata.index(oldIndexName).rolloverInfos).thenReturn(mapOf(alias to mock()))
+
+        // Mock the aliases: rollover alias + an additional alias to copy
+        whenever(indexMetadata.aliases).thenReturn(
+            mapOf(
+                alias to AliasMetadata.builder(alias).build(),
+                additionalAlias to AliasMetadata.builder(additionalAlias).build(),
+            ),
+        )
     }
 
     fun `test copy alias in rollover step is not acknowledged`() {
@@ -191,6 +201,35 @@ class AttemptRolloverStepTests : OpenSearchTestCase() {
         }
     }
 
+    fun `test copy alias in rollover step with no additional aliases to copy`() {
+        val rolloverResponse = RolloverResponse(oldIndexName, newIndexName, mapOf(), false, true, true, true)
+        val client = getClient(getAdminClient(getIndicesAdminClient(rolloverResponse, null, null, null)))
+
+        // Override setup to have only rollover alias (no additional aliases to copy)
+        val metadata = clusterService.state().metadata()
+        val indexMetadata = metadata.index(oldIndexName)
+        whenever(indexMetadata.aliases).thenReturn(mapOf(alias to AliasMetadata.builder(alias).build()))
+
+        runBlocking {
+            val rolloverAction = RolloverAction(null, null, null, null, true, false, 0)
+            val managedIndexMetaData =
+                ManagedIndexMetaData(
+                    oldIndexName, "indexUuid", "policy_id",
+                    null, null, null,
+                    null, null, null,
+                    null, ActionMetaData("rollover", Instant.now().toEpochMilli(), 0, false, 1, null, null), null,
+                    null, null, rolledOverIndexName = newIndexName,
+                )
+            val attemptRolloverStep = AttemptRolloverStep(rolloverAction)
+            val context = StepContext(managedIndexMetaData, clusterService, client, null, null, scriptService, settings, lockService)
+            attemptRolloverStep.preExecute(logger, context).execute().postExecute(logger, IndexManagementActionsMetrics.instance, attemptRolloverStep, managedIndexMetaData)
+            val updatedManagedIndexMetaData = attemptRolloverStep.getUpdatedManagedIndexMetadata(managedIndexMetaData)
+            assertEquals("Step status is not COMPLETED", Step.StepStatus.COMPLETED, updatedManagedIndexMetaData.stepMetaData?.stepStatus)
+            assertEquals("message info is not matched", AttemptRolloverStep.getSuccessNoAliasesToCopyMessage(oldIndexName, newIndexName), updatedManagedIndexMetaData.info?.get("message"))
+            verify(rolloverActionMetrics.successes).add(eq(1.0), any<Tags>())
+        }
+    }
+
     private fun getClient(adminClient: AdminClient): Client = mock { on { admin() } doReturn adminClient }
 
     private fun getAdminClient(indicesAdminClient: IndicesAdminClient): AdminClient = mock { on { indices() } doReturn indicesAdminClient }
@@ -205,10 +244,13 @@ class AttemptRolloverStepTests : OpenSearchTestCase() {
             "Must provide one and only one response or exception",
             (rolloverResponse != null).xor(rolloverException != null),
         )
-        assertTrue(
-            "Must provide one and only one response or exception",
-            (aliasResponse != null).xor(aliasException != null),
-        )
+        // Allow both aliasResponse and aliasException to be null (for tests where aliases() is not called)
+        if (aliasResponse != null || aliasException != null) {
+            assertTrue(
+                "Must provide one and only one response or exception",
+                (aliasResponse != null).xor(aliasException != null),
+            )
+        }
         return mock {
             doAnswer { invocationOnMock ->
                 val listener = invocationOnMock.getArgument<ActionListener<AcknowledgedResponse>>(1)
@@ -223,9 +265,10 @@ class AttemptRolloverStepTests : OpenSearchTestCase() {
                 val listener = invocationOnMock.getArgument<ActionListener<AcknowledgedResponse>>(1)
                 if (aliasResponse != null) {
                     listener.onResponse(aliasResponse)
-                } else {
+                } else if (aliasException != null) {
                     listener.onFailure(aliasException)
                 }
+                // If both are null, do nothing (for tests where aliases() should not be called)
             }.whenever(this.mock).aliases(any(), any())
         }
     }


### PR DESCRIPTION
### Description
If index has only a single alias that has been rolled over on, copyAlias() throws exception, becuse it tries to call Alias API with empty actions param.

### Related Issues
Resolves https://github.com/opensearch-project/index-management/issues/1488
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/index-management/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
