### PR TITLE
Change min version for supporting source index in ISM rollups to 3.5.0

### DIFF
--- a/src/main/kotlin/org/opensearch/indexmanagement/rollup/model/ISMRollup.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/rollup/model/ISMRollup.kt
@@ -109,7 +109,6 @@ data class ISMRollup(
     constructor(sin: StreamInput) : this(
         description = sin.readString(),
         targetIndex = sin.readString(),
-        // TODO: Update to Version.V_3_5_0 once OpenSearch 3.5.0 is released and the constant is available
         targetIndexSettings = if (sin.version.onOrAfter(Version.V_3_0_0) && sin.readBoolean()) {
             Settings.readSettingsFromStream(sin)
         } else {
@@ -133,8 +132,7 @@ data class ISMRollup(
             dimensionsList.toList()
         },
         metrics = sin.readList(::RollupMetrics),
-        // TODO: Update to Version.V_3_5_0 once OpenSearch 3.5.0 is released and the constant is available
-        sourceIndex = if (sin.version.onOrAfter(Version.V_3_0_0) && sin.readBoolean()) {
+        sourceIndex = if (sin.version.onOrAfter(Version.V_3_5_0) && sin.readBoolean()) {
             sin.readString()
         } else {
             null
@@ -163,7 +161,6 @@ data class ISMRollup(
     override fun writeTo(out: StreamOutput) {
         out.writeString(description)
         out.writeString(targetIndex)
-        // TODO: Update to Version.V_3_5_0 once OpenSearch 3.5.0 is released and the constant is available
         if (out.version.onOrAfter(Version.V_3_0_0)) {
             out.writeBoolean(targetIndexSettings != null)
             if (targetIndexSettings != null) Settings.writeSettingsToStream(targetIndexSettings, out)
@@ -179,8 +176,7 @@ data class ISMRollup(
             }
         }
         out.writeCollection(metrics)
-        // TODO: Update to Version.V_3_5_0 once OpenSearch 3.5.0 is released and the constant is available
-        if (out.version.onOrAfter(Version.V_3_0_0)) {
+        if (out.version.onOrAfter(Version.V_3_5_0)) {
             out.writeBoolean(sourceIndex != null)
             if (sourceIndex != null) out.writeString(sourceIndex)
         }

--- a/src/test/kotlin/org/opensearch/indexmanagement/rollup/model/ISMRollupTests.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/rollup/model/ISMRollupTests.kt
@@ -155,15 +155,15 @@ class ISMRollupTests : OpenSearchTestCase() {
         assertNull(parsed.sourceIndex)
     }
 
-    fun `test ism rollup stream serialization without source index on V3_0_0`() {
+    fun `test ism rollup stream serialization without source index on V3_5_0`() {
         val ismRollup = randomISMRollup().copy(sourceIndex = null)
 
         val output = BytesStreamOutput()
-        output.version = Version.V_3_0_0
+        output.version = Version.V_3_5_0
         ismRollup.writeTo(output)
 
         val input = StreamInput.wrap(output.bytes().toBytesRef().bytes)
-        input.version = Version.V_3_0_0
+        input.version = Version.V_3_5_0
         val parsed = ISMRollup(input)
 
         assertEquals(ismRollup.description, parsed.description)
@@ -174,16 +174,16 @@ class ISMRollupTests : OpenSearchTestCase() {
         assertNull(parsed.sourceIndex)
     }
 
-    fun `test ism rollup stream serialization with source index on V3_0_0`() {
+    fun `test ism rollup stream serialization with source index on V3_5_0`() {
         val sourceIndex = "my-source-index"
         val ismRollup = randomISMRollup().copy(sourceIndex = sourceIndex)
 
         val output = BytesStreamOutput()
-        output.version = Version.V_3_0_0
+        output.version = Version.V_3_5_0
         ismRollup.writeTo(output)
 
         val input = StreamInput.wrap(output.bytes().toBytesRef().bytes)
-        input.version = Version.V_3_0_0
+        input.version = Version.V_3_5_0
         val parsed = ISMRollup(input)
 
         assertEquals(ismRollup.description, parsed.description)
@@ -292,11 +292,11 @@ class ISMRollupTests : OpenSearchTestCase() {
 
         // Stream round trip
         val output = BytesStreamOutput()
-        output.version = Version.V_3_0_0
+        output.version = Version.V_3_5_0
         original.writeTo(output)
 
         val input = StreamInput.wrap(output.bytes().toBytesRef().bytes)
-        input.version = Version.V_3_0_0
+        input.version = Version.V_3_5_0
         val parsedFromStream = ISMRollup(input)
 
         assertEquals(original.description, parsedFromStream.description)


### PR DESCRIPTION
### Description
Change min version for supporting source index in ISM rollups to 3.5.0 which was done to 3.0.0 earlier as placeholder when 3.5 was not available in this [PR](https://github.com/opensearch-project/index-management/pull/1533/files#r2627358152)

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/index-management/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
