### PR TITLE
Add `delete_snapshot` option to ISM delete action for cleaning up searchable snapshot sources

### DIFF
--- a/.github/workflows/test-and-build-workflow.yml
+++ b/.github/workflows/test-and-build-workflow.yml
@@ -52,7 +52,7 @@ jobs:
       # This is a hack, but this step creates a link to the X: mounted drive, which makes the path
       # short enough to work on Windows
       - name: Build with Gradle
-        timeout-minutes: 20
+        timeout-minutes: 25
         run: |
           chown -R 1000:1000 `pwd`
           su `id -un 1000` -c "./gradlew build ${{ env.TEST_FILTER }}"

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/action/DeleteAction.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/action/DeleteAction.kt
@@ -5,6 +5,9 @@
 
 package org.opensearch.indexmanagement.indexstatemanagement.action
 
+import org.opensearch.core.common.io.stream.StreamOutput
+import org.opensearch.core.xcontent.ToXContent
+import org.opensearch.core.xcontent.XContentBuilder
 import org.opensearch.indexmanagement.indexstatemanagement.step.delete.AttemptDeleteStep
 import org.opensearch.indexmanagement.spi.indexstatemanagement.Action
 import org.opensearch.indexmanagement.spi.indexstatemanagement.Step
@@ -12,15 +15,30 @@ import org.opensearch.indexmanagement.spi.indexstatemanagement.model.StepContext
 
 class DeleteAction(
     index: Int,
+    val deleteSnapshot: Boolean = false,
 ) : Action(name, index) {
     companion object {
         const val name = "delete"
+        const val DELETE_SNAPSHOT_FIELD = "delete_snapshot"
     }
 
-    private val attemptDeleteStep = AttemptDeleteStep()
+    private val attemptDeleteStep = AttemptDeleteStep(this)
     private val steps = listOf(attemptDeleteStep)
 
     override fun getStepToExecute(context: StepContext): Step = attemptDeleteStep
 
     override fun getSteps(): List<Step> = steps
+
+    override fun populateAction(builder: XContentBuilder, params: ToXContent.Params) {
+        builder.startObject(type)
+        if (deleteSnapshot) {
+            builder.field(DELETE_SNAPSHOT_FIELD, deleteSnapshot)
+        }
+        builder.endObject()
+    }
+
+    override fun populateAction(out: StreamOutput) {
+        out.writeInt(actionIndex)
+        out.writeBoolean(deleteSnapshot)
+    }
 }

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/delete/AttemptDeleteStep.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/delete/AttemptDeleteStep.kt
@@ -7,8 +7,12 @@ package org.opensearch.indexmanagement.indexstatemanagement.step.delete
 
 import org.apache.logging.log4j.LogManager
 import org.opensearch.ExceptionsHelper
+import org.opensearch.action.admin.cluster.snapshots.delete.DeleteSnapshotRequest
 import org.opensearch.action.admin.indices.delete.DeleteIndexRequest
+import org.opensearch.action.admin.indices.settings.get.GetSettingsRequest
+import org.opensearch.action.admin.indices.settings.get.GetSettingsResponse
 import org.opensearch.action.support.clustermanager.AcknowledgedResponse
+import org.opensearch.indexmanagement.indexstatemanagement.action.DeleteAction
 import org.opensearch.indexmanagement.opensearchapi.suspendUntil
 import org.opensearch.indexmanagement.spi.indexstatemanagement.Step
 import org.opensearch.indexmanagement.spi.indexstatemanagement.model.ManagedIndexMetaData
@@ -16,22 +20,59 @@ import org.opensearch.indexmanagement.spi.indexstatemanagement.model.StepMetaDat
 import org.opensearch.snapshots.SnapshotInProgressException
 import org.opensearch.transport.RemoteTransportException
 
-class AttemptDeleteStep : Step(name) {
+class AttemptDeleteStep(private val action: DeleteAction) : Step(name) {
     private val logger = LogManager.getLogger(javaClass)
     private var stepStatus = StepStatus.STARTING
     private var info: Map<String, Any>? = null
 
+    @Suppress("CyclomaticComplexMethod")
     override suspend fun execute(): Step {
         val context = this.context ?: return this
         val indexName = context.metadata.index
+
+        var snapshotRepository: String? = null
+        var snapshotName: String? = null
+
+        if (action.deleteSnapshot) {
+            try {
+                val settingsResponse = getIndexSettings(indexName)
+                val settings = settingsResponse.indexToSettings[indexName]
+                snapshotRepository = settings?.get(SEARCHABLE_SNAPSHOT_REPOSITORY_SETTING)
+                snapshotName = settings?.get(SEARCHABLE_SNAPSHOT_NAME_SETTING)
+
+                if (snapshotRepository != null && snapshotName != null) {
+                    val otherIndicesUsingSameSnapshot = findOtherIndicesUsingSameSnapshot(
+                        indexName,
+                        snapshotRepository,
+                        snapshotName,
+                    )
+                    if (otherIndicesUsingSameSnapshot.isNotEmpty()) {
+                        logger.info(
+                            "Snapshot [$snapshotRepository:$snapshotName] is used by other indices $otherIndicesUsingSameSnapshot, " +
+                                "will skip snapshot deletion [index=$indexName]",
+                        )
+                        // Clear snapshot info to skip deletion later
+                        snapshotRepository = null
+                        snapshotName = null
+                    }
+                }
+            } catch (e: Exception) {
+                handleException(indexName, e, "Failed to get index settings")
+            }
+        }
+
         try {
             val response: AcknowledgedResponse =
                 context.client.admin().indices()
                     .suspendUntil { delete(DeleteIndexRequest(indexName), it) }
 
             if (response.isAcknowledged) {
-                stepStatus = StepStatus.COMPLETED
-                info = mapOf("message" to getSuccessMessage(indexName))
+                if (action.deleteSnapshot && snapshotRepository != null && snapshotName != null) {
+                    deleteSnapshot(indexName, snapshotRepository, snapshotName)
+                } else {
+                    stepStatus = StepStatus.COMPLETED
+                    info = mapOf("message" to getSuccessMessage(indexName))
+                }
             } else {
                 val message = getFailedMessage(indexName)
                 logger.warn(message)
@@ -41,12 +82,12 @@ class AttemptDeleteStep : Step(name) {
         } catch (e: RemoteTransportException) {
             val cause = ExceptionsHelper.unwrapCause(e)
             if (cause is SnapshotInProgressException) {
-                handleSnapshotException(indexName, cause)
+                handleSnapshotInProgressException(indexName, cause)
             } else {
                 handleException(indexName, cause as Exception)
             }
         } catch (e: SnapshotInProgressException) {
-            handleSnapshotException(indexName, e)
+            handleSnapshotInProgressException(indexName, e)
         } catch (e: Exception) {
             handleException(indexName, e)
         }
@@ -54,15 +95,60 @@ class AttemptDeleteStep : Step(name) {
         return this
     }
 
-    private fun handleSnapshotException(indexName: String, e: SnapshotInProgressException) {
-        val message = getSnapshotMessage(indexName)
+    private suspend fun getIndexSettings(indexName: String): GetSettingsResponse {
+        val context = this.context!!
+        return context.client.admin().indices()
+            .suspendUntil { getSettings(GetSettingsRequest().indices(indexName), it) }
+    }
+
+    private suspend fun findOtherIndicesUsingSameSnapshot(
+        currentIndex: String,
+        repository: String,
+        snapshotName: String,
+    ): List<String> {
+        val context = this.context!!
+        val allSettingsResponse: GetSettingsResponse =
+            context.client.admin().indices()
+                .suspendUntil { getSettings(GetSettingsRequest().indices("*"), it) }
+
+        return allSettingsResponse.indexToSettings
+            .filter { (indexName, settings) ->
+                indexName != currentIndex &&
+                    settings.get(SEARCHABLE_SNAPSHOT_REPOSITORY_SETTING) == repository &&
+                    settings.get(SEARCHABLE_SNAPSHOT_NAME_SETTING) == snapshotName
+            }
+            .keys
+            .toList()
+    }
+
+    private suspend fun deleteSnapshot(indexName: String, repository: String, snapshotName: String) {
+        val context = this.context!!
+        try {
+            val deleteSnapshotResponse: AcknowledgedResponse =
+                context.client.admin().cluster()
+                    .suspendUntil { deleteSnapshot(DeleteSnapshotRequest(repository, snapshotName), it) }
+
+            if (deleteSnapshotResponse.isAcknowledged) {
+                stepStatus = StepStatus.COMPLETED
+                info = mapOf("message" to getSuccessWithSnapshotMessage(indexName, repository, snapshotName))
+            } else {
+                stepStatus = StepStatus.FAILED
+                info = mapOf("message" to getSnapshotDeleteFailedMessage(indexName, repository, snapshotName))
+            }
+        } catch (e: Exception) {
+            handleException(indexName, e, "Index deleted but failed to delete snapshot [$repository:$snapshotName]")
+        }
+    }
+
+    private fun handleSnapshotInProgressException(indexName: String, e: SnapshotInProgressException) {
+        val message = getSnapshotInProgressMessage(indexName)
         logger.warn(message, e)
         stepStatus = StepStatus.CONDITION_NOT_MET
         info = mapOf("message" to message)
     }
 
-    private fun handleException(indexName: String, e: Exception) {
-        val message = getFailedMessage(indexName)
+    private fun handleException(indexName: String, e: Exception, customMessage: String? = null) {
+        val message = customMessage ?: getFailedMessage(indexName)
         logger.error(message, e)
         stepStatus = StepStatus.FAILED
         val mutableInfo = mutableMapOf("message" to message)
@@ -81,11 +167,20 @@ class AttemptDeleteStep : Step(name) {
 
     companion object {
         const val name = "attempt_delete"
+        const val SEARCHABLE_SNAPSHOT_REPOSITORY_SETTING = "index.searchable_snapshot.repository"
+        const val SEARCHABLE_SNAPSHOT_NAME_SETTING = "index.searchable_snapshot.snapshot_id.name"
 
         fun getFailedMessage(indexName: String) = "Failed to delete index [index=$indexName]"
 
         fun getSuccessMessage(indexName: String) = "Successfully deleted index [index=$indexName]"
 
-        fun getSnapshotMessage(indexName: String) = "Index had snapshot in progress, retrying deletion [index=$indexName]"
+        fun getSuccessWithSnapshotMessage(indexName: String, repository: String, snapshotName: String) =
+            "Successfully deleted index [index=$indexName] and snapshot [$repository:$snapshotName]"
+
+        fun getSnapshotInProgressMessage(indexName: String) =
+            "Index had snapshot in progress, retrying deletion [index=$indexName]"
+
+        fun getSnapshotDeleteFailedMessage(indexName: String, repository: String, snapshotName: String) =
+            "Index deleted but failed to delete snapshot [index=$indexName, snapshot=$repository:$snapshotName]"
     }
 }

--- a/src/main/resources/mappings/opendistro-ism-config.json
+++ b/src/main/resources/mappings/opendistro-ism-config.json
@@ -1,6 +1,6 @@
 {
   "_meta" : {
-    "schema_version": 26
+    "schema_version": 27
   },
   "dynamic": "strict",
   "properties": {

--- a/src/main/resources/mappings/opendistro-ism-config.json
+++ b/src/main/resources/mappings/opendistro-ism-config.json
@@ -168,7 +168,11 @@
                   }
                 },
                 "delete": {
-                  "type": "object"
+                  "properties": {
+                    "delete_snapshot": {
+                      "type": "boolean"
+                    }
+                  }
                 },
                 "stop_replication": {
                   "type": "object"

--- a/src/test/kotlin/org/opensearch/indexmanagement/IndexManagementRestTestCase.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/IndexManagementRestTestCase.kt
@@ -41,7 +41,7 @@ import javax.management.remote.JMXConnectorFactory
 import javax.management.remote.JMXServiceURL
 
 abstract class IndexManagementRestTestCase : ODFERestTestCase() {
-    val configSchemaVersion = 26
+    val configSchemaVersion = 27
     val historySchemaVersion = 7
 
     // Having issues with tests leaking into other tests and mappings being incorrect and they are not caught by any pending task wait check as

--- a/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/TestHelpers.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/TestHelpers.kt
@@ -125,7 +125,8 @@ fun randomConditions(
 fun nonNullRandomConditions(): Conditions =
     randomConditions(OpenSearchRestTestCase.randomFrom(listOf(randomIndexAge(), randomDocCount(), randomSize())))!!
 
-fun randomDeleteActionConfig(): DeleteAction = DeleteAction(index = 0)
+fun randomDeleteActionConfig(deleteSnapshot: Boolean = false): DeleteAction =
+    DeleteAction(index = 0, deleteSnapshot = deleteSnapshot)
 
 fun randomRolloverActionConfig(
     minSize: ByteSizeValue = randomByteSizeValue(),

--- a/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/action/DeleteSearchableSnapshotActionIT.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/action/DeleteSearchableSnapshotActionIT.kt
@@ -1,0 +1,178 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.indexmanagement.indexstatemanagement.action
+
+import org.opensearch.common.xcontent.json.JsonXContent.jsonXContent
+import org.opensearch.core.xcontent.DeprecationHandler
+import org.opensearch.core.xcontent.NamedXContentRegistry
+import org.opensearch.indexmanagement.indexstatemanagement.IndexStateManagementRestTestCase
+import org.opensearch.indexmanagement.indexstatemanagement.model.Policy
+import org.opensearch.indexmanagement.indexstatemanagement.model.State
+import org.opensearch.indexmanagement.indexstatemanagement.model.Transition
+import org.opensearch.indexmanagement.indexstatemanagement.randomErrorNotification
+import org.opensearch.indexmanagement.indexstatemanagement.step.restore.AttemptRestoreStep
+import org.opensearch.indexmanagement.indexstatemanagement.step.snapshot.AttemptSnapshotStep
+import org.opensearch.indexmanagement.indexstatemanagement.step.snapshot.WaitForSnapshotStep
+import org.opensearch.indexmanagement.makeRequest
+import org.opensearch.indexmanagement.waitFor
+import java.time.Instant
+import java.time.temporal.ChronoUnit
+import java.util.Locale
+
+class DeleteSearchableSnapshotActionIT : IndexStateManagementRestTestCase() {
+
+    private val testIndexName = javaClass.simpleName.lowercase(Locale.ROOT)
+
+    @Suppress("UNCHECKED_CAST")
+    fun `test delete action with delete_snapshot deletes searchable snapshot index and its source snapshot`() {
+        val indexName = "${testIndexName}_index"
+        val policyID = "${testIndexName}_policy"
+        val repository = "repository"
+
+        createIndex(indexName, null)
+        indexDoc(indexName, "1", """{"field": "value1"}""")
+
+        createRepository(repository)
+
+        // State 1: Create snapshot
+        val snapshotAction = SnapshotAction(repository = repository, snapshot = indexName, index = 0)
+        val snapshotState = State(
+            name = "snapshotState",
+            actions = listOf(snapshotAction),
+            transitions = listOf(Transition(stateName = "convertToRemoteState", conditions = null)),
+        )
+
+        // State 2: Convert to searchable snapshot (remote_snapshot)
+        val convertAction = ConvertIndexToRemoteAction(repository = repository, snapshot = indexName, index = 0)
+        val convertToRemoteState = State(
+            name = "convertToRemoteState",
+            actions = listOf(convertAction),
+            transitions = listOf(Transition(stateName = "deleteState", conditions = null)),
+        )
+
+        // State 3: Delete with delete_snapshot=true
+        val deleteAction = DeleteAction(index = 0, deleteSnapshot = true)
+        val deleteState = State(
+            name = "deleteState",
+            actions = listOf(deleteAction),
+            transitions = listOf(),
+        )
+
+        val policy = Policy(
+            id = policyID,
+            description = "$testIndexName description",
+            schemaVersion = 1L,
+            lastUpdatedTime = Instant.now().truncatedTo(ChronoUnit.MILLIS),
+            errorNotification = randomErrorNotification(),
+            defaultState = snapshotState.name,
+            states = listOf(snapshotState, convertToRemoteState, deleteState),
+        )
+
+        createPolicy(policy, policyID)
+        addPolicyToIndex(indexName, policyID)
+
+        val managedIndexConfig = getExistingManagedIndexConfig(indexName)
+
+        // Initialize policy
+        updateManagedIndexConfigStartTime(managedIndexConfig)
+        waitFor {
+            assertEquals(
+                "Successfully initialized policy: $policyID",
+                getExplainManagedIndexMetaData(indexName).info?.get("message"),
+            )
+        }
+
+        // Execute snapshot action
+        updateManagedIndexConfigStartTime(managedIndexConfig)
+        waitFor {
+            assertEquals(
+                AttemptSnapshotStep.getSuccessMessage(indexName),
+                getExplainManagedIndexMetaData(indexName).info?.get("message"),
+            )
+        }
+
+        // Wait for snapshot completion
+        updateManagedIndexConfigStartTime(managedIndexConfig)
+        waitFor {
+            assertEquals(
+                WaitForSnapshotStep.getSuccessMessage(indexName),
+                getExplainManagedIndexMetaData(indexName).info?.get("message"),
+            )
+        }
+
+        // Transition to convert state
+        updateManagedIndexConfigStartTime(managedIndexConfig)
+        waitFor {
+            val message = getExplainManagedIndexMetaData(indexName).info?.get("message") as String?
+            assertTrue("Expected transition message", message?.contains("Transitioning to convertToRemoteState") == true)
+        }
+
+        // Execute convert action (restore as searchable snapshot)
+        updateManagedIndexConfigStartTime(managedIndexConfig)
+        waitFor {
+            assertEquals(
+                AttemptRestoreStep.getSuccessMessage(indexName),
+                getExplainManagedIndexMetaData(indexName).info?.get("message"),
+            )
+        }
+
+        val remoteIndexName = "${indexName}_remote"
+        waitFor { assertIndexExists(remoteIndexName) }
+
+        // Verify it's a searchable snapshot
+        assertTrue("Index $remoteIndexName is not a remote index", isIndexRemote(remoteIndexName))
+
+        // Verify snapshot exists before delete
+        assertSnapshotExists(repository, indexName)
+
+        // Create a delete-only policy for the remote index
+        val deletePolicyID = "${testIndexName}_delete_policy"
+        val deleteOnlyPolicy = Policy(
+            id = deletePolicyID,
+            description = "Delete searchable snapshot",
+            schemaVersion = 1L,
+            lastUpdatedTime = Instant.now().truncatedTo(ChronoUnit.MILLIS),
+            errorNotification = randomErrorNotification(),
+            defaultState = "deleteState",
+            states = listOf(deleteState),
+        )
+        createPolicy(deleteOnlyPolicy, deletePolicyID)
+        addPolicyToIndex(remoteIndexName, deletePolicyID)
+
+        val deleteIndexConfig = getExistingManagedIndexConfig(remoteIndexName)
+
+        // Initialize delete policy
+        updateManagedIndexConfigStartTime(deleteIndexConfig)
+        waitFor {
+            assertEquals(
+                "Successfully initialized policy: $deletePolicyID",
+                getExplainManagedIndexMetaData(remoteIndexName).info?.get("message"),
+            )
+        }
+
+        // Execute delete action
+        updateManagedIndexConfigStartTime(deleteIndexConfig)
+        waitFor {
+            assertIndexDoesNotExist(remoteIndexName)
+        }
+
+        // Verify snapshot was also deleted
+        waitFor {
+            val snapshots = getSnapshotList(repository)
+            assertFalse("Snapshot should have been deleted", snapshots.any { it.startsWith(indexName) })
+        }
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    private fun getSnapshotList(repository: String): List<String> {
+        val response = client().makeRequest("GET", "_cat/snapshots/$repository?format=json", emptyMap<String, String>())
+        val snapshots =
+            jsonXContent
+                .createParser(NamedXContentRegistry.EMPTY, DeprecationHandler.THROW_UNSUPPORTED_OPERATION, response.entity.content)
+                .use { parser -> parser.list() } as List<Map<String, Any>>
+        return snapshots.map { it["id"] as String }
+    }
+}

--- a/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/AttemptDeleteStepTests.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/AttemptDeleteStepTests.kt
@@ -8,6 +8,7 @@ package org.opensearch.indexmanagement.indexstatemanagement.step
 import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.doReturn
 import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.never
 import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.whenever
 import kotlinx.coroutines.runBlocking
@@ -15,11 +16,14 @@ import org.junit.Before
 import org.mockito.ArgumentMatchers.anyString
 import org.mockito.ArgumentMatchers.eq
 import org.mockito.Mockito.doAnswer
+import org.opensearch.action.admin.indices.settings.get.GetSettingsRequest
+import org.opensearch.action.admin.indices.settings.get.GetSettingsResponse
 import org.opensearch.action.support.clustermanager.AcknowledgedResponse
 import org.opensearch.cluster.service.ClusterService
 import org.opensearch.common.settings.Settings
 import org.opensearch.core.action.ActionListener
 import org.opensearch.indexmanagement.indexstatemanagement.ManagedIndexRunner
+import org.opensearch.indexmanagement.indexstatemanagement.action.DeleteAction
 import org.opensearch.indexmanagement.indexstatemanagement.step.delete.AttemptDeleteStep
 import org.opensearch.indexmanagement.spi.indexstatemanagement.Step
 import org.opensearch.indexmanagement.spi.indexstatemanagement.metrics.IndexManagementActionsMetrics
@@ -36,6 +40,7 @@ import org.opensearch.telemetry.metrics.tags.Tags
 import org.opensearch.test.OpenSearchTestCase
 import org.opensearch.transport.client.AdminClient
 import org.opensearch.transport.client.Client
+import org.opensearch.transport.client.ClusterAdminClient
 import org.opensearch.transport.client.IndicesAdminClient
 import java.time.Instant
 
@@ -67,7 +72,8 @@ class AttemptDeleteStepTests : OpenSearchTestCase() {
                 "test", "indexUuid", "policy_id", null, null, null, null, null, null, null,
                 ActionMetaData("delete", Instant.now().toEpochMilli(), 0, false, 1, null, null), null, null, null,
             )
-            val attemptDeleteStep = AttemptDeleteStep()
+            val deleteAction = DeleteAction(0)
+            val attemptDeleteStep = AttemptDeleteStep(deleteAction)
             val context = StepContext(managedIndexMetaData, clusterService, client, null, null, scriptService, settings, lockService)
             attemptDeleteStep.preExecute(logger, context).execute().postExecute(logger, IndexManagementActionsMetrics.instance, attemptDeleteStep, managedIndexMetaData)
             val updatedManagedIndexMetaData = attemptDeleteStep.getUpdatedManagedIndexMetadata(managedIndexMetaData)
@@ -82,7 +88,8 @@ class AttemptDeleteStepTests : OpenSearchTestCase() {
 
         runBlocking {
             val managedIndexMetaData = ManagedIndexMetaData("test", "indexUuid", "policy_id", null, null, null, null, null, null, null, ActionMetaData("delete", Instant.now().toEpochMilli(), 0, false, 1, null, null), null, null, null)
-            val attemptDeleteStep = AttemptDeleteStep()
+            val deleteAction = DeleteAction(0)
+            val attemptDeleteStep = AttemptDeleteStep(deleteAction)
             val context = StepContext(managedIndexMetaData, clusterService, client, null, null, scriptService, settings, lockService)
             attemptDeleteStep.preExecute(logger, context).execute().postExecute(logger, IndexManagementActionsMetrics.instance, attemptDeleteStep, managedIndexMetaData)
             val updatedManagedIndexMetaData = attemptDeleteStep.getUpdatedManagedIndexMetadata(managedIndexMetaData)
@@ -97,7 +104,8 @@ class AttemptDeleteStepTests : OpenSearchTestCase() {
 
         runBlocking {
             val managedIndexMetaData = ManagedIndexMetaData("test", "indexUuid", "policy_id", null, null, null, null, null, null, null, ActionMetaData("delete", Instant.now().toEpochMilli(), 0, false, 1, null, null), null, null, null)
-            val attemptDeleteStep = AttemptDeleteStep()
+            val deleteAction = DeleteAction(0)
+            val attemptDeleteStep = AttemptDeleteStep(deleteAction)
             val context = StepContext(managedIndexMetaData, clusterService, client, null, null, scriptService, settings, lockService)
             attemptDeleteStep.preExecute(logger, context).execute().postExecute(logger, IndexManagementActionsMetrics.instance, attemptDeleteStep, managedIndexMetaData)
             val updatedManagedIndexMetaData = attemptDeleteStep.getUpdatedManagedIndexMetadata(managedIndexMetaData)
@@ -113,7 +121,8 @@ class AttemptDeleteStepTests : OpenSearchTestCase() {
 
         runBlocking {
             val managedIndexMetaData = ManagedIndexMetaData("test", "indexUuid", "policy_id", null, null, null, null, null, null, null, ActionMetaData("delete", Instant.now().toEpochMilli(), 0, false, 1, null, null), null, null, null)
-            val attemptDeleteStep = AttemptDeleteStep()
+            val deleteAction = DeleteAction(0)
+            val attemptDeleteStep = AttemptDeleteStep(deleteAction)
             val context = StepContext(managedIndexMetaData, clusterService, client, null, null, scriptService, settings, lockService)
             attemptDeleteStep.preExecute(logger, context).execute().postExecute(logger, IndexManagementActionsMetrics.instance, attemptDeleteStep, managedIndexMetaData)
             val updatedManagedIndexMetaData = attemptDeleteStep.getUpdatedManagedIndexMetadata(managedIndexMetaData)
@@ -124,6 +133,11 @@ class AttemptDeleteStepTests : OpenSearchTestCase() {
     private fun getClient(adminClient: AdminClient): Client = mock { on { admin() } doReturn adminClient }
 
     private fun getAdminClient(indicesAdminClient: IndicesAdminClient): AdminClient = mock { on { indices() } doReturn indicesAdminClient }
+
+    private fun getAdminClient(indicesAdminClient: IndicesAdminClient, clusterAdminClient: ClusterAdminClient): AdminClient = mock {
+        on { indices() } doReturn indicesAdminClient
+        on { cluster() } doReturn clusterAdminClient
+    }
 
     private fun getIndicesAdminClient(acknowledgedResponse: AcknowledgedResponse?, exception: Exception?): IndicesAdminClient {
         assertTrue("Must provide one and only one response or exception", (acknowledgedResponse != null).xor(exception != null))
@@ -136,6 +150,164 @@ class AttemptDeleteStepTests : OpenSearchTestCase() {
                     listener.onFailure(exception)
                 }
             }.whenever(this.mock).delete(any(), any())
+        }
+    }
+
+    private fun getIndicesAdminClient(
+        deleteResponse: AcknowledgedResponse?,
+        deleteException: Exception?,
+        getSettingsResponse: GetSettingsResponse?,
+    ): IndicesAdminClient = mock {
+        doAnswer { invocationOnMock ->
+            val listener = invocationOnMock.getArgument<ActionListener<AcknowledgedResponse>>(1)
+            if (deleteResponse != null) {
+                listener.onResponse(deleteResponse)
+            } else {
+                listener.onFailure(deleteException)
+            }
+        }.whenever(this.mock).delete(any(), any())
+
+        doAnswer { invocationOnMock ->
+            val listener = invocationOnMock.getArgument<ActionListener<GetSettingsResponse>>(1)
+            listener.onResponse(getSettingsResponse)
+        }.whenever(this.mock).getSettings(any(), any())
+    }
+
+    private fun getClusterAdminClient(deleteSnapshotResponse: AcknowledgedResponse): ClusterAdminClient = mock {
+        doAnswer { invocationOnMock ->
+            val listener = invocationOnMock.getArgument<ActionListener<AcknowledgedResponse>>(1)
+            listener.onResponse(deleteSnapshotResponse)
+        }.whenever(this.mock).deleteSnapshot(any(), any())
+    }
+
+    private fun createGetSettingsResponse(indexName: String, settings: Settings): GetSettingsResponse {
+        val indexToSettings = mapOf(indexName to settings)
+        return mock {
+            on { this.indexToSettings } doReturn indexToSettings
+        }
+    }
+
+    fun `test delete step with delete_snapshot deletes both index and snapshot`() {
+        val indexName = "test-searchable-snapshot"
+        val repository = "my-repo"
+        val snapshotName = "my-snapshot"
+
+        val indexSettings = Settings.builder()
+            .put("index.searchable_snapshot.repository", repository)
+            .put("index.searchable_snapshot.snapshot_id.name", snapshotName)
+            .build()
+        val getSettingsResponse = createGetSettingsResponse(indexName, indexSettings)
+
+        val indicesAdminClient = getIndicesAdminClient(AcknowledgedResponse(true), null, getSettingsResponse)
+        val clusterAdminClient = getClusterAdminClient(AcknowledgedResponse(true))
+        val client = getClient(getAdminClient(indicesAdminClient, clusterAdminClient))
+
+        runBlocking {
+            val managedIndexMetaData = ManagedIndexMetaData(
+                indexName, "indexUuid", "policy_id", null, null, null, null, null, null, null,
+                ActionMetaData("delete", Instant.now().toEpochMilli(), 0, false, 1, null, null), null, null, null,
+            )
+            val deleteAction = DeleteAction(0, deleteSnapshot = true)
+            val attemptDeleteStep = AttemptDeleteStep(deleteAction)
+            val context = StepContext(managedIndexMetaData, clusterService, client, null, null, scriptService, settings, lockService)
+            attemptDeleteStep.preExecute(logger, context).execute().postExecute(logger, IndexManagementActionsMetrics.instance, attemptDeleteStep, managedIndexMetaData)
+            val updatedManagedIndexMetaData = attemptDeleteStep.getUpdatedManagedIndexMetadata(managedIndexMetaData)
+
+            assertEquals("Step status is not COMPLETED", Step.StepStatus.COMPLETED, updatedManagedIndexMetaData.stepMetaData?.stepStatus)
+            assertTrue(
+                "Info message should mention snapshot deletion",
+                updatedManagedIndexMetaData.info?.get("message").toString().contains("snapshot"),
+            )
+            verify(clusterAdminClient).deleteSnapshot(any(), any())
+        }
+    }
+
+    fun `test delete step with delete_snapshot skips snapshot deletion for non-searchable-snapshot index`() {
+        val indexName = "test-normal-index"
+
+        // Normal index without searchable snapshot settings
+        val indexSettings = Settings.builder().build()
+        val getSettingsResponse = createGetSettingsResponse(indexName, indexSettings)
+
+        val indicesAdminClient = getIndicesAdminClient(AcknowledgedResponse(true), null, getSettingsResponse)
+        val clusterAdminClient: ClusterAdminClient = mock()
+        val client = getClient(getAdminClient(indicesAdminClient, clusterAdminClient))
+
+        runBlocking {
+            val managedIndexMetaData = ManagedIndexMetaData(
+                indexName, "indexUuid", "policy_id", null, null, null, null, null, null, null,
+                ActionMetaData("delete", Instant.now().toEpochMilli(), 0, false, 1, null, null), null, null, null,
+            )
+            val deleteAction = DeleteAction(0, deleteSnapshot = true)
+            val attemptDeleteStep = AttemptDeleteStep(deleteAction)
+            val context = StepContext(managedIndexMetaData, clusterService, client, null, null, scriptService, settings, lockService)
+            attemptDeleteStep.preExecute(logger, context).execute().postExecute(logger, IndexManagementActionsMetrics.instance, attemptDeleteStep, managedIndexMetaData)
+            val updatedManagedIndexMetaData = attemptDeleteStep.getUpdatedManagedIndexMetadata(managedIndexMetaData)
+
+            assertEquals("Step status is not COMPLETED", Step.StepStatus.COMPLETED, updatedManagedIndexMetaData.stepMetaData?.stepStatus)
+            verify(clusterAdminClient, never()).deleteSnapshot(any(), any())
+        }
+    }
+
+    fun `test delete step with delete_snapshot skips snapshot deletion when snapshot is used by other index`() {
+        val indexName = "test-searchable-snapshot"
+        val otherIndexName = "other-searchable-snapshot"
+        val repository = "my-repo"
+        val snapshotName = "my-snapshot"
+
+        // Both indices use the same snapshot
+        val indexSettings = Settings.builder()
+            .put("index.searchable_snapshot.repository", repository)
+            .put("index.searchable_snapshot.snapshot_id.name", snapshotName)
+            .build()
+
+        // Mock getSettings to return both indices when querying "*"
+        val allIndicesSettings = mapOf(
+            indexName to indexSettings,
+            otherIndexName to indexSettings,
+        )
+        val getSettingsResponseForIndex: GetSettingsResponse = mock {
+            on { this.indexToSettings } doReturn mapOf(indexName to indexSettings)
+        }
+        val getSettingsResponseForAll: GetSettingsResponse = mock {
+            on { this.indexToSettings } doReturn allIndicesSettings
+        }
+
+        val indicesAdminClient: IndicesAdminClient = mock {
+            doAnswer { invocationOnMock ->
+                val listener = invocationOnMock.getArgument<ActionListener<AcknowledgedResponse>>(1)
+                listener.onResponse(AcknowledgedResponse(true))
+            }.whenever(this.mock).delete(any(), any())
+
+            doAnswer { invocationOnMock ->
+                val request = invocationOnMock.getArgument<GetSettingsRequest>(0)
+                val listener = invocationOnMock.getArgument<ActionListener<GetSettingsResponse>>(1)
+                // Return different response based on indices pattern
+                if (request.indices().contentEquals(arrayOf("*"))) {
+                    listener.onResponse(getSettingsResponseForAll)
+                } else {
+                    listener.onResponse(getSettingsResponseForIndex)
+                }
+            }.whenever(this.mock).getSettings(any(), any())
+        }
+
+        val clusterAdminClient: ClusterAdminClient = mock()
+        val client = getClient(getAdminClient(indicesAdminClient, clusterAdminClient))
+
+        runBlocking {
+            val managedIndexMetaData = ManagedIndexMetaData(
+                indexName, "indexUuid", "policy_id", null, null, null, null, null, null, null,
+                ActionMetaData("delete", Instant.now().toEpochMilli(), 0, false, 1, null, null), null, null, null,
+            )
+            val deleteAction = DeleteAction(0, deleteSnapshot = true)
+            val attemptDeleteStep = AttemptDeleteStep(deleteAction)
+            val context = StepContext(managedIndexMetaData, clusterService, client, null, null, scriptService, settings, lockService)
+            attemptDeleteStep.preExecute(logger, context).execute().postExecute(logger, IndexManagementActionsMetrics.instance, attemptDeleteStep, managedIndexMetaData)
+            val updatedManagedIndexMetaData = attemptDeleteStep.getUpdatedManagedIndexMetadata(managedIndexMetaData)
+
+            // Index should be deleted successfully, but snapshot deletion should be skipped
+            assertEquals("Step status is not COMPLETED", Step.StepStatus.COMPLETED, updatedManagedIndexMetaData.stepMetaData?.stepStatus)
+            verify(clusterAdminClient, never()).deleteSnapshot(any(), any())
         }
     }
 }

--- a/src/test/resources/mappings/cached-opendistro-ism-config.json
+++ b/src/test/resources/mappings/cached-opendistro-ism-config.json
@@ -1,6 +1,6 @@
 {
   "_meta" : {
-    "schema_version": 26
+    "schema_version": 27
   },
   "dynamic": "strict",
   "properties": {

--- a/src/test/resources/mappings/cached-opendistro-ism-config.json
+++ b/src/test/resources/mappings/cached-opendistro-ism-config.json
@@ -168,7 +168,11 @@
                   }
                 },
                 "delete": {
-                  "type": "object"
+                  "properties": {
+                    "delete_snapshot": {
+                      "type": "boolean"
+                    }
+                  }
                 },
                 "stop_replication": {
                   "type": "object"


### PR DESCRIPTION
### Description
This PR adds a new optional `delete_snapshot` parameter to the ISM delete action. When enabled, it automatically deletes the source snapshot of a searchable snapshot index along with the index itself.

**use case**
Hot → Warm (searchable snapshot) → Delete lifecycle where both the index and underlying snapshot should be removed to free up storage.

**format**
```json
"actions": [
    {
        "delete": {
            "delete_snapshot": true
        }
    }
],
```

**behavior**
- If `delete_snapshot: true` and the index is a searchable snapshot, both the index and its source snapshot are deleted
- If the snapshot is still used by other indices, snapshot deletion is skipped (index deletion still succeeds)
- If the index is not a searchable snapshot, only the index is deleted (no error)
- Default is `false` for backward compatibility

In addition to unit tests, I manually tested with local build.

### Related Issues
Resolves #1476

### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/index-management/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).