### PR TITLE
Fix CVE-2025-11226

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -113,8 +113,8 @@ configurations.all {
         force "com.fasterxml.jackson.core:jackson-databind:${versions.jackson_databind}"
         force "org.yaml:snakeyaml:${versions.snakeyaml}"
         force 'org.codehaus.plexus:plexus-utils:3.0.24'
-        force "ch.qos.logback:logback-classic:1.5.16"
-        force "ch.qos.logback:logback-core:1.5.16"
+        force "ch.qos.logback:logback-classic:1.5.26"
+        force "ch.qos.logback:logback-core:1.5.26"
     }
 }
 


### PR DESCRIPTION
### Description
[Describe what this change achieves]
Fixes CVE-2025-11226 by changing ch.qos.logback:logback-classic and ch.qos.logback:logback-core to use 1.5.26

### Related Issues
CVE-2025-11226

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/index-management/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
