### PR TITLE
Fix typo in validFileNameExcludingAsterisk

### DIFF
--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/ISMTemplateService.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/ISMTemplateService.kt
@@ -49,7 +49,7 @@ fun validateFormat(indexPatterns: List<String>): OpenSearchException? {
         if (patternToValidate.startsWith("_")) {
             indexPatternFormatErrors.add("index_pattern [$indexPattern] must not start with '_'")
         }
-        if (!Strings.validFileNameExcludingAstrix(patternToValidate)) {
+        if (!Strings.validFileNameExcludingAsterisk(patternToValidate)) {
             indexPatternFormatErrors.add(
                 "index_pattern [" + indexPattern + "] must not contain the following characters " +
                     Strings.INVALID_FILENAME_CHARS,

--- a/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/ISMTemplateServiceTests.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/ISMTemplateServiceTests.kt
@@ -89,7 +89,7 @@ class ISMTemplateServiceTests : OpenSearchTestCase() {
         val patterns = listOf("")
         val exception = validateFormat(patterns)
         // Empty string is treated as an inclusion pattern, so it should not fail the "only exclusions" check
-        // It may fail other validations depending on Strings.validFileNameExcludingAstrix
+        // It may fail other validations depending on Strings.validFileNameExcludingAsterisk
         // For now, we're just testing that it doesn't fail the exclusion-only check
         if (exception != null) {
             assertFalse(exception.message!!.contains("must contain at least one inclusion pattern"))


### PR DESCRIPTION
### Description

Fix typo in validFileNameExcludingAsterisk

### Related Issues

Resolves https://github.com/opensearch-project/index-management/issues/1590#issuecomment-4129296263

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/index-management/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
