### PR TITLE
[Backport 3.4] Add boolean parameter to the ISM rollover action that prevents rollover on empty indices

### DIFF
--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/action/RolloverAction.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/action/RolloverAction.kt
@@ -5,6 +5,7 @@
 
 package org.opensearch.indexmanagement.indexstatemanagement.action
 
+import org.opensearch.Version
 import org.opensearch.common.unit.TimeValue
 import org.opensearch.core.common.io.stream.StreamOutput
 import org.opensearch.core.common.unit.ByteSizeValue
@@ -21,6 +22,7 @@ class RolloverAction(
     val minAge: TimeValue?,
     val minPrimaryShardSize: ByteSizeValue?,
     val copyAlias: Boolean = false,
+    val preventEmptyRollover: Boolean = false,
     index: Int,
 ) : Action(name, index) {
     init {
@@ -48,6 +50,7 @@ class RolloverAction(
         if (minAge != null) builder.field(MIN_INDEX_AGE_FIELD, minAge.stringRep)
         if (minPrimaryShardSize != null) builder.field(MIN_PRIMARY_SHARD_SIZE_FIELD, minPrimaryShardSize.stringRep)
         builder.field(COPY_ALIAS_FIELD, copyAlias)
+        if (preventEmptyRollover) builder.field(PREVENT_EMPTY_ROLLOVER_FIELD, preventEmptyRollover)
         builder.endObject()
     }
 
@@ -57,6 +60,9 @@ class RolloverAction(
         out.writeOptionalTimeValue(minAge)
         out.writeOptionalWriteable(minPrimaryShardSize)
         out.writeBoolean(copyAlias)
+        if (out.version.onOrAfter(Version.V_3_4_0)) {
+            out.writeBoolean(preventEmptyRollover)
+        }
         out.writeInt(actionIndex)
     }
 
@@ -67,5 +73,6 @@ class RolloverAction(
         const val MIN_INDEX_AGE_FIELD = "min_index_age"
         const val MIN_PRIMARY_SHARD_SIZE_FIELD = "min_primary_shard_size"
         const val COPY_ALIAS_FIELD = "copy_alias"
+        const val PREVENT_EMPTY_ROLLOVER_FIELD = "prevent_empty_rollover"
     }
 }

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/action/RolloverActionParser.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/action/RolloverActionParser.kt
@@ -5,6 +5,7 @@
 
 package org.opensearch.indexmanagement.indexstatemanagement.action
 
+import org.opensearch.Version
 import org.opensearch.common.unit.TimeValue
 import org.opensearch.core.common.io.stream.StreamInput
 import org.opensearch.core.common.unit.ByteSizeValue
@@ -20,9 +21,14 @@ class RolloverActionParser : ActionParser() {
         val minAge = sin.readOptionalTimeValue()
         val minPrimaryShardSize = sin.readOptionalWriteable(::ByteSizeValue)
         val copyAlias = sin.readBoolean()
+        val preventEmptyRollover = if (sin.version.onOrAfter(Version.V_3_4_0)) {
+            sin.readBoolean()
+        } else {
+            false
+        }
         val index = sin.readInt()
 
-        return RolloverAction(minSize, minDocs, minAge, minPrimaryShardSize, copyAlias, index)
+        return RolloverAction(minSize, minDocs, minAge, minPrimaryShardSize, copyAlias, preventEmptyRollover, index)
     }
 
     override fun fromXContent(xcp: XContentParser, index: Int): Action {
@@ -31,6 +37,7 @@ class RolloverActionParser : ActionParser() {
         var minAge: TimeValue? = null
         var minPrimaryShardSize: ByteSizeValue? = null
         var copyAlias = false
+        var preventEmptyRollover = false
 
         ensureExpectedToken(XContentParser.Token.START_OBJECT, xcp.currentToken(), xcp)
         while (xcp.nextToken() != XContentParser.Token.END_OBJECT) {
@@ -49,11 +56,14 @@ class RolloverActionParser : ActionParser() {
                                 .MIN_PRIMARY_SHARD_SIZE_FIELD,
                         )
                 RolloverAction.COPY_ALIAS_FIELD -> copyAlias = xcp.booleanValue()
+
+                RolloverAction.PREVENT_EMPTY_ROLLOVER_FIELD -> preventEmptyRollover = xcp.booleanValue()
+
                 else -> throw IllegalArgumentException("Invalid field: [$fieldName] found in RolloverAction.")
             }
         }
 
-        return RolloverAction(minSize, minDocs, minAge, minPrimaryShardSize, copyAlias, index)
+        return RolloverAction(minSize, minDocs, minAge, minPrimaryShardSize, copyAlias, preventEmptyRollover, index)
     }
 
     override fun getActionType(): String = RolloverAction.name

--- a/src/main/resources/mappings/opendistro-ism-config.json
+++ b/src/main/resources/mappings/opendistro-ism-config.json
@@ -1,6 +1,6 @@
 {
   "_meta" : {
-    "schema_version": 24
+    "schema_version": 25
   },
   "dynamic": "strict",
   "properties": {
@@ -244,6 +244,9 @@
                       "type": "keyword"
                     },
                     "copy_alias": {
+                      "type": "boolean"
+                    },
+                    "prevent_empty_rollover": {
                       "type": "boolean"
                     }
                   }

--- a/src/test/kotlin/org/opensearch/indexmanagement/IndexManagementRestTestCase.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/IndexManagementRestTestCase.kt
@@ -41,7 +41,7 @@ import javax.management.remote.JMXConnectorFactory
 import javax.management.remote.JMXServiceURL
 
 abstract class IndexManagementRestTestCase : ODFERestTestCase() {
-    val configSchemaVersion = 24
+    val configSchemaVersion = 25
     val historySchemaVersion = 7
 
     // Having issues with tests leaking into other tests and mappings being incorrect and they are not caught by any pending task wait check as

--- a/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/TestHelpers.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/TestHelpers.kt
@@ -133,6 +133,7 @@ fun randomRolloverActionConfig(
     minDocs = minDocs,
     minAge = minAge,
     minPrimaryShardSize = minPrimaryShardSize,
+    preventEmptyRollover = false,
     index = 0,
 )
 

--- a/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/action/RolloverActionIT.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/action/RolloverActionIT.kt
@@ -41,7 +41,7 @@ class RolloverActionIT : IndexStateManagementRestTestCase() {
         val indexNameBase = "${testIndexName}_index"
         val firstIndex = "$indexNameBase-1"
         val policyID = "${testIndexName}_testPolicyName_1"
-        val actionConfig = RolloverAction(null, null, null, null, false, 0)
+        val actionConfig = RolloverAction(null, null, null, null, false, false, 0)
         val states = listOf(State(name = "RolloverAction", actions = listOf(actionConfig), transitions = listOf()))
         val policy =
             Policy(
@@ -96,7 +96,7 @@ class RolloverActionIT : IndexStateManagementRestTestCase() {
         )
 
         val policyID = "${testIndexName}_bwc"
-        val actionConfig = RolloverAction(null, null, null, null, false, 0)
+        val actionConfig = RolloverAction(null, null, null, null, false, false, 0)
         val states = listOf(State(name = "RolloverAction", actions = listOf(actionConfig), transitions = listOf()))
         val policy =
             Policy(
@@ -134,7 +134,7 @@ class RolloverActionIT : IndexStateManagementRestTestCase() {
         val indexNameBase = "${testIndexName}_index_byte"
         val firstIndex = "$indexNameBase-1"
         val policyID = "${testIndexName}_testPolicyName_byte_1"
-        val actionConfig = RolloverAction(ByteSizeValue(10, ByteSizeUnit.BYTES), 1000000, null, null, false, 0)
+        val actionConfig = RolloverAction(ByteSizeValue(10, ByteSizeUnit.BYTES), 1000000, null, null, false, false, 0)
         val states = listOf(State(name = "RolloverAction", actions = listOf(actionConfig), transitions = listOf()))
         val policy =
             Policy(
@@ -207,7 +207,7 @@ class RolloverActionIT : IndexStateManagementRestTestCase() {
         val indexNameBase = "${testIndexName}_index_primary_shard"
         val firstIndex = "$indexNameBase-1"
         val policyID = "${testIndexName}_primary_shard_1"
-        val actionConfig = RolloverAction(null, null, null, ByteSizeValue(100, ByteSizeUnit.KB), false, 0)
+        val actionConfig = RolloverAction(null, null, null, ByteSizeValue(100, ByteSizeUnit.KB), false, false, 0)
         val states = listOf(State(name = "RolloverAction", actions = listOf(actionConfig), transitions = listOf()))
         val policy =
             Policy(
@@ -319,7 +319,7 @@ class RolloverActionIT : IndexStateManagementRestTestCase() {
         val indexNameBase = "${testIndexName}_index_doc"
         val firstIndex = "$indexNameBase-1"
         val policyID = "${testIndexName}_testPolicyName_doc_1"
-        val actionConfig = RolloverAction(null, 3, TimeValue.timeValueDays(2), null, false, 0)
+        val actionConfig = RolloverAction(null, 3, TimeValue.timeValueDays(2), null, false, false, 0)
         val states = listOf(State(name = "RolloverAction", actions = listOf(actionConfig), transitions = listOf()))
         val policy =
             Policy(
@@ -393,7 +393,7 @@ class RolloverActionIT : IndexStateManagementRestTestCase() {
         val index2 = "index-2"
         val alias1 = "x"
         val policyID = "${testIndexName}_precheck"
-        val actionConfig = RolloverAction(null, 3, TimeValue.timeValueDays(2), null, false, 0)
+        val actionConfig = RolloverAction(null, 3, TimeValue.timeValueDays(2), null, false, false, 0)
         actionConfig.configRetry = ActionRetry(0)
         val states = listOf(State(name = "RolloverAction", actions = listOf(actionConfig), transitions = listOf()))
         val policy =
@@ -454,7 +454,7 @@ class RolloverActionIT : IndexStateManagementRestTestCase() {
         val policyID = "${testIndexName}_rollover_policy"
 
         // Create the rollover policy
-        val rolloverAction = RolloverAction(null, null, null, null, false, 0)
+        val rolloverAction = RolloverAction(null, null, null, null, false, false, 0)
         val states = listOf(State(name = "default", actions = listOf(rolloverAction), transitions = listOf()))
         val policy =
             Policy(
@@ -514,7 +514,7 @@ class RolloverActionIT : IndexStateManagementRestTestCase() {
         val policyID = "${testIndexName}_rollover_policy_multi"
 
         // Create the rollover policy
-        val rolloverAction = RolloverAction(null, 3, TimeValue.timeValueDays(2), null, false, 0)
+        val rolloverAction = RolloverAction(null, 3, TimeValue.timeValueDays(2), null, false, false, 0)
         val states = listOf(State(name = "default", actions = listOf(rolloverAction), transitions = listOf()))
         val policy =
             Policy(
@@ -610,7 +610,7 @@ class RolloverActionIT : IndexStateManagementRestTestCase() {
         val indexNameBase = "${testIndexName}_index"
         val firstIndex = "$indexNameBase-1"
         val policyID = "${testIndexName}_testPolicyName_1"
-        val actionConfig = RolloverAction(null, null, null, null, false, 0)
+        val actionConfig = RolloverAction(null, null, null, null, false, false, 0)
         val states = listOf(State(name = "RolloverAction", actions = listOf(actionConfig), transitions = listOf()))
         val policy =
             Policy(
@@ -653,7 +653,7 @@ class RolloverActionIT : IndexStateManagementRestTestCase() {
         val indexNameBase = "${testIndexName}_index_doc"
         val firstIndex = "$indexNameBase-1"
         val policyID = "${testIndexName}_testPolicyName_doc_1"
-        val actionConfig = RolloverAction(null, 3, TimeValue.timeValueDays(2), null, true, 0)
+        val actionConfig = RolloverAction(null, 3, TimeValue.timeValueDays(2), null, true, false, 0)
         val states = listOf(State(name = "RolloverAction", actions = listOf(actionConfig), transitions = listOf()))
         val policy =
             Policy(
@@ -752,7 +752,7 @@ class RolloverActionIT : IndexStateManagementRestTestCase() {
         val indexNameBase = "${testIndexName}_index"
         val firstIndex = "$indexNameBase-1"
         val policyID = "${testIndexName}_testPolicyName_1"
-        val actionConfig = RolloverAction(null, 1, null, null, false, 0)
+        val actionConfig = RolloverAction(null, 1, null, null, false, false, 0)
         val states = listOf(State(name = "RolloverAction", actions = listOf(actionConfig), transitions = listOf()))
         val policy =
             Policy(
@@ -808,5 +808,173 @@ class RolloverActionIT : IndexStateManagementRestTestCase() {
             assertEquals("Executing the wrong step", "attempt_rollover", metadata.stepMetaData?.name)
             assertEquals("rollover step did not continue executing after detecting the transient failure.", Step.StepStatus.COMPLETED, metadata.stepMetaData?.stepStatus)
         }
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    fun `test empty index is not rolled over with preventEmptyRollover`() {
+        val aliasName = "${testIndexName}_prevent_empty_alias"
+        val indexNameBase = "${testIndexName}_prevent_empty_index"
+        val firstIndex = "$indexNameBase-1"
+        val policyID = "${testIndexName}_prevent_empty_policy"
+        val actionConfig = RolloverAction(null, null, TimeValue.timeValueSeconds(1), null, false, true, 0)
+        val states = listOf(State(name = "RolloverAction", actions = listOf(actionConfig), transitions = listOf()))
+        val policy =
+            Policy(
+                id = policyID,
+                description = "$testIndexName description",
+                schemaVersion = 1L,
+                lastUpdatedTime = Instant.now().truncatedTo(ChronoUnit.MILLIS),
+                errorNotification = randomErrorNotification(),
+                defaultState = states[0].name,
+                states = states,
+            )
+
+        createPolicy(policy, policyID)
+        createIndex(firstIndex, policyID, aliasName)
+
+        val managedIndexConfig = getExistingManagedIndexConfig(firstIndex)
+
+        // Initialize the policy
+        updateManagedIndexConfigStartTime(managedIndexConfig)
+        waitFor { assertEquals(policyID, getExplainManagedIndexMetaData(firstIndex).policyID) }
+
+        // Wait for age condition to be met
+        Thread.sleep(1500)
+
+        // Execute rollover step - should be prevented due to empty index
+        updateManagedIndexConfigStartTime(managedIndexConfig)
+        waitFor {
+            val metadata = getExplainManagedIndexMetaData(firstIndex)
+            val info = metadata.info as Map<String, Any?>
+            assertEquals(
+                "Rollover was not prevented for empty index",
+                AttemptRolloverStep.getPreventedEmptyRolloverMessage(firstIndex), info["message"],
+            )
+            assertEquals(
+                "Step status should be CONDITION_NOT_MET",
+                Step.StepStatus.CONDITION_NOT_MET, metadata.stepMetaData?.stepStatus,
+            )
+
+            val conditions = info["conditions"] as Map<String, Any?>
+            assertTrue(
+                "Should have prevent_empty_rollover condition",
+                conditions.containsKey("prevent_empty_rollover"),
+            )
+            val preventCondition = conditions["prevent_empty_rollover"] as Map<String, Any?>
+            assertEquals("Condition should be message", "index must have at least 1 document", preventCondition["condition"])
+            assertEquals("Current doc count should be 0", 0, preventCondition["current"])
+        }
+
+        // Verify new index was NOT created
+        assertFalse("New rollover index should not exist", indexExists("$indexNameBase-000002"))
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    fun `test rollover proceeds after documents added with preventEmptyRollover`() {
+        val aliasName = "${testIndexName}_prevent_then_rollover_alias"
+        val indexNameBase = "${testIndexName}_prevent_then_rollover_index"
+        val firstIndex = "$indexNameBase-1"
+        val policyID = "${testIndexName}_prevent_then_rollover_policy"
+        val actionConfig = RolloverAction(null, null, TimeValue.timeValueSeconds(1), null, false, true, 0)
+        val states = listOf(State(name = "RolloverAction", actions = listOf(actionConfig), transitions = listOf()))
+        val policy =
+            Policy(
+                id = policyID,
+                description = "$testIndexName description",
+                schemaVersion = 1L,
+                lastUpdatedTime = Instant.now().truncatedTo(ChronoUnit.MILLIS),
+                errorNotification = randomErrorNotification(),
+                defaultState = states[0].name,
+                states = states,
+            )
+
+        createPolicy(policy, policyID)
+        createIndex(firstIndex, policyID, aliasName)
+
+        val managedIndexConfig = getExistingManagedIndexConfig(firstIndex)
+
+        // Initialize the policy
+        updateManagedIndexConfigStartTime(managedIndexConfig)
+        waitFor { assertEquals(policyID, getExplainManagedIndexMetaData(firstIndex).policyID) }
+
+        // Wait for age condition to be met
+        Thread.sleep(1500)
+
+        // Execute rollover step multiple times - should remain CONDITION_NOT_MET without consuming retries
+        for (i in 1..3) {
+            updateManagedIndexConfigStartTime(managedIndexConfig)
+            waitFor {
+                val metadata = getExplainManagedIndexMetaData(firstIndex)
+                assertEquals(
+                    "Step status should be CONDITION_NOT_MET on attempt $i",
+                    Step.StepStatus.CONDITION_NOT_MET, metadata.stepMetaData?.stepStatus,
+                )
+                assertEquals(
+                    "Retries should not be consumed on attempt $i",
+                    0, metadata.actionMetaData?.consumedRetries ?: 0,
+                )
+            }
+        }
+
+        // Add a document
+        insertSampleData(index = firstIndex, docCount = 1, delay = 0)
+
+        // Execute again - should now rollover
+        updateManagedIndexConfigStartTime(managedIndexConfig)
+        waitFor {
+            val info = getExplainManagedIndexMetaData(firstIndex).info as Map<String, Any?>
+            assertEquals(
+                "Index did not rollover after adding documents",
+                AttemptRolloverStep.getSuccessMessage(firstIndex), info["message"],
+            )
+        }
+
+        // Verify new index was created
+        assertTrue("New rollover index should exist", indexExists("$indexNameBase-000002"))
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    fun `test default behavior without preventEmptyRollover`() {
+        val aliasName = "${testIndexName}_default_behavior_alias"
+        val indexNameBase = "${testIndexName}_default_behavior_index"
+        val firstIndex = "$indexNameBase-1"
+        val policyID = "${testIndexName}_default_behavior_policy"
+        // preventEmptyRollover defaults to false
+        val actionConfig = RolloverAction(null, null, TimeValue.timeValueSeconds(1), null, false, false, 0)
+        val states = listOf(State(name = "RolloverAction", actions = listOf(actionConfig), transitions = listOf()))
+        val policy =
+            Policy(
+                id = policyID,
+                description = "$testIndexName description",
+                schemaVersion = 1L,
+                lastUpdatedTime = Instant.now().truncatedTo(ChronoUnit.MILLIS),
+                errorNotification = randomErrorNotification(),
+                defaultState = states[0].name,
+                states = states,
+            )
+
+        createPolicy(policy, policyID)
+        createIndex(firstIndex, policyID, aliasName)
+
+        val managedIndexConfig = getExistingManagedIndexConfig(firstIndex)
+
+        // Initialize the policy
+        updateManagedIndexConfigStartTime(managedIndexConfig)
+        waitFor { assertEquals(policyID, getExplainManagedIndexMetaData(firstIndex).policyID) }
+
+        // Wait for age condition to be met
+        Thread.sleep(1500)
+
+        // Execute rollover step - should succeed even though index is empty (existing behavior)
+        updateManagedIndexConfigStartTime(managedIndexConfig)
+        waitFor {
+            val info = getExplainManagedIndexMetaData(firstIndex).info as Map<String, Any?>
+            assertEquals(
+                "Empty index should rollover with default behavior",
+                AttemptRolloverStep.getSuccessMessage(firstIndex), info["message"],
+            )
+        }
+
+        assertTrue("New rollover index should exist", indexExists("$indexNameBase-000002"))
     }
 }

--- a/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/action/RolloverActionTests.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/action/RolloverActionTests.kt
@@ -1,0 +1,398 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.indexmanagement.indexstatemanagement.action
+
+import org.opensearch.Version
+import org.opensearch.common.unit.TimeValue
+import org.opensearch.common.xcontent.LoggingDeprecationHandler
+import org.opensearch.common.xcontent.XContentFactory
+import org.opensearch.common.xcontent.XContentType
+import org.opensearch.core.common.io.stream.InputStreamStreamInput
+import org.opensearch.core.common.io.stream.OutputStreamStreamOutput
+import org.opensearch.core.common.unit.ByteSizeValue
+import org.opensearch.indexmanagement.indexstatemanagement.ISMActionsParser
+import org.opensearch.indexmanagement.opensearchapi.string
+import org.opensearch.indexmanagement.spi.indexstatemanagement.model.ActionRetry
+import org.opensearch.indexmanagement.spi.indexstatemanagement.model.ActionTimeout
+import org.opensearch.test.OpenSearchTestCase
+import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
+
+class RolloverActionTests : OpenSearchTestCase() {
+
+    fun `test XContent serialization with preventEmptyRollover true`() {
+        val action = RolloverAction(
+            minSize = ByteSizeValue.parseBytesSizeValue("50gb", "test"),
+            minDocs = 1000L,
+            minAge = TimeValue.parseTimeValue("7d", "test"),
+            minPrimaryShardSize = ByteSizeValue.parseBytesSizeValue("30gb", "test"),
+            copyAlias = false,
+            preventEmptyRollover = true,
+            index = 0,
+        )
+
+        val builder = XContentFactory.jsonBuilder()
+        builder.startObject()
+        action.populateAction(builder, org.opensearch.core.xcontent.ToXContent.EMPTY_PARAMS)
+        builder.endObject()
+
+        val jsonString = builder.string()
+        assertTrue("XContent should contain prevent_empty_rollover field", jsonString.contains("\"prevent_empty_rollover\":true"))
+    }
+
+    fun `test XContent serialization with preventEmptyRollover false`() {
+        val action = RolloverAction(
+            minSize = ByteSizeValue.parseBytesSizeValue("50gb", "test"),
+            minDocs = 1000L,
+            minAge = TimeValue.parseTimeValue("7d", "test"),
+            minPrimaryShardSize = ByteSizeValue.parseBytesSizeValue("30gb", "test"),
+            copyAlias = false,
+            preventEmptyRollover = false,
+            index = 0,
+        )
+
+        val builder = XContentFactory.jsonBuilder()
+        builder.startObject()
+        action.populateAction(builder, org.opensearch.core.xcontent.ToXContent.EMPTY_PARAMS)
+        builder.endObject()
+
+        val jsonString = builder.string()
+        assertFalse(
+            "XContent should NOT contain prevent_empty_rollover field when false",
+            jsonString.contains("prevent_empty_rollover"),
+        )
+    }
+
+    fun `test StreamOutput serialization`() {
+        val originalAction = RolloverAction(
+            minSize = ByteSizeValue.parseBytesSizeValue("50gb", "test"),
+            minDocs = 1000L,
+            minAge = TimeValue.parseTimeValue("7d", "test"),
+            minPrimaryShardSize = ByteSizeValue.parseBytesSizeValue("30gb", "test"),
+            copyAlias = true,
+            preventEmptyRollover = true,
+            index = 0,
+        )
+
+        val baos = ByteArrayOutputStream()
+        val osso = OutputStreamStreamOutput(baos)
+        originalAction.writeTo(osso)
+
+        val input = InputStreamStreamInput(ByteArrayInputStream(baos.toByteArray()))
+        val deserializedAction = ISMActionsParser.instance.fromStreamInput(input) as RolloverAction
+
+        assertEquals("minSize should be preserved", originalAction.minSize, deserializedAction.minSize)
+        assertEquals("minDocs should be preserved", originalAction.minDocs, deserializedAction.minDocs)
+        assertEquals("minAge should be preserved", originalAction.minAge, deserializedAction.minAge)
+        assertEquals("minPrimaryShardSize should be preserved", originalAction.minPrimaryShardSize, deserializedAction.minPrimaryShardSize)
+        assertEquals("copyAlias should be preserved", originalAction.copyAlias, deserializedAction.copyAlias)
+        assertEquals("preventEmptyRollover should be preserved", originalAction.preventEmptyRollover, deserializedAction.preventEmptyRollover)
+    }
+
+    fun `test backward compatibility deserialization`() {
+        // Create XContent without prevent_empty_rollover field
+        val jsonString = """
+            {
+                "rollover": {
+                    "min_size": "50gb",
+                    "min_doc_count": 1000,
+                    "min_index_age": "7d",
+                    "min_primary_shard_size": "30gb",
+                    "copy_alias": false
+                }
+            }
+        """.trimIndent()
+
+        val parser = XContentType.JSON.xContent().createParser(
+            xContentRegistry(),
+            LoggingDeprecationHandler.INSTANCE,
+            jsonString,
+        )
+        parser.nextToken()
+
+        val action = ISMActionsParser.instance.parse(parser, 0) as RolloverAction
+
+        assertFalse("preventEmptyRollover should default to false when not present", action.preventEmptyRollover)
+        assertEquals("minSize should be parsed correctly", ByteSizeValue.parseBytesSizeValue("50gb", "test"), action.minSize)
+        assertEquals("minDocs should be parsed correctly", 1000L, action.minDocs)
+        assertFalse("copyAlias should be parsed correctly", action.copyAlias)
+    }
+
+    fun `test preventEmptyRollover field defaults to false`() {
+        val action = RolloverAction(
+            minSize = ByteSizeValue.parseBytesSizeValue("50gb", "test"),
+            minDocs = null,
+            minAge = null,
+            minPrimaryShardSize = null,
+            copyAlias = false,
+            preventEmptyRollover = false,
+            index = 0,
+        )
+
+        assertFalse("preventEmptyRollover should default to false", action.preventEmptyRollover)
+    }
+
+    fun `test preventEmptyRollover can be set to true`() {
+        val action = RolloverAction(
+            minSize = null,
+            minDocs = null,
+            minAge = TimeValue.parseTimeValue("7d", "test"),
+            minPrimaryShardSize = null,
+            copyAlias = false,
+            preventEmptyRollover = true,
+            index = 0,
+        )
+
+        assertTrue("preventEmptyRollover should be true", action.preventEmptyRollover)
+    }
+
+    fun `test preventEmptyRollover with all conditions`() {
+        val action = RolloverAction(
+            minSize = ByteSizeValue.parseBytesSizeValue("50gb", "test"),
+            minDocs = 1000L,
+            minAge = TimeValue.parseTimeValue("7d", "test"),
+            minPrimaryShardSize = ByteSizeValue.parseBytesSizeValue("30gb", "test"),
+            copyAlias = true,
+            preventEmptyRollover = true,
+            index = 0,
+        )
+
+        assertTrue("preventEmptyRollover should be true", action.preventEmptyRollover)
+        assertTrue("copyAlias should be true", action.copyAlias)
+        assertEquals("minSize should be preserved", ByteSizeValue.parseBytesSizeValue("50gb", "test"), action.minSize)
+        assertEquals("minDocs should be preserved", 1000L, action.minDocs)
+        assertEquals("minAge should be preserved", TimeValue.parseTimeValue("7d", "test"), action.minAge)
+        assertEquals(
+            "minPrimaryShardSize should be preserved",
+            ByteSizeValue.parseBytesSizeValue("30gb", "test"), action.minPrimaryShardSize,
+        )
+    }
+
+    fun `test XContent round trip with all fields`() {
+        val originalAction = RolloverAction(
+            minSize = ByteSizeValue.parseBytesSizeValue("50gb", "test"),
+            minDocs = 1000L,
+            minAge = TimeValue.parseTimeValue("7d", "test"),
+            minPrimaryShardSize = ByteSizeValue.parseBytesSizeValue("30gb", "test"),
+            copyAlias = true,
+            preventEmptyRollover = true,
+            index = 0,
+        )
+
+        val builder = XContentFactory.jsonBuilder()
+        builder.startObject()
+        originalAction.populateAction(builder, org.opensearch.core.xcontent.ToXContent.EMPTY_PARAMS)
+        builder.endObject()
+
+        val parser = XContentType.JSON.xContent().createParser(
+            xContentRegistry(),
+            LoggingDeprecationHandler.INSTANCE,
+            builder.string(),
+        )
+        parser.nextToken() // Move to START_OBJECT
+
+        val parsedAction = ISMActionsParser.instance.parse(parser, 0) as RolloverAction
+
+        assertEquals("minSize should match", originalAction.minSize, parsedAction.minSize)
+        assertEquals("minDocs should match", originalAction.minDocs, parsedAction.minDocs)
+        assertEquals("minAge should match", originalAction.minAge, parsedAction.minAge)
+        assertEquals("minPrimaryShardSize should match", originalAction.minPrimaryShardSize, parsedAction.minPrimaryShardSize)
+        assertEquals("copyAlias should match", originalAction.copyAlias, parsedAction.copyAlias)
+        assertEquals("preventEmptyRollover should match", originalAction.preventEmptyRollover, parsedAction.preventEmptyRollover)
+    }
+
+    fun `test preventEmptyRollover with only minAge condition`() {
+        val action = RolloverAction(
+            minSize = null,
+            minDocs = null,
+            minAge = TimeValue.parseTimeValue("1d", "test"),
+            minPrimaryShardSize = null,
+            copyAlias = false,
+            preventEmptyRollover = true,
+            index = 0,
+        )
+
+        assertTrue("preventEmptyRollover should be true", action.preventEmptyRollover)
+        assertNull("minSize should be null", action.minSize)
+        assertNull("minDocs should be null", action.minDocs)
+        assertNotNull("minAge should not be null", action.minAge)
+        assertNull("minPrimaryShardSize should be null", action.minPrimaryShardSize)
+    }
+
+    fun `test preventEmptyRollover with only minDocs condition`() {
+        val action = RolloverAction(
+            minSize = null,
+            minDocs = 100L,
+            minAge = null,
+            minPrimaryShardSize = null,
+            copyAlias = false,
+            preventEmptyRollover = true,
+            index = 0,
+        )
+
+        assertTrue("preventEmptyRollover should be true", action.preventEmptyRollover)
+        assertNull("minSize should be null", action.minSize)
+        assertEquals("minDocs should be 100", 100L, action.minDocs)
+        assertNull("minAge should be null", action.minAge)
+        assertNull("minPrimaryShardSize should be null", action.minPrimaryShardSize)
+    }
+
+    fun `test preventEmptyRollover with copyAlias true`() {
+        val action = RolloverAction(
+            minSize = null,
+            minDocs = null,
+            minAge = TimeValue.parseTimeValue("1d", "test"),
+            minPrimaryShardSize = null,
+            copyAlias = true,
+            preventEmptyRollover = true,
+            index = 0,
+        )
+
+        assertTrue("preventEmptyRollover should be true", action.preventEmptyRollover)
+        assertTrue("copyAlias should be true", action.copyAlias)
+    }
+
+    fun `test StreamOutput round trip with mixed conditions`() {
+        val originalAction = RolloverAction(
+            minSize = ByteSizeValue.parseBytesSizeValue("10gb", "test"),
+            minDocs = null,
+            minAge = TimeValue.parseTimeValue("3d", "test"),
+            minPrimaryShardSize = null,
+            copyAlias = false,
+            preventEmptyRollover = true,
+            index = 0,
+        )
+
+        val baos = ByteArrayOutputStream()
+        val osso = OutputStreamStreamOutput(baos)
+        originalAction.writeTo(osso)
+
+        val input = InputStreamStreamInput(ByteArrayInputStream(baos.toByteArray()))
+        val deserializedAction = ISMActionsParser.instance.fromStreamInput(input) as RolloverAction
+
+        assertEquals("minSize should be preserved", originalAction.minSize, deserializedAction.minSize)
+        assertNull("minDocs should be null", deserializedAction.minDocs)
+        assertEquals("minAge should be preserved", originalAction.minAge, deserializedAction.minAge)
+        assertNull("minPrimaryShardSize should be null", deserializedAction.minPrimaryShardSize)
+        assertEquals("copyAlias should be preserved", originalAction.copyAlias, deserializedAction.copyAlias)
+        assertEquals("preventEmptyRollover should be preserved", originalAction.preventEmptyRollover, deserializedAction.preventEmptyRollover)
+    }
+
+    fun `test backward compatibility - old version without preventEmptyRollover`() {
+        // Simulate serialization from an older version (< 3.4.0) that doesn't have preventEmptyRollover
+        val baos = ByteArrayOutputStream()
+        val osso = OutputStreamStreamOutput(baos)
+        osso.version = Version.V_3_3_0
+
+        // Write action type and config fields as ISMActionsParser expects
+        osso.writeString("rollover")
+        osso.writeOptionalWriteable(null) // configTimeout
+        osso.writeOptionalWriteable(null) // configRetry
+
+        // Manually write fields as an old version would (without preventEmptyRollover)
+        osso.writeOptionalWriteable(ByteSizeValue.parseBytesSizeValue("50gb", "test"))
+        osso.writeOptionalLong(1000L)
+        osso.writeOptionalTimeValue(TimeValue.parseTimeValue("7d", "test"))
+        osso.writeOptionalWriteable(ByteSizeValue.parseBytesSizeValue("30gb", "test"))
+        osso.writeBoolean(true) // copyAlias
+        // Note: preventEmptyRollover is NOT written for old version
+        osso.writeInt(0) // actionIndex
+
+        // Deserialize with current version parser
+        val input = InputStreamStreamInput(ByteArrayInputStream(baos.toByteArray()))
+        input.version = Version.V_3_3_0
+        val deserializedAction = ISMActionsParser.instance.fromStreamInput(input) as RolloverAction
+
+        assertEquals("minSize should be preserved", ByteSizeValue.parseBytesSizeValue("50gb", "test"), deserializedAction.minSize)
+        assertEquals("minDocs should be preserved", 1000L, deserializedAction.minDocs)
+        assertEquals("minAge should be preserved", TimeValue.parseTimeValue("7d", "test"), deserializedAction.minAge)
+        assertEquals("minPrimaryShardSize should be preserved", ByteSizeValue.parseBytesSizeValue("30gb", "test"), deserializedAction.minPrimaryShardSize)
+        assertTrue("copyAlias should be true", deserializedAction.copyAlias)
+        assertFalse("preventEmptyRollover should default to false for old version", deserializedAction.preventEmptyRollover)
+    }
+
+    fun `test forward compatibility - new version with preventEmptyRollover`() {
+        // Test that new version (>= 3.4.0) correctly serializes and deserializes preventEmptyRollover
+        val originalAction = RolloverAction(
+            minSize = ByteSizeValue.parseBytesSizeValue("50gb", "test"),
+            minDocs = 1000L,
+            minAge = TimeValue.parseTimeValue("7d", "test"),
+            minPrimaryShardSize = ByteSizeValue.parseBytesSizeValue("30gb", "test"),
+            copyAlias = true,
+            preventEmptyRollover = true,
+            index = 0,
+        )
+
+        val baos = ByteArrayOutputStream()
+        val osso = OutputStreamStreamOutput(baos)
+        osso.version = Version.V_3_4_0
+        originalAction.writeTo(osso)
+
+        val input = InputStreamStreamInput(ByteArrayInputStream(baos.toByteArray()))
+        input.version = Version.V_3_4_0
+        val deserializedAction = ISMActionsParser.instance.fromStreamInput(input) as RolloverAction
+
+        assertEquals("minSize should be preserved", originalAction.minSize, deserializedAction.minSize)
+        assertEquals("minDocs should be preserved", originalAction.minDocs, deserializedAction.minDocs)
+        assertEquals("minAge should be preserved", originalAction.minAge, deserializedAction.minAge)
+        assertEquals("minPrimaryShardSize should be preserved", originalAction.minPrimaryShardSize, deserializedAction.minPrimaryShardSize)
+        assertEquals("copyAlias should be preserved", originalAction.copyAlias, deserializedAction.copyAlias)
+        assertTrue("preventEmptyRollover should be preserved as true", deserializedAction.preventEmptyRollover)
+    }
+
+    fun `test version compatibility - writing to old version skips preventEmptyRollover`() {
+        // Test that when writing to an old version node, preventEmptyRollover is not serialized
+        val action = RolloverAction(
+            minSize = ByteSizeValue.parseBytesSizeValue("50gb", "test"),
+            minDocs = 1000L,
+            minAge = TimeValue.parseTimeValue("7d", "test"),
+            minPrimaryShardSize = ByteSizeValue.parseBytesSizeValue("30gb", "test"),
+            copyAlias = true,
+            preventEmptyRollover = true,
+            index = 0,
+        )
+
+        // Serialize with old version (< 3.4.0)
+        val baos = ByteArrayOutputStream()
+        val osso = OutputStreamStreamOutput(baos)
+        osso.version = Version.V_3_3_0
+
+        // Write action type and config fields as ISMActionsParser expects
+        osso.writeString("rollover")
+        osso.writeOptionalWriteable(action.configTimeout)
+        osso.writeOptionalWriteable(action.configRetry)
+
+        // Now write the action itself
+        action.populateAction(osso)
+
+        // The byte array should NOT contain the preventEmptyRollover field
+        // We can verify this by deserializing with old version expectations
+        val input = InputStreamStreamInput(ByteArrayInputStream(baos.toByteArray()))
+        input.version = Version.V_3_3_0
+
+        // Skip the action type and config fields that ISMActionsParser would read
+        input.readString() // action type
+        input.readOptionalWriteable(::ActionTimeout) // configTimeout
+        input.readOptionalWriteable(::ActionRetry) // configRetry
+
+        // Read fields as old version would
+        val minSize = input.readOptionalWriteable(::ByteSizeValue)
+        val minDocs = input.readOptionalLong()
+        val minAge = input.readOptionalTimeValue()
+        val minPrimaryShardSize = input.readOptionalWriteable(::ByteSizeValue)
+        val copyAlias = input.readBoolean()
+        // Old version doesn't read preventEmptyRollover
+        val actionIndex = input.readInt()
+
+        assertEquals("minSize should match", action.minSize, minSize)
+        assertEquals("minDocs should match", action.minDocs, minDocs)
+        assertEquals("minAge should match", action.minAge, minAge)
+        assertEquals("minPrimaryShardSize should match", action.minPrimaryShardSize, minPrimaryShardSize)
+        assertEquals("copyAlias should match", action.copyAlias, copyAlias)
+        assertEquals("actionIndex should match", action.actionIndex, actionIndex)
+        assertEquals("Stream should be fully consumed", 0, input.available())
+    }
+}

--- a/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/coordinator/ManagedIndexCoordinatorIT.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/coordinator/ManagedIndexCoordinatorIT.kt
@@ -144,7 +144,7 @@ class ManagedIndexCoordinatorIT : IndexStateManagementRestTestCase() {
         val policyID = "test_policy_1"
 
         // Create a policy with one State that performs rollover
-        val rolloverActionConfig = RolloverAction(index = 0, minDocs = 5, minAge = null, minSize = null, minPrimaryShardSize = null)
+        val rolloverActionConfig = RolloverAction(index = 0, minDocs = 5, minAge = null, minSize = null, minPrimaryShardSize = null, preventEmptyRollover = false)
         val states =
             listOf(State(name = "RolloverState", actions = listOf(rolloverActionConfig), transitions = listOf()))
         val policy =

--- a/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/resthandler/RestChangePolicyActionIT.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/resthandler/RestChangePolicyActionIT.kt
@@ -598,7 +598,7 @@ class RestChangePolicyActionIT : IndexStateManagementRestTestCase() {
 
     fun `test allowing change policy to happen in middle of state if same state structure`() {
         // Creates a policy that has one state with rollover
-        val action = RolloverAction(index = 0, minDocs = 100_000_000, minAge = null, minSize = null, minPrimaryShardSize = null)
+        val action = RolloverAction(index = 0, minDocs = 100_000_000, minAge = null, minSize = null, minPrimaryShardSize = null, preventEmptyRollover = false)
         val stateWithReadOnlyAction = randomState(actions = listOf(action))
         val randomPolicy = randomPolicy(states = listOf(stateWithReadOnlyAction))
         val policy = createPolicy(randomPolicy)
@@ -631,7 +631,7 @@ class RestChangePolicyActionIT : IndexStateManagementRestTestCase() {
         val newStateWithReadOnlyAction =
             randomState(
                 name = stateWithReadOnlyAction.name,
-                actions = listOf(RolloverAction(index = 0, minDocs = 5, minAge = null, minSize = null, minPrimaryShardSize = null)),
+                actions = listOf(RolloverAction(index = 0, minDocs = 5, minAge = null, minSize = null, minPrimaryShardSize = null, preventEmptyRollover = false)),
             )
         val newRandomPolicy = randomPolicy(states = listOf(newStateWithReadOnlyAction))
         val newPolicy = createPolicy(newRandomPolicy)

--- a/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/AttemptRolloverStepTests.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/AttemptRolloverStepTests.kt
@@ -94,7 +94,7 @@ class AttemptRolloverStepTests : OpenSearchTestCase() {
         val client = getClient(getAdminClient(getIndicesAdminClient(rolloverResponse, aliasResponse, null, null)))
 
         runBlocking {
-            val rolloverAction = RolloverAction(null, null, null, null, true, 0)
+            val rolloverAction = RolloverAction(null, null, null, null, true, false, 0)
             val managedIndexMetaData =
                 ManagedIndexMetaData(
                     oldIndexName, "indexUuid", "policy_id",
@@ -120,7 +120,7 @@ class AttemptRolloverStepTests : OpenSearchTestCase() {
         val client = getClient(getAdminClient(getIndicesAdminClient(rolloverResponse, null, null, exception)))
 
         runBlocking {
-            val rolloverAction = RolloverAction(null, null, null, null, true, 0)
+            val rolloverAction = RolloverAction(null, null, null, null, true, false, 0)
             val managedIndexMetaData =
                 ManagedIndexMetaData(
                     oldIndexName, "indexUuid", "policy_id",
@@ -146,7 +146,7 @@ class AttemptRolloverStepTests : OpenSearchTestCase() {
         val client = getClient(getAdminClient(getIndicesAdminClient(rolloverResponse, null, null, exception)))
 
         runBlocking {
-            val rolloverAction = RolloverAction(null, null, null, null, true, 0)
+            val rolloverAction = RolloverAction(null, null, null, null, true, false, 0)
             val managedIndexMetaData =
                 ManagedIndexMetaData(
                     oldIndexName, "indexUuid", "policy_id",
@@ -172,7 +172,7 @@ class AttemptRolloverStepTests : OpenSearchTestCase() {
         val client = getClient(getAdminClient(getIndicesAdminClient(rolloverResponse, aliasResponse, null, null)))
 
         runBlocking {
-            val rolloverAction = RolloverAction(null, null, null, null, true, 0)
+            val rolloverAction = RolloverAction(null, null, null, null, true, false, 0)
             val managedIndexMetaData =
                 ManagedIndexMetaData(
                     oldIndexName, "indexUuid", "policy_id",

--- a/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/util/ManagedIndexUtilsTests.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/util/ManagedIndexUtilsTests.kt
@@ -129,7 +129,7 @@ class ManagedIndexUtilsTests : OpenSearchTestCase() {
     }
 
     fun `test rollover action config evaluate conditions`() {
-        val noConditionsConfig = RolloverAction(minSize = null, minDocs = null, minAge = null, minPrimaryShardSize = null, index = 0)
+        val noConditionsConfig = RolloverAction(minSize = null, minDocs = null, minAge = null, minPrimaryShardSize = null, preventEmptyRollover = false, index = 0)
         assertTrue(
             "No conditions should always pass",
             noConditionsConfig
@@ -146,7 +146,7 @@ class ManagedIndexUtilsTests : OpenSearchTestCase() {
                 .evaluateConditions(indexAgeTimeValue = TimeValue.timeValueMillis(6000), numDocs = 5, indexSize = ByteSizeValue(5), primaryShardSize = ByteSizeValue(5)),
         )
 
-        val minSizeConfig = RolloverAction(minSize = ByteSizeValue(5), minDocs = null, minAge = null, minPrimaryShardSize = null, index = 0)
+        val minSizeConfig = RolloverAction(minSize = ByteSizeValue(5), minDocs = null, minAge = null, minPrimaryShardSize = null, preventEmptyRollover = false, index = 0)
         assertFalse(
             "Less bytes should not pass",
             minSizeConfig
@@ -163,7 +163,7 @@ class ManagedIndexUtilsTests : OpenSearchTestCase() {
                 .evaluateConditions(indexAgeTimeValue = TimeValue.timeValueMillis(1000), numDocs = 0, indexSize = ByteSizeValue(10), primaryShardSize = ByteSizeValue(10)),
         )
 
-        val minPrimarySizeConfig = RolloverAction(minSize = null, minDocs = null, minAge = null, minPrimaryShardSize = ByteSizeValue(5), index = 0)
+        val minPrimarySizeConfig = RolloverAction(minSize = null, minDocs = null, minAge = null, minPrimaryShardSize = ByteSizeValue(5), preventEmptyRollover = false, index = 0)
         assertFalse(
             "Less primary bytes should not pass",
             minPrimarySizeConfig
@@ -180,7 +180,7 @@ class ManagedIndexUtilsTests : OpenSearchTestCase() {
                 .evaluateConditions(indexAgeTimeValue = TimeValue.timeValueMillis(1000), numDocs = 0, indexSize = ByteSizeValue(10), primaryShardSize = ByteSizeValue(10)),
         )
 
-        val minDocsConfig = RolloverAction(minSize = null, minDocs = 5, minAge = null, minPrimaryShardSize = null, index = 0)
+        val minDocsConfig = RolloverAction(minSize = null, minDocs = 5, minAge = null, minPrimaryShardSize = null, preventEmptyRollover = false, index = 0)
         assertFalse(
             "Less docs should not pass",
             minDocsConfig
@@ -197,7 +197,7 @@ class ManagedIndexUtilsTests : OpenSearchTestCase() {
                 .evaluateConditions(indexAgeTimeValue = TimeValue.timeValueMillis(1000), numDocs = 10, indexSize = ByteSizeValue.ZERO, primaryShardSize = ByteSizeValue.ZERO),
         )
 
-        val minAgeConfig = RolloverAction(minSize = null, minDocs = null, minAge = TimeValue.timeValueSeconds(5), minPrimaryShardSize = null, index = 0)
+        val minAgeConfig = RolloverAction(minSize = null, minDocs = null, minAge = TimeValue.timeValueSeconds(5), minPrimaryShardSize = null, preventEmptyRollover = false, index = 0)
         assertFalse(
             "Index age that is too young should not pass",
             minAgeConfig
@@ -209,7 +209,7 @@ class ManagedIndexUtilsTests : OpenSearchTestCase() {
                 .evaluateConditions(indexAgeTimeValue = TimeValue.timeValueMillis(10000), numDocs = 0, indexSize = ByteSizeValue.ZERO, primaryShardSize = ByteSizeValue.ZERO),
         )
 
-        val multiConfig = RolloverAction(minSize = ByteSizeValue(1), minDocs = 1, minAge = TimeValue.timeValueSeconds(5), minPrimaryShardSize = ByteSizeValue(1), index = 0)
+        val multiConfig = RolloverAction(minSize = ByteSizeValue(1), minDocs = 1, minAge = TimeValue.timeValueSeconds(5), minPrimaryShardSize = ByteSizeValue(1), preventEmptyRollover = false, index = 0)
         assertFalse(
             "No conditions met should not pass",
             multiConfig

--- a/src/test/resources/mappings/cached-opendistro-ism-config.json
+++ b/src/test/resources/mappings/cached-opendistro-ism-config.json
@@ -1,6 +1,6 @@
 {
   "_meta" : {
-    "schema_version": 24
+    "schema_version": 25
   },
   "dynamic": "strict",
   "properties": {
@@ -244,6 +244,9 @@
                       "type": "keyword"
                     },
                     "copy_alias": {
+                      "type": "boolean"
+                    },
+                    "prevent_empty_rollover": {
                       "type": "boolean"
                     }
                   }


### PR DESCRIPTION
### Description
Backport https://github.com/opensearch-project/index-management/pull/1545

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/index-management/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
