### PR TITLE
Adapt ActionFilter interface implementation to core change

### DIFF
--- a/src/main/kotlin/org/opensearch/indexmanagement/controlcenter/notification/filter/IndexOperationActionFilter.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/controlcenter/notification/filter/IndexOperationActionFilter.kt
@@ -9,6 +9,7 @@ import org.apache.logging.log4j.LogManager
 import org.opensearch.action.ActionRequest
 import org.opensearch.action.support.ActionFilter
 import org.opensearch.action.support.ActionFilterChain
+import org.opensearch.action.support.ActionRequestMetadata
 import org.opensearch.action.support.ActiveShardsObserver
 import org.opensearch.cluster.metadata.IndexNameExpressionResolver
 import org.opensearch.cluster.service.ClusterService
@@ -33,6 +34,7 @@ class IndexOperationActionFilter(
         task: Task,
         action: String,
         request: Request,
+        actionRequestMetadata: ActionRequestMetadata<Request, Response>,
         listener: ActionListener<Response>,
         chain: ActionFilterChain<Request, Response>,
     ) {

--- a/src/main/kotlin/org/opensearch/indexmanagement/rollup/actionfilter/FieldCapsFilter.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/rollup/actionfilter/FieldCapsFilter.kt
@@ -12,6 +12,7 @@ import org.opensearch.action.fieldcaps.FieldCapabilitiesRequest
 import org.opensearch.action.fieldcaps.FieldCapabilitiesResponse
 import org.opensearch.action.support.ActionFilter
 import org.opensearch.action.support.ActionFilterChain
+import org.opensearch.action.support.ActionRequestMetadata
 import org.opensearch.action.support.IndicesOptions
 import org.opensearch.cluster.metadata.IndexNameExpressionResolver
 import org.opensearch.cluster.service.ClusterService
@@ -49,6 +50,7 @@ class FieldCapsFilter(
         task: Task,
         action: String,
         request: Request,
+        actionRequestMetadata: ActionRequestMetadata<Request, Response>,
         listener: ActionListener<Response>,
         chain: ActionFilterChain<Request, Response>,
     ) {


### PR DESCRIPTION
### Description

The core PR https://github.com/opensearch-project/OpenSearch/pull/18523 has changed the `ActionFilter` interface by adding a new `apply()` method with an additional parameter. The old `apply()` method is now deprecated. This change adds the parameter to the ActionFilter implementations.

### Check List
- [x] Commits are signed per the DCO using `--signoff`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/index-management/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
