### PR TITLE
1528 add min_primary_shard_doc_count condition for rollover and transition

### DIFF
--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/action/RolloverAction.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/action/RolloverAction.kt
@@ -19,6 +19,7 @@ import org.opensearch.indexmanagement.spi.indexstatemanagement.model.StepContext
 class RolloverAction(
     val minSize: ByteSizeValue?,
     val minDocs: Long?,
+    val minPrimaryShardDocs: Long?,
     val minAge: TimeValue?,
     val minPrimaryShardSize: ByteSizeValue?,
     val copyAlias: Boolean = false,
@@ -34,6 +35,7 @@ class RolloverAction(
             }
         }
         if (minDocs != null) require(minDocs > 0) { "RolloverAction minDocs value must be greater than 0" }
+        if (minPrimaryShardDocs != null) require(minPrimaryShardDocs > 0) { "RolloverAction minPrimaryShardDocs value must be greater than 0" }
     }
 
     private val attemptRolloverStep = AttemptRolloverStep(this)
@@ -47,6 +49,7 @@ class RolloverAction(
         builder.startObject(type)
         if (minSize != null) builder.field(MIN_SIZE_FIELD, minSize.stringRep)
         if (minDocs != null) builder.field(MIN_DOC_COUNT_FIELD, minDocs)
+        if (minPrimaryShardDocs != null) builder.field(MIN_PRIMARY_SHARD_DOC_COUNT_FIELD, minPrimaryShardDocs)
         if (minAge != null) builder.field(MIN_INDEX_AGE_FIELD, minAge.stringRep)
         if (minPrimaryShardSize != null) builder.field(MIN_PRIMARY_SHARD_SIZE_FIELD, minPrimaryShardSize.stringRep)
         builder.field(COPY_ALIAS_FIELD, copyAlias)
@@ -57,6 +60,7 @@ class RolloverAction(
     override fun populateAction(out: StreamOutput) {
         out.writeOptionalWriteable(minSize)
         out.writeOptionalLong(minDocs)
+        out.writeOptionalLong(minPrimaryShardDocs)
         out.writeOptionalTimeValue(minAge)
         out.writeOptionalWriteable(minPrimaryShardSize)
         out.writeBoolean(copyAlias)
@@ -70,6 +74,7 @@ class RolloverAction(
         const val name = "rollover"
         const val MIN_SIZE_FIELD = "min_size"
         const val MIN_DOC_COUNT_FIELD = "min_doc_count"
+        const val MIN_PRIMARY_SHARD_DOC_COUNT_FIELD = "min_primary_shard_doc_count"
         const val MIN_INDEX_AGE_FIELD = "min_index_age"
         const val MIN_PRIMARY_SHARD_SIZE_FIELD = "min_primary_shard_size"
         const val COPY_ALIAS_FIELD = "copy_alias"

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/action/RolloverActionParser.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/action/RolloverActionParser.kt
@@ -18,6 +18,7 @@ class RolloverActionParser : ActionParser() {
     override fun fromStreamInput(sin: StreamInput): Action {
         val minSize = sin.readOptionalWriteable(::ByteSizeValue)
         val minDocs = sin.readOptionalLong()
+        val minPrimaryShardDocs = sin.readOptionalLong()
         val minAge = sin.readOptionalTimeValue()
         val minPrimaryShardSize = sin.readOptionalWriteable(::ByteSizeValue)
         val copyAlias = sin.readBoolean()
@@ -28,12 +29,13 @@ class RolloverActionParser : ActionParser() {
         }
         val index = sin.readInt()
 
-        return RolloverAction(minSize, minDocs, minAge, minPrimaryShardSize, copyAlias, preventEmptyRollover, index)
+        return RolloverAction(minSize, minDocs, minPrimaryShardDocs, minAge, minPrimaryShardSize, copyAlias, preventEmptyRollover, index)
     }
 
     override fun fromXContent(xcp: XContentParser, index: Int): Action {
         var minSize: ByteSizeValue? = null
         var minDocs: Long? = null
+        var minPrimaryShardDocs: Long? = null
         var minAge: TimeValue? = null
         var minPrimaryShardSize: ByteSizeValue? = null
         var copyAlias = false
@@ -48,6 +50,8 @@ class RolloverActionParser : ActionParser() {
                 RolloverAction.MIN_SIZE_FIELD -> minSize = ByteSizeValue.parseBytesSizeValue(xcp.text(), RolloverAction.MIN_SIZE_FIELD)
 
                 RolloverAction.MIN_DOC_COUNT_FIELD -> minDocs = xcp.longValue()
+
+                RolloverAction.MIN_PRIMARY_SHARD_DOC_COUNT_FIELD -> minPrimaryShardDocs = xcp.longValue()
 
                 RolloverAction.MIN_INDEX_AGE_FIELD -> minAge = TimeValue.parseTimeValue(xcp.text(), RolloverAction.MIN_INDEX_AGE_FIELD)
 
@@ -67,7 +71,7 @@ class RolloverActionParser : ActionParser() {
             }
         }
 
-        return RolloverAction(minSize, minDocs, minAge, minPrimaryShardSize, copyAlias, preventEmptyRollover, index)
+        return RolloverAction(minSize, minDocs, minPrimaryShardDocs, minAge, minPrimaryShardSize, copyAlias, preventEmptyRollover, index)
     }
 
     override fun getActionType(): String = RolloverAction.name

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/model/Transition.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/model/Transition.kt
@@ -87,11 +87,12 @@ data class Conditions(
 ) : ToXContentObject,
     Writeable {
     init {
-        val conditionsList = listOf(indexAge, docCount, size, cron, rolloverAge, noAlias, minStateAge)
+        val conditionsList = listOf(indexAge, docCount, primaryShardDocCount, size, cron, rolloverAge, noAlias, minStateAge)
         require(conditionsList.filterNotNull().size == 1) { "Cannot provide more than one Transition condition" }
 
         // Validate doc count condition
         if (docCount != null) require(docCount > 0) { "Transition doc count condition must be greater than 0" }
+        if (primaryShardDocCount != null) require(primaryShardDocCount > 0) { "Transition pimary shard doc count condition must be greater than 0" }
 
         // Validate size condition
         if (size != null) require(size.bytes > 0) { "Transition size condition must be greater than 0" }
@@ -114,6 +115,7 @@ data class Conditions(
     constructor(sin: StreamInput) : this(
         indexAge = sin.readOptionalTimeValue(),
         docCount = sin.readOptionalLong(),
+        primaryShardDocCount = sin.readOptionalLong(),
         size = sin.readOptionalWriteable(::ByteSizeValue),
         cron = sin.readOptionalWriteable(::CronSchedule),
         rolloverAge = sin.readOptionalTimeValue(),

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/model/Transition.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/model/Transition.kt
@@ -78,6 +78,7 @@ data class Transition(
 data class Conditions(
     val indexAge: TimeValue? = null,
     val docCount: Long? = null,
+    val primaryShardDocCount: Long? = null,
     val size: ByteSizeValue? = null,
     val cron: CronSchedule? = null,
     val rolloverAge: TimeValue? = null,
@@ -100,6 +101,7 @@ data class Conditions(
         builder.startObject()
         if (indexAge != null) builder.field(MIN_INDEX_AGE_FIELD, indexAge.stringRep)
         if (docCount != null) builder.field(MIN_DOC_COUNT_FIELD, docCount)
+        if (primaryShardDocCount != null) builder.field(MIN_PRIMARY_SHARD_DOC_COUNT_FIELD, primaryShardDocCount)
         if (size != null) builder.field(MIN_SIZE_FIELD, size.stringRep)
         if (cron != null) builder.field(CRON_FIELD, cron)
         if (rolloverAge != null) builder.field(MIN_ROLLOVER_AGE_FIELD, rolloverAge.stringRep)
@@ -135,6 +137,7 @@ data class Conditions(
     companion object {
         const val MIN_INDEX_AGE_FIELD = "min_index_age"
         const val MIN_DOC_COUNT_FIELD = "min_doc_count"
+        const val MIN_PRIMARY_SHARD_DOC_COUNT_FIELD = "min_primary_shard_doc_count"
         const val MIN_SIZE_FIELD = "min_size"
         const val CRON_FIELD = "cron"
         const val MIN_ROLLOVER_AGE_FIELD = "min_rollover_age"
@@ -146,6 +149,7 @@ data class Conditions(
         fun parse(xcp: XContentParser): Conditions {
             var indexAge: TimeValue? = null
             var docCount: Long? = null
+            var primaryShardDocCount: Long? = null
             var size: ByteSizeValue? = null
             var cron: CronSchedule? = null
             var rolloverAge: TimeValue? = null
@@ -160,6 +164,7 @@ data class Conditions(
                 when (fieldName) {
                     MIN_INDEX_AGE_FIELD -> indexAge = TimeValue.parseTimeValue(xcp.text(), MIN_INDEX_AGE_FIELD)
                     MIN_DOC_COUNT_FIELD -> docCount = xcp.longValue()
+                    MIN_PRIMARY_SHARD_DOC_COUNT_FIELD -> primaryShardDocCount = xcp.longValue()
                     MIN_SIZE_FIELD -> size = ByteSizeValue.parseBytesSizeValue(xcp.text(), MIN_SIZE_FIELD)
                     CRON_FIELD -> cron = ScheduleParser.parse(xcp) as? CronSchedule
                     MIN_ROLLOVER_AGE_FIELD -> rolloverAge = TimeValue.parseTimeValue(xcp.text(), MIN_ROLLOVER_AGE_FIELD)
@@ -169,7 +174,7 @@ data class Conditions(
                 }
             }
 
-            return Conditions(indexAge, docCount, size, cron, rolloverAge, noAlias, minStateAge)
+            return Conditions(indexAge, docCount, primaryShardDocCount, size, cron, rolloverAge, noAlias, minStateAge)
         }
     }
 }

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/rollover/AttemptRolloverStep.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/rollover/AttemptRolloverStep.kt
@@ -161,7 +161,8 @@ class AttemptRolloverStep(private val action: RolloverAction) : Step(name) {
         if (action.evaluateConditions(indexAgeTimeValue, numDocs, numDocsMostCrowdedShard, indexSize, largestPrimaryShardSize)) {
             logger.info(
                 "$indexName rollover conditions evaluated to true [indexCreationDate=$indexCreationDate," +
-                    " numDocs=$numDocs, primaryShardNumDocs=$numDocsMostCrowdedShard, indexSize=${indexSize.bytes}, primaryShardSize=${largestPrimaryShardSize.bytes}]",
+                    " numDocs=$numDocs, primaryShardNumDocs=$numDocsMostCrowdedShard," +
+                    " indexSize=${indexSize.bytes}, primaryShardSize=${largestPrimaryShardSize.bytes}]",
             )
             executeRollover(context, rolloverTarget, isDataStream, conditions)
             copyAlias(clusterService, indexName, context.client, rolloverTarget, context.metadata)

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/rollover/AttemptRolloverStep.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/rollover/AttemptRolloverStep.kt
@@ -104,6 +104,15 @@ class AttemptRolloverStep(private val action: RolloverAction) : Step(name) {
                 TimeValue.timeValueMillis(Instant.now().toEpochMilli() - indexCreationDate)
             }
         val numDocs = statsResponse.primaries.docs?.count ?: 0
+        var numDocsMostCrowdedShard: Long = 0
+        for (shard in statsResponse.getShards()) {
+            if (shard.getShardRouting().primary()) {
+                val currentShardNumDocs: Long? = shard.getStats().getDocs()?.count
+                if (currentShardNumDocs != null && currentShardNumDocs > numDocsMostCrowdedShard) {
+                    numDocsMostCrowdedShard = currentShardNumDocs
+                }
+            }
+        }
         val indexSize = ByteSizeValue(statsResponse.primaries.docs?.totalSizeInBytes ?: 0)
         val largestPrimaryShard = statsResponse.shards.maxByOrNull { it.stats.docs?.totalSizeInBytes ?: 0 }
         val largestPrimaryShardSize = ByteSizeValue(largestPrimaryShard?.stats?.docs?.totalSizeInBytes ?: 0)
@@ -125,6 +134,13 @@ class AttemptRolloverStep(private val action: RolloverAction) : Step(name) {
                             "current" to numDocs,
                         )
                 },
+                action.minPrimaryShardDocs?.let {
+                    RolloverAction.MIN_PRIMARY_SHARD_DOC_COUNT_FIELD to
+                        mapOf(
+                            "condition" to it,
+                            "current" to numDocsMostCrowdedShard,
+                        )
+                },
                 action.minSize?.let {
                     RolloverAction.MIN_SIZE_FIELD to
                         mapOf(
@@ -142,10 +158,10 @@ class AttemptRolloverStep(private val action: RolloverAction) : Step(name) {
                 },
             ).toMap()
 
-        if (action.evaluateConditions(indexAgeTimeValue, numDocs, indexSize, largestPrimaryShardSize)) {
+        if (action.evaluateConditions(indexAgeTimeValue, numDocs, numDocsMostCrowdedShard, indexSize, largestPrimaryShardSize)) {
             logger.info(
                 "$indexName rollover conditions evaluated to true [indexCreationDate=$indexCreationDate," +
-                    " numDocs=$numDocs, indexSize=${indexSize.bytes}, primaryShardSize=${largestPrimaryShardSize.bytes}]",
+                    " numDocs=$numDocs, primaryShardNumDocs=$numDocsMostCrowdedShard, indexSize=${indexSize.bytes}, primaryShardSize=${largestPrimaryShardSize.bytes}]",
             )
             executeRollover(context, rolloverTarget, isDataStream, conditions)
             copyAlias(clusterService, indexName, context.client, rolloverTarget, context.metadata)

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/transition/AttemptTransitionStep.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/transition/AttemptTransitionStep.kt
@@ -59,6 +59,7 @@ class AttemptTransitionStep(private val action: TransitionsAction) : Step(name) 
             }
             val stepStartTime = getStepStartTime(context.metadata)
             var numDocs: Long? = null
+            var numDocsMostCrowdedShard: Long? = null
             var indexSize: ByteSizeValue? = null
 
             val rolloverDate: Instant? = if (inCluster) indexMetadata.getOldestRolloverTime() else null
@@ -94,6 +95,15 @@ class AttemptTransitionStep(private val action: TransitionsAction) : Step(name) 
                         return this
                     }
                     numDocs = statsResponse.primaries.getDocs()?.count ?: 0
+                    for (shard in statsResponse.getShards()) {
+                        if (shard.getShardRouting().primary()) {
+                            val currentShardNumDocs: Long? = shard.getStats().getDocs()?.count
+                            if (numDocsMostCrowdedShard == null || (currentShardNumDocs != null && currentShardNumDocs > numDocsMostCrowdedShard)) {
+                                numDocsMostCrowdedShard = currentShardNumDocs
+                            }
+                        }
+                    }
+                    numDocsMostCrowdedShard = numDocsMostCrowdedShard ?: 0
                     indexSize = ByteSizeValue(statsResponse.primaries.getDocs()?.totalSizeInBytes ?: 0)
                 } else {
                     logger.warn("Cannot use index size/doc count transition conditions for index [$indexName] that does not exist in cluster")
@@ -110,6 +120,7 @@ class AttemptTransitionStep(private val action: TransitionsAction) : Step(name) 
                         TransitionConditionContext(
                             indexCreationDate = indexCreationDateInstant,
                             numDocs = numDocs,
+                            primaryShardNumDocs = numDocsMostCrowdedShard,
                             indexSize = indexSize,
                             transitionStartTime = stepStartTime,
                             rolloverDate = rolloverDate,
@@ -123,7 +134,7 @@ class AttemptTransitionStep(private val action: TransitionsAction) : Step(name) 
             if (stateName != null) {
                 logger.info(
                     "$indexName transition conditions evaluated to true [indexCreationDate=$indexCreationDate," +
-                        " numDocs=$numDocs, indexSize=${indexSize?.bytes},stepStartTime=${stepStartTime.toEpochMilli()}]",
+                        " numDocs=$numDocs, primaryShardNumDocs=$numDocsMostCrowdedShard, indexSize=${indexSize?.bytes},stepStartTime=${stepStartTime.toEpochMilli()}]",
                 )
                 stepStatus = StepStatus.COMPLETED
                 message = getSuccessMessage(indexName, stateName)

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/transition/AttemptTransitionStep.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/transition/AttemptTransitionStep.kt
@@ -134,7 +134,8 @@ class AttemptTransitionStep(private val action: TransitionsAction) : Step(name) 
             if (stateName != null) {
                 logger.info(
                     "$indexName transition conditions evaluated to true [indexCreationDate=$indexCreationDate," +
-                        " numDocs=$numDocs, primaryShardNumDocs=$numDocsMostCrowdedShard, indexSize=${indexSize?.bytes},stepStartTime=${stepStartTime.toEpochMilli()}]",
+                        " numDocs=$numDocs, primaryShardNumDocs=$numDocsMostCrowdedShard," +
+                        " indexSize=${indexSize?.bytes},stepStartTime=${stepStartTime.toEpochMilli()}]",
                 )
                 stepStatus = StepStatus.COMPLETED
                 message = getSuccessMessage(indexName, stateName)

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/util/ManagedIndexUtils.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/util/ManagedIndexUtils.kt
@@ -187,6 +187,7 @@ fun getSweptManagedIndexSearchRequest(scroll: Boolean = false, size: Int = Manag
 data class TransitionConditionContext(
     val indexCreationDate: Instant,
     val numDocs: Long?,
+    val primaryShardNumDocs: Long?,
     val indexSize: ByteSizeValue?,
     val transitionStartTime: Instant,
     val rolloverDate: Instant?,
@@ -200,6 +201,7 @@ fun Transition.evaluateConditions(
 ): Boolean {
     val conditions = this.conditions ?: return true
     if (checkDocCount(conditions, context)) return true
+    if (checkPrimaryShardDocCount(conditions, context)) return true
     if (checkIndexAge(conditions, context)) return true
     if (checkSize(conditions, context)) return true
     if (checkCron(conditions, context)) return true
@@ -213,6 +215,11 @@ private fun checkDocCount(conditions: Conditions, context: TransitionConditionCo
     conditions.docCount != null &&
         context.numDocs != null &&
         conditions.docCount <= context.numDocs
+
+private fun checkPrimaryShardDocCount(conditions: Conditions, context: TransitionConditionContext): Boolean =
+    conditions.primaryShardDocCount != null &&
+        context.primaryShardNumDocs != null &&
+        conditions.primaryShardDocCount <= context.primaryShardNumDocs
 
 @Suppress("ReturnCount")
 private fun checkIndexAge(conditions: Conditions, context: TransitionConditionContext): Boolean {

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/util/ManagedIndexUtils.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/util/ManagedIndexUtils.kt
@@ -266,10 +266,12 @@ fun Transition.hasStatsConditions(): Boolean = this.conditions?.docCount != null
 fun RolloverAction.evaluateConditions(
     indexAgeTimeValue: TimeValue,
     numDocs: Long,
+    primaryShardNumDocs: Long,
     indexSize: ByteSizeValue,
     primaryShardSize: ByteSizeValue,
 ): Boolean {
     if (this.minDocs == null &&
+        this.minPrimaryShardDocs == null &&
         this.minAge == null &&
         this.minSize == null &&
         this.minPrimaryShardSize == null
@@ -280,6 +282,10 @@ fun RolloverAction.evaluateConditions(
 
     if (this.minDocs != null) {
         if (this.minDocs <= numDocs) return true
+    }
+
+    if (this.minPrimaryShardDocs != null) {
+        if (this.minPrimaryShardDocs <= primaryShardNumDocs) return true
     }
 
     if (this.minAge != null) {

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/util/ManagedIndexUtils.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/util/ManagedIndexUtils.kt
@@ -269,7 +269,7 @@ private fun checkMinStateAge(conditions: Conditions, context: TransitionConditio
 
 fun Transition.hasStatsConditions(): Boolean = this.conditions?.docCount != null || this.conditions?.size != null
 
-@Suppress("ReturnCount", "ComplexCondition")
+@Suppress("ReturnCount", "ComplexCondition", "CyclomaticComplexMethod")
 fun RolloverAction.evaluateConditions(
     indexAgeTimeValue: TimeValue,
     numDocs: Long,

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/util/ManagedIndexUtils.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/util/ManagedIndexUtils.kt
@@ -267,7 +267,8 @@ private fun checkMinStateAge(conditions: Conditions, context: TransitionConditio
         context.stateStartTime != null &&
         (System.currentTimeMillis() - context.stateStartTime.toEpochMilli() >= conditions.minStateAge.millis)
 
-fun Transition.hasStatsConditions(): Boolean = this.conditions?.docCount != null || this.conditions?.size != null
+fun Transition.hasStatsConditions(): Boolean = this.conditions?.docCount != null || this.conditions?.primaryShardDocCount != null ||
+    this.conditions?.size != null
 
 @Suppress("ReturnCount", "ComplexCondition", "CyclomaticComplexMethod")
 fun RolloverAction.evaluateConditions(

--- a/src/main/resources/mappings/opendistro-ism-config.json
+++ b/src/main/resources/mappings/opendistro-ism-config.json
@@ -243,6 +243,9 @@
                     "min_doc_count": {
                       "type": "keyword"
                     },
+                    "min_primary_shard_doc_count": {
+                      "type": "keyword"
+                    },
                     "min_primary_shard_size": {
                       "type": "keyword"
                     },

--- a/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/TestHelpers.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/TestHelpers.kt
@@ -130,11 +130,13 @@ fun randomDeleteActionConfig(): DeleteAction = DeleteAction(index = 0)
 fun randomRolloverActionConfig(
     minSize: ByteSizeValue = randomByteSizeValue(),
     minDocs: Long = OpenSearchRestTestCase.randomLongBetween(1, 1000),
+    minPrimaryShardDocs: Long = OpenSearchRestTestCase.randomLongBetween(900, 1000),
     minAge: TimeValue = randomTimeValueObject(),
     minPrimaryShardSize: ByteSizeValue = randomByteSizeValue(),
 ): RolloverAction = RolloverAction(
     minSize = minSize,
     minDocs = minDocs,
+    minPrimaryShardDocs = minPrimaryShardDocs,
     minAge = minAge,
     minPrimaryShardSize = minPrimaryShardSize,
     preventEmptyRollover = false,

--- a/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/action/RolloverActionIT.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/action/RolloverActionIT.kt
@@ -41,7 +41,7 @@ class RolloverActionIT : IndexStateManagementRestTestCase() {
         val indexNameBase = "${testIndexName}_index"
         val firstIndex = "$indexNameBase-1"
         val policyID = "${testIndexName}_testPolicyName_1"
-        val actionConfig = RolloverAction(null, null, null, null, false, false, 0)
+        val actionConfig = RolloverAction(null, null, null, null, null, false, false, 0)
         val states = listOf(State(name = "RolloverAction", actions = listOf(actionConfig), transitions = listOf()))
         val policy =
             Policy(
@@ -96,7 +96,7 @@ class RolloverActionIT : IndexStateManagementRestTestCase() {
         )
 
         val policyID = "${testIndexName}_bwc"
-        val actionConfig = RolloverAction(null, null, null, null, false, false, 0)
+        val actionConfig = RolloverAction(null, null, null, null, null, false, false, 0)
         val states = listOf(State(name = "RolloverAction", actions = listOf(actionConfig), transitions = listOf()))
         val policy =
             Policy(
@@ -134,7 +134,7 @@ class RolloverActionIT : IndexStateManagementRestTestCase() {
         val indexNameBase = "${testIndexName}_index_byte"
         val firstIndex = "$indexNameBase-1"
         val policyID = "${testIndexName}_testPolicyName_byte_1"
-        val actionConfig = RolloverAction(ByteSizeValue(10, ByteSizeUnit.BYTES), 1000000, null, null, false, false, 0)
+        val actionConfig = RolloverAction(ByteSizeValue(10, ByteSizeUnit.BYTES), 1000000, null, null, null, false, false, 0)
         val states = listOf(State(name = "RolloverAction", actions = listOf(actionConfig), transitions = listOf()))
         val policy =
             Policy(
@@ -207,7 +207,7 @@ class RolloverActionIT : IndexStateManagementRestTestCase() {
         val indexNameBase = "${testIndexName}_index_primary_shard"
         val firstIndex = "$indexNameBase-1"
         val policyID = "${testIndexName}_primary_shard_1"
-        val actionConfig = RolloverAction(null, null, null, ByteSizeValue(100, ByteSizeUnit.KB), false, false, 0)
+        val actionConfig = RolloverAction(null, null, null, null, ByteSizeValue(100, ByteSizeUnit.KB), false, false, 0)
         val states = listOf(State(name = "RolloverAction", actions = listOf(actionConfig), transitions = listOf()))
         val policy =
             Policy(
@@ -319,7 +319,7 @@ class RolloverActionIT : IndexStateManagementRestTestCase() {
         val indexNameBase = "${testIndexName}_index_doc"
         val firstIndex = "$indexNameBase-1"
         val policyID = "${testIndexName}_testPolicyName_doc_1"
-        val actionConfig = RolloverAction(null, 3, TimeValue.timeValueDays(2), null, false, false, 0)
+        val actionConfig = RolloverAction(null, 3, null, TimeValue.timeValueDays(2), null, false, false, 0)
         val states = listOf(State(name = "RolloverAction", actions = listOf(actionConfig), transitions = listOf()))
         val policy =
             Policy(
@@ -393,7 +393,7 @@ class RolloverActionIT : IndexStateManagementRestTestCase() {
         val index2 = "index-2"
         val alias1 = "x"
         val policyID = "${testIndexName}_precheck"
-        val actionConfig = RolloverAction(null, 3, TimeValue.timeValueDays(2), null, false, false, 0)
+        val actionConfig = RolloverAction(null, 3, null, TimeValue.timeValueDays(2), null, false, false, 0)
         actionConfig.configRetry = ActionRetry(0)
         val states = listOf(State(name = "RolloverAction", actions = listOf(actionConfig), transitions = listOf()))
         val policy =
@@ -454,7 +454,7 @@ class RolloverActionIT : IndexStateManagementRestTestCase() {
         val policyID = "${testIndexName}_rollover_policy"
 
         // Create the rollover policy
-        val rolloverAction = RolloverAction(null, null, null, null, false, false, 0)
+        val rolloverAction = RolloverAction(null, null, null, null, null, false, false, 0)
         val states = listOf(State(name = "default", actions = listOf(rolloverAction), transitions = listOf()))
         val policy =
             Policy(
@@ -514,7 +514,7 @@ class RolloverActionIT : IndexStateManagementRestTestCase() {
         val policyID = "${testIndexName}_rollover_policy_multi"
 
         // Create the rollover policy
-        val rolloverAction = RolloverAction(null, 3, TimeValue.timeValueDays(2), null, false, false, 0)
+        val rolloverAction = RolloverAction(null, 3, null, TimeValue.timeValueDays(2), null, false, false, 0)
         val states = listOf(State(name = "default", actions = listOf(rolloverAction), transitions = listOf()))
         val policy =
             Policy(
@@ -605,12 +605,102 @@ class RolloverActionIT : IndexStateManagementRestTestCase() {
         assertEquals(metadata.rolledOverIndexName, secondIndexName)
     }
 
+    @Suppress("UNCHECKED_CAST")
+    fun `test data stream rollover condition num doc primary shard`() {
+        val dataStreamName = "${testIndexName}_data_stream_ndps"
+        val policyID = "${testIndexName}_rollover_policy_ndps"
+
+        // Create the rollover policy
+        val rolloverAction = RolloverAction(null, null, 3, TimeValue.timeValueDays(2), null, false, false, 0)
+        val states = listOf(State(name = "default", actions = listOf(rolloverAction), transitions = listOf()))
+        val policy =
+            Policy(
+                id = policyID,
+                description = "rollover policy description",
+                schemaVersion = 1L,
+                lastUpdatedTime = Instant.now().truncatedTo(ChronoUnit.MILLIS),
+                errorNotification = randomErrorNotification(),
+                defaultState = states[0].name,
+                states = states,
+                ismTemplate = listOf(ISMTemplate(listOf(dataStreamName), 100, Instant.now().truncatedTo(ChronoUnit.MILLIS))),
+            )
+        createPolicy(policy, policyID)
+
+        // Create the data stream
+        val firstIndexName = DataStream.getDefaultBackingIndexName(dataStreamName, 1L)
+        client().makeRequest(
+            "PUT",
+            "/_index_template/rollover-data-stream-template",
+            StringEntity("{ \"index_patterns\": [ \"$dataStreamName\" ], \"data_stream\": { } }", ContentType.APPLICATION_JSON),
+        )
+        client().makeRequest("PUT", "/_data_stream/$dataStreamName")
+
+        val managedIndexConfig = getExistingManagedIndexConfig(firstIndexName)
+
+        // Change the start time so that the job will trigger in 2 seconds. This will trigger the first initialization of the policy.
+        updateManagedIndexConfigStartTime(managedIndexConfig)
+        waitFor { assertEquals(policyID, getExplainManagedIndexMetaData(firstIndexName).policyID) }
+
+        // Speed up to the second execution of the policy where it will trigger the first execution of the action.
+        // Rollover shouldn't have happened yet as the conditions aren't met.
+        updateManagedIndexConfigStartTime(managedIndexConfig)
+        waitFor {
+            val info = getExplainManagedIndexMetaData(firstIndexName).info as Map<String, Any?>
+            assertEquals(
+                "Index rollover before it met the condition.",
+                AttemptRolloverStep.getPendingMessage(firstIndexName),
+                info["message"],
+            )
+
+            val conditions = info["conditions"] as Map<String, Any?>
+            assertEquals(
+                "Did not have exclusively min primary shard doc count condition",
+                setOf(RolloverAction.MIN_PRIMARY_SHARD_DOC_COUNT_FIELD),
+                conditions.keys,
+            )
+
+            val minPrimaryShardDocCount = conditions[RolloverAction.MIN_PRIMARY_SHARD_DOC_COUNT_FIELD] as Map<String, Any?>
+            assertEquals("minPrimaryShardDocCount", 3, minPrimaryShardDocCount["condition"])
+        }
+
+        insertSampleData(index = dataStreamName, docCount = 5, jsonString = "{ \"@timestamp\": \"2020-12-06T11:04:05.000Z\" }")
+
+        // Speed up to the third execution of the policy where it will trigger the second execution of the action.
+        // Rollover should have happened as the conditions were met.
+        updateManagedIndexConfigStartTime(managedIndexConfig)
+        waitFor {
+            val info = getExplainManagedIndexMetaData(firstIndexName).info as Map<String, Any?>
+            assertEquals(
+                "Data stream did not rollover",
+                AttemptRolloverStep.getSuccessDataStreamRolloverMessage(dataStreamName, firstIndexName),
+                info["message"],
+            )
+
+            val conditions = info["conditions"] as Map<String, Any?>
+            assertEquals(
+                "Did not have exclusively min primary shard doc count condition",
+                setOf(RolloverAction.MIN_PRIMARY_SHARD_DOC_COUNT_FIELD),
+                conditions.keys,
+            )
+
+            val minPrimaryShardDocCount = conditions[RolloverAction.MIN_PRIMARY_SHARD_DOC_COUNT_FIELD] as Map<String, Any?>
+            assertEquals("Incorrect min docs condition", 3, minPrimaryShardDocCount["condition"])
+            assertEquals("Incorrect min docs current", 5, minPrimaryShardDocCount["current"])
+        }
+
+        val secondIndexName = DataStream.getDefaultBackingIndexName(dataStreamName, 2L)
+        Assert.assertTrue("New rollover index does not exist.", indexExists(secondIndexName))
+
+        val metadata = getExplainManagedIndexMetaData(firstIndexName)
+        assertEquals(metadata.rolledOverIndexName, secondIndexName)
+    }
+
     fun `test rollover from outside ISM doesn't fail ISM job`() {
         val aliasName = "${testIndexName}_alias"
         val indexNameBase = "${testIndexName}_index"
         val firstIndex = "$indexNameBase-1"
         val policyID = "${testIndexName}_testPolicyName_1"
-        val actionConfig = RolloverAction(null, null, null, null, false, false, 0)
+        val actionConfig = RolloverAction(null, null, null, null, null, false, false, 0)
         val states = listOf(State(name = "RolloverAction", actions = listOf(actionConfig), transitions = listOf()))
         val policy =
             Policy(
@@ -653,7 +743,7 @@ class RolloverActionIT : IndexStateManagementRestTestCase() {
         val indexNameBase = "${testIndexName}_index_doc"
         val firstIndex = "$indexNameBase-1"
         val policyID = "${testIndexName}_testPolicyName_doc_1"
-        val actionConfig = RolloverAction(null, 3, TimeValue.timeValueDays(2), null, true, false, 0)
+        val actionConfig = RolloverAction(null, 3, null, TimeValue.timeValueDays(2), null, true, false, 0)
         val states = listOf(State(name = "RolloverAction", actions = listOf(actionConfig), transitions = listOf()))
         val policy =
             Policy(
@@ -752,7 +842,7 @@ class RolloverActionIT : IndexStateManagementRestTestCase() {
         val indexNameBase = "${testIndexName}_index"
         val firstIndex = "$indexNameBase-1"
         val policyID = "${testIndexName}_testPolicyName_1"
-        val actionConfig = RolloverAction(null, 1, null, null, false, false, 0)
+        val actionConfig = RolloverAction(null, 1, null, null, null, false, false, 0)
         val states = listOf(State(name = "RolloverAction", actions = listOf(actionConfig), transitions = listOf()))
         val policy =
             Policy(
@@ -816,7 +906,7 @@ class RolloverActionIT : IndexStateManagementRestTestCase() {
         val indexNameBase = "${testIndexName}_prevent_empty_index"
         val firstIndex = "$indexNameBase-1"
         val policyID = "${testIndexName}_prevent_empty_policy"
-        val actionConfig = RolloverAction(null, null, TimeValue.timeValueSeconds(1), null, false, true, 0)
+        val actionConfig = RolloverAction(null, null, null, TimeValue.timeValueSeconds(1), null, false, true, 0)
         val states = listOf(State(name = "RolloverAction", actions = listOf(actionConfig), transitions = listOf()))
         val policy =
             Policy(
@@ -875,7 +965,7 @@ class RolloverActionIT : IndexStateManagementRestTestCase() {
         val indexNameBase = "${testIndexName}_prevent_then_rollover_index"
         val firstIndex = "$indexNameBase-1"
         val policyID = "${testIndexName}_prevent_then_rollover_policy"
-        val actionConfig = RolloverAction(null, null, TimeValue.timeValueSeconds(1), null, false, true, 0)
+        val actionConfig = RolloverAction(null, null, null, TimeValue.timeValueSeconds(1), null, false, true, 0)
         val states = listOf(State(name = "RolloverAction", actions = listOf(actionConfig), transitions = listOf()))
         val policy =
             Policy(
@@ -940,7 +1030,7 @@ class RolloverActionIT : IndexStateManagementRestTestCase() {
         val firstIndex = "$indexNameBase-1"
         val policyID = "${testIndexName}_default_behavior_policy"
         // preventEmptyRollover defaults to false
-        val actionConfig = RolloverAction(null, null, TimeValue.timeValueSeconds(1), null, false, false, 0)
+        val actionConfig = RolloverAction(null, null, null, TimeValue.timeValueSeconds(1), null, false, false, 0)
         val states = listOf(State(name = "RolloverAction", actions = listOf(actionConfig), transitions = listOf()))
         val policy =
             Policy(

--- a/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/action/RolloverActionIT.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/action/RolloverActionIT.kt
@@ -611,7 +611,7 @@ class RolloverActionIT : IndexStateManagementRestTestCase() {
         val policyID = "${testIndexName}_rollover_policy_ndps"
 
         // Create the rollover policy
-        val rolloverAction = RolloverAction(null, null, 3, TimeValue.timeValueDays(2), null, false, false, 0)
+        val rolloverAction = RolloverAction(null, null, 3, null, null, false, false, 0)
         val states = listOf(State(name = "default", actions = listOf(rolloverAction), transitions = listOf()))
         val policy =
             Policy(

--- a/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/action/RolloverActionTests.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/action/RolloverActionTests.kt
@@ -62,9 +62,9 @@ class RolloverActionTests : OpenSearchTestCase() {
         builder.endObject()
 
         val jsonString = builder.string()
-        assertFalse(
-            "XContent should NOT contain prevent_empty_rollover field when false",
-            jsonString.contains("prevent_empty_rollover"),
+        assertTrue(
+            "XContent should contain min_primary_shard_doc_count field",
+            jsonString.contains("min_primary_shard_doc_count"),
         )
     }
 
@@ -117,7 +117,7 @@ class RolloverActionTests : OpenSearchTestCase() {
         val originalAction = RolloverAction(
             minSize = ByteSizeValue.parseBytesSizeValue("50gb", "test"),
             minDocs = 1000L,
-            minPrimaryShardDocs = null,
+            minPrimaryShardDocs = 1000,
             minAge = TimeValue.parseTimeValue("7d", "test"),
             minPrimaryShardSize = ByteSizeValue.parseBytesSizeValue("30gb", "test"),
             copyAlias = true,
@@ -135,6 +135,7 @@ class RolloverActionTests : OpenSearchTestCase() {
         assertEquals("minSize should be preserved", originalAction.minSize, deserializedAction.minSize)
         assertEquals("minDocs should be preserved", originalAction.minDocs, deserializedAction.minDocs)
         assertEquals("minAge should be preserved", originalAction.minAge, deserializedAction.minAge)
+        assertEquals("minPrimaryShardDocs should be preserved", originalAction.minPrimaryShardDocs, deserializedAction.minPrimaryShardDocs)
         assertEquals("minPrimaryShardSize should be preserved", originalAction.minPrimaryShardSize, deserializedAction.minPrimaryShardSize)
         assertEquals("copyAlias should be preserved", originalAction.copyAlias, deserializedAction.copyAlias)
         assertEquals("preventEmptyRollover should be preserved", originalAction.preventEmptyRollover, deserializedAction.preventEmptyRollover)

--- a/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/action/RolloverActionTests.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/action/RolloverActionTests.kt
@@ -23,10 +23,56 @@ import java.io.ByteArrayOutputStream
 
 class RolloverActionTests : OpenSearchTestCase() {
 
+    fun `test XContent serialization with minPrimaryShardDocs null`() {
+        val action = RolloverAction(
+            minSize = ByteSizeValue.parseBytesSizeValue("50gb", "test"),
+            minDocs = 1000L,
+            minPrimaryShardDocs = null,
+            minAge = TimeValue.parseTimeValue("7d", "test"),
+            minPrimaryShardSize = ByteSizeValue.parseBytesSizeValue("30gb", "test"),
+            copyAlias = false,
+            preventEmptyRollover = true,
+            index = 0,
+        )
+
+        val builder = XContentFactory.jsonBuilder()
+        builder.startObject()
+        action.populateAction(builder, org.opensearch.core.xcontent.ToXContent.EMPTY_PARAMS)
+        builder.endObject()
+
+        val jsonString = builder.string()
+        assertTrue("XContent should contain prevent_empty_rollover field", jsonString.contains("\"prevent_empty_rollover\":true"))
+    }
+
+    fun `test XContent serialization with minPrimaryShardDocs set to 2000000000`() {
+        val action = RolloverAction(
+            minSize = ByteSizeValue.parseBytesSizeValue("50gb", "test"),
+            minDocs = null,
+            minPrimaryShardDocs = 2000000000,
+            minAge = TimeValue.parseTimeValue("7d", "test"),
+            minPrimaryShardSize = ByteSizeValue.parseBytesSizeValue("30gb", "test"),
+            copyAlias = false,
+            preventEmptyRollover = false,
+            index = 0,
+        )
+
+        val builder = XContentFactory.jsonBuilder()
+        builder.startObject()
+        action.populateAction(builder, org.opensearch.core.xcontent.ToXContent.EMPTY_PARAMS)
+        builder.endObject()
+
+        val jsonString = builder.string()
+        assertFalse(
+            "XContent should NOT contain prevent_empty_rollover field when false",
+            jsonString.contains("prevent_empty_rollover"),
+        )
+    }
+
     fun `test XContent serialization with preventEmptyRollover true`() {
         val action = RolloverAction(
             minSize = ByteSizeValue.parseBytesSizeValue("50gb", "test"),
             minDocs = 1000L,
+            minPrimaryShardDocs = null,
             minAge = TimeValue.parseTimeValue("7d", "test"),
             minPrimaryShardSize = ByteSizeValue.parseBytesSizeValue("30gb", "test"),
             copyAlias = false,
@@ -47,6 +93,7 @@ class RolloverActionTests : OpenSearchTestCase() {
         val action = RolloverAction(
             minSize = ByteSizeValue.parseBytesSizeValue("50gb", "test"),
             minDocs = 1000L,
+            minPrimaryShardDocs = null,
             minAge = TimeValue.parseTimeValue("7d", "test"),
             minPrimaryShardSize = ByteSizeValue.parseBytesSizeValue("30gb", "test"),
             copyAlias = false,
@@ -70,6 +117,7 @@ class RolloverActionTests : OpenSearchTestCase() {
         val originalAction = RolloverAction(
             minSize = ByteSizeValue.parseBytesSizeValue("50gb", "test"),
             minDocs = 1000L,
+            minPrimaryShardDocs = null,
             minAge = TimeValue.parseTimeValue("7d", "test"),
             minPrimaryShardSize = ByteSizeValue.parseBytesSizeValue("30gb", "test"),
             copyAlias = true,
@@ -125,6 +173,7 @@ class RolloverActionTests : OpenSearchTestCase() {
         val action = RolloverAction(
             minSize = ByteSizeValue.parseBytesSizeValue("50gb", "test"),
             minDocs = null,
+            minPrimaryShardDocs = null,
             minAge = null,
             minPrimaryShardSize = null,
             copyAlias = false,
@@ -139,6 +188,7 @@ class RolloverActionTests : OpenSearchTestCase() {
         val action = RolloverAction(
             minSize = null,
             minDocs = null,
+            minPrimaryShardDocs = null,
             minAge = TimeValue.parseTimeValue("7d", "test"),
             minPrimaryShardSize = null,
             copyAlias = false,
@@ -153,6 +203,7 @@ class RolloverActionTests : OpenSearchTestCase() {
         val action = RolloverAction(
             minSize = ByteSizeValue.parseBytesSizeValue("50gb", "test"),
             minDocs = 1000L,
+            minPrimaryShardDocs = null,
             minAge = TimeValue.parseTimeValue("7d", "test"),
             minPrimaryShardSize = ByteSizeValue.parseBytesSizeValue("30gb", "test"),
             copyAlias = true,
@@ -175,6 +226,7 @@ class RolloverActionTests : OpenSearchTestCase() {
         val originalAction = RolloverAction(
             minSize = ByteSizeValue.parseBytesSizeValue("50gb", "test"),
             minDocs = 1000L,
+            minPrimaryShardDocs = null,
             minAge = TimeValue.parseTimeValue("7d", "test"),
             minPrimaryShardSize = ByteSizeValue.parseBytesSizeValue("30gb", "test"),
             copyAlias = true,
@@ -208,6 +260,7 @@ class RolloverActionTests : OpenSearchTestCase() {
         val action = RolloverAction(
             minSize = null,
             minDocs = null,
+            minPrimaryShardDocs = null,
             minAge = TimeValue.parseTimeValue("1d", "test"),
             minPrimaryShardSize = null,
             copyAlias = false,
@@ -226,6 +279,7 @@ class RolloverActionTests : OpenSearchTestCase() {
         val action = RolloverAction(
             minSize = null,
             minDocs = 100L,
+            minPrimaryShardDocs = null,
             minAge = null,
             minPrimaryShardSize = null,
             copyAlias = false,
@@ -244,6 +298,7 @@ class RolloverActionTests : OpenSearchTestCase() {
         val action = RolloverAction(
             minSize = null,
             minDocs = null,
+            minPrimaryShardDocs = null,
             minAge = TimeValue.parseTimeValue("1d", "test"),
             minPrimaryShardSize = null,
             copyAlias = true,
@@ -259,6 +314,7 @@ class RolloverActionTests : OpenSearchTestCase() {
         val originalAction = RolloverAction(
             minSize = ByteSizeValue.parseBytesSizeValue("10gb", "test"),
             minDocs = null,
+            minPrimaryShardDocs = null,
             minAge = TimeValue.parseTimeValue("3d", "test"),
             minPrimaryShardSize = null,
             copyAlias = false,
@@ -295,6 +351,7 @@ class RolloverActionTests : OpenSearchTestCase() {
         // Manually write fields as an old version would (without preventEmptyRollover)
         osso.writeOptionalWriteable(ByteSizeValue.parseBytesSizeValue("50gb", "test"))
         osso.writeOptionalLong(1000L)
+        osso.writeOptionalLong(1000L)
         osso.writeOptionalTimeValue(TimeValue.parseTimeValue("7d", "test"))
         osso.writeOptionalWriteable(ByteSizeValue.parseBytesSizeValue("30gb", "test"))
         osso.writeBoolean(true) // copyAlias
@@ -319,6 +376,7 @@ class RolloverActionTests : OpenSearchTestCase() {
         val originalAction = RolloverAction(
             minSize = ByteSizeValue.parseBytesSizeValue("50gb", "test"),
             minDocs = 1000L,
+            minPrimaryShardDocs = null,
             minAge = TimeValue.parseTimeValue("7d", "test"),
             minPrimaryShardSize = ByteSizeValue.parseBytesSizeValue("30gb", "test"),
             copyAlias = true,
@@ -348,6 +406,7 @@ class RolloverActionTests : OpenSearchTestCase() {
         val action = RolloverAction(
             minSize = ByteSizeValue.parseBytesSizeValue("50gb", "test"),
             minDocs = 1000L,
+            minPrimaryShardDocs = null,
             minAge = TimeValue.parseTimeValue("7d", "test"),
             minPrimaryShardSize = ByteSizeValue.parseBytesSizeValue("30gb", "test"),
             copyAlias = true,
@@ -381,6 +440,7 @@ class RolloverActionTests : OpenSearchTestCase() {
         // Read fields as old version would
         val minSize = input.readOptionalWriteable(::ByteSizeValue)
         val minDocs = input.readOptionalLong()
+        val minPrimaryShardDocs = input.readOptionalLong()
         val minAge = input.readOptionalTimeValue()
         val minPrimaryShardSize = input.readOptionalWriteable(::ByteSizeValue)
         val copyAlias = input.readBoolean()
@@ -389,6 +449,7 @@ class RolloverActionTests : OpenSearchTestCase() {
 
         assertEquals("minSize should match", action.minSize, minSize)
         assertEquals("minDocs should match", action.minDocs, minDocs)
+        assertEquals("minPrimaryShardDocs should match", action.minPrimaryShardDocs, minPrimaryShardDocs)
         assertEquals("minAge should match", action.minAge, minAge)
         assertEquals("minPrimaryShardSize should match", action.minPrimaryShardSize, minPrimaryShardSize)
         assertEquals("copyAlias should match", action.copyAlias, copyAlias)

--- a/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/action/TransitionActionIT.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/action/TransitionActionIT.kt
@@ -148,6 +148,47 @@ class TransitionActionIT : IndexStateManagementRestTestCase() {
         waitFor { assertEquals(AttemptTransitionStep.getSuccessMessage(indexName, secondStateName), getExplainManagedIndexMetaData(indexName).info?.get("message")) }
     }
 
+    fun `test primary shard doc count transition for index`() {
+        val indexName = "${testIndexName}_rollover_primary_shard_doc_count-01"
+        val policyID = "${testIndexName}_rollover_primary_shard_doc_count_policy"
+        val secondStateName = "second"
+        val states =
+            listOf(
+                State("first", listOf(), listOf(Transition(secondStateName, Conditions(primaryShardDocCount = 5)))),
+                State(secondStateName, listOf(), listOf()),
+            )
+
+        val policy =
+            Policy(
+                id = policyID,
+                description = "$testIndexName description",
+                schemaVersion = 1L,
+                lastUpdatedTime = Instant.now().truncatedTo(ChronoUnit.MILLIS),
+                errorNotification = randomErrorNotification(),
+                defaultState = states[0].name,
+                states = states,
+            )
+
+        createPolicy(policy, policyID)
+        createIndex(indexName, policyID)
+
+        val managedIndexConfig = getExistingManagedIndexConfig(indexName)
+
+        // Initializing the policy/metadata
+        updateManagedIndexConfigStartTime(managedIndexConfig)
+
+        waitFor { assertEquals(policyID, getExplainManagedIndexMetaData(indexName).policyID) }
+
+        // Add 6 documents (>5)
+        insertSampleData(indexName, 6)
+
+        // Evaluating transition conditions for first time
+        updateManagedIndexConfigStartTime(managedIndexConfig)
+
+        // Should have evaluated to true
+        waitFor { assertEquals(AttemptTransitionStep.getSuccessMessage(indexName, secondStateName), getExplainManagedIndexMetaData(indexName).info?.get("message")) }
+    }
+
     fun `test noAlias transition condition`() {
         val indexName = "${testIndexName}_no_alias"
         val policyID = "${testIndexName}_no_alias_policy"

--- a/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/coordinator/ManagedIndexCoordinatorIT.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/coordinator/ManagedIndexCoordinatorIT.kt
@@ -144,7 +144,7 @@ class ManagedIndexCoordinatorIT : IndexStateManagementRestTestCase() {
         val policyID = "test_policy_1"
 
         // Create a policy with one State that performs rollover
-        val rolloverActionConfig = RolloverAction(index = 0, minDocs = 5, minAge = null, minSize = null, minPrimaryShardSize = null, preventEmptyRollover = false)
+        val rolloverActionConfig = RolloverAction(index = 0, minDocs = 5, minPrimaryShardDocs = 5, minAge = null, minSize = null, minPrimaryShardSize = null, preventEmptyRollover = false)
         val states =
             listOf(State(name = "RolloverState", actions = listOf(rolloverActionConfig), transitions = listOf()))
         val policy =

--- a/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/model/ActionTests.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/model/ActionTests.kt
@@ -69,8 +69,20 @@ class ActionTests : OpenSearchTestCase() {
     }
 
     fun `test rollover action minimum doc count of zero fails`() {
-        assertFailsWith(IllegalArgumentException::class, "Expected IllegalArgumentException for minDoc less than 1") {
+        assertFailsWith(IllegalArgumentException::class, "Expected IllegalArgumentException for minDocs less than 1") {
             randomRolloverActionConfig(minDocs = 0)
+        }
+    }
+
+    fun `test rollover action minimum primary shard size of zero fails`() {
+        assertFailsWith(IllegalArgumentException::class, "Expected IllegalArgumentException for minPrimaryShardSize less than 1") {
+            randomRolloverActionConfig(minPrimaryShardSize = ByteSizeValue.parseBytesSizeValue("0", "min_primary_shard_size_test"))
+        }
+    }
+
+    fun `test rollover action minimum primary shard doc count of zero fails`() {
+        assertFailsWith(IllegalArgumentException::class, "Expected IllegalArgumentException for minPrimaryShardDocs less than 1") {
+            randomRolloverActionConfig(minPrimaryShardDocs = 0)
         }
     }
 

--- a/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/model/ConditionsTests.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/model/ConditionsTests.kt
@@ -30,6 +30,15 @@ class ConditionsTests : OpenSearchTestCase() {
         }
     }
 
+    fun `test primary shard doc count condition of zero fails`() {
+        assertFailsWith(
+            IllegalArgumentException::class,
+            "Expected IllegalArgumentException for primary shard doc count condition less than 1",
+        ) {
+            Conditions(primaryShardDocCount = 0)
+        }
+    }
+
     fun `test size condition of zero fails`() {
         assertFailsWith(
             IllegalArgumentException::class,

--- a/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/resthandler/RestChangePolicyActionIT.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/resthandler/RestChangePolicyActionIT.kt
@@ -598,7 +598,7 @@ class RestChangePolicyActionIT : IndexStateManagementRestTestCase() {
 
     fun `test allowing change policy to happen in middle of state if same state structure`() {
         // Creates a policy that has one state with rollover
-        val action = RolloverAction(index = 0, minDocs = 100_000_000, minAge = null, minSize = null, minPrimaryShardSize = null, preventEmptyRollover = false)
+        val action = RolloverAction(index = 0, minDocs = 100_000_000, minPrimaryShardDocs = null, minAge = null, minSize = null, minPrimaryShardSize = null, preventEmptyRollover = false)
         val stateWithReadOnlyAction = randomState(actions = listOf(action))
         val randomPolicy = randomPolicy(states = listOf(stateWithReadOnlyAction))
         val policy = createPolicy(randomPolicy)
@@ -631,7 +631,7 @@ class RestChangePolicyActionIT : IndexStateManagementRestTestCase() {
         val newStateWithReadOnlyAction =
             randomState(
                 name = stateWithReadOnlyAction.name,
-                actions = listOf(RolloverAction(index = 0, minDocs = 5, minAge = null, minSize = null, minPrimaryShardSize = null, preventEmptyRollover = false)),
+                actions = listOf(RolloverAction(index = 0, minDocs = 5, minPrimaryShardDocs = null, minAge = null, minSize = null, minPrimaryShardSize = null, preventEmptyRollover = false)),
             )
         val newRandomPolicy = randomPolicy(states = listOf(newStateWithReadOnlyAction))
         val newPolicy = createPolicy(newRandomPolicy)

--- a/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/AttemptRolloverStepTests.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/AttemptRolloverStepTests.kt
@@ -104,7 +104,7 @@ class AttemptRolloverStepTests : OpenSearchTestCase() {
         val client = getClient(getAdminClient(getIndicesAdminClient(rolloverResponse, aliasResponse, null, null)))
 
         runBlocking {
-            val rolloverAction = RolloverAction(null, null, null, null, true, false, 0)
+            val rolloverAction = RolloverAction(null, null, null, null, null, true, false, 0)
             val managedIndexMetaData =
                 ManagedIndexMetaData(
                     oldIndexName, "indexUuid", "policy_id",
@@ -130,7 +130,7 @@ class AttemptRolloverStepTests : OpenSearchTestCase() {
         val client = getClient(getAdminClient(getIndicesAdminClient(rolloverResponse, null, null, exception)))
 
         runBlocking {
-            val rolloverAction = RolloverAction(null, null, null, null, true, false, 0)
+            val rolloverAction = RolloverAction(null, null, null, null, null, true, false, 0)
             val managedIndexMetaData =
                 ManagedIndexMetaData(
                     oldIndexName, "indexUuid", "policy_id",
@@ -156,7 +156,7 @@ class AttemptRolloverStepTests : OpenSearchTestCase() {
         val client = getClient(getAdminClient(getIndicesAdminClient(rolloverResponse, null, null, exception)))
 
         runBlocking {
-            val rolloverAction = RolloverAction(null, null, null, null, true, false, 0)
+            val rolloverAction = RolloverAction(null, null, null, null, null, true, false, 0)
             val managedIndexMetaData =
                 ManagedIndexMetaData(
                     oldIndexName, "indexUuid", "policy_id",
@@ -182,7 +182,7 @@ class AttemptRolloverStepTests : OpenSearchTestCase() {
         val client = getClient(getAdminClient(getIndicesAdminClient(rolloverResponse, aliasResponse, null, null)))
 
         runBlocking {
-            val rolloverAction = RolloverAction(null, null, null, null, true, false, 0)
+            val rolloverAction = RolloverAction(null, null, null, null, null, true, false, 0)
             val managedIndexMetaData =
                 ManagedIndexMetaData(
                     oldIndexName, "indexUuid", "policy_id",
@@ -211,7 +211,7 @@ class AttemptRolloverStepTests : OpenSearchTestCase() {
         whenever(indexMetadata.aliases).thenReturn(mapOf(alias to AliasMetadata.builder(alias).build()))
 
         runBlocking {
-            val rolloverAction = RolloverAction(null, null, null, null, true, false, 0)
+            val rolloverAction = RolloverAction(null, null, null, null, null, true, false, 0)
             val managedIndexMetaData =
                 ManagedIndexMetaData(
                     oldIndexName, "indexUuid", "policy_id",

--- a/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/util/ManagedIndexUtilsTests.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/util/ManagedIndexUtilsTests.kt
@@ -247,6 +247,7 @@ class ManagedIndexUtilsTests : OpenSearchTestCase() {
                     TransitionConditionContext(
                         indexCreationDate = Instant.now(),
                         numDocs = null,
+                        primaryShardNumDocs = null,
                         indexSize = null,
                         transitionStartTime = Instant.now(),
                         rolloverDate = null,
@@ -266,6 +267,7 @@ class ManagedIndexUtilsTests : OpenSearchTestCase() {
                     TransitionConditionContext(
                         indexCreationDate = Instant.now(),
                         numDocs = null,
+                        primaryShardNumDocs = null,
                         indexSize = null,
                         transitionStartTime = Instant.now(),
                         rolloverDate = null,
@@ -279,6 +281,7 @@ class ManagedIndexUtilsTests : OpenSearchTestCase() {
                     TransitionConditionContext(
                         indexCreationDate = Instant.now().minusSeconds(10),
                         numDocs = null,
+                        primaryShardNumDocs = null,
                         indexSize = null,
                         transitionStartTime = Instant.now(),
                         rolloverDate = null,
@@ -292,6 +295,7 @@ class ManagedIndexUtilsTests : OpenSearchTestCase() {
                     TransitionConditionContext(
                         indexCreationDate = Instant.ofEpochMilli(-1L),
                         numDocs = null,
+                        primaryShardNumDocs = null,
                         indexSize = null,
                         transitionStartTime = Instant.now(),
                         rolloverDate = null,
@@ -311,6 +315,7 @@ class ManagedIndexUtilsTests : OpenSearchTestCase() {
                     TransitionConditionContext(
                         indexCreationDate = Instant.now(),
                         numDocs = null,
+                        primaryShardNumDocs = null,
                         indexSize = null,
                         transitionStartTime = Instant.now(),
                         rolloverDate = Instant.now(),
@@ -324,6 +329,7 @@ class ManagedIndexUtilsTests : OpenSearchTestCase() {
                     TransitionConditionContext(
                         indexCreationDate = Instant.now().minusSeconds(10),
                         numDocs = null,
+                        primaryShardNumDocs = null,
                         indexSize = null,
                         transitionStartTime = Instant.now(),
                         rolloverDate = Instant.now().minusSeconds(10),
@@ -337,6 +343,7 @@ class ManagedIndexUtilsTests : OpenSearchTestCase() {
                     TransitionConditionContext(
                         indexCreationDate = Instant.ofEpochMilli(-1L),
                         numDocs = null,
+                        primaryShardNumDocs = null,
                         indexSize = null,
                         transitionStartTime = Instant.now(),
                         rolloverDate = null,
@@ -355,6 +362,7 @@ class ManagedIndexUtilsTests : OpenSearchTestCase() {
                 TransitionConditionContext(
                     indexCreationDate = Instant.now(),
                     numDocs = null,
+                    primaryShardNumDocs = null,
                     indexSize = null,
                     transitionStartTime = Instant.now(),
                     rolloverDate = null,
@@ -369,6 +377,7 @@ class ManagedIndexUtilsTests : OpenSearchTestCase() {
                 TransitionConditionContext(
                     indexCreationDate = Instant.now(),
                     numDocs = null,
+                    primaryShardNumDocs = null,
                     indexSize = null,
                     transitionStartTime = Instant.now(),
                     rolloverDate = null,
@@ -389,6 +398,7 @@ class ManagedIndexUtilsTests : OpenSearchTestCase() {
                 TransitionConditionContext(
                     indexCreationDate = Instant.now(),
                     numDocs = null,
+                    primaryShardNumDocs = null,
                     indexSize = null,
                     transitionStartTime = Instant.now(),
                     rolloverDate = null,
@@ -403,6 +413,7 @@ class ManagedIndexUtilsTests : OpenSearchTestCase() {
                 TransitionConditionContext(
                     indexCreationDate = Instant.now(),
                     numDocs = null,
+                    primaryShardNumDocs = null,
                     indexSize = null,
                     transitionStartTime = Instant.now(),
                     rolloverDate = null,
@@ -424,6 +435,7 @@ class ManagedIndexUtilsTests : OpenSearchTestCase() {
                 TransitionConditionContext(
                     indexCreationDate = Instant.now(),
                     numDocs = null,
+                    primaryShardNumDocs = null,
                     indexSize = null,
                     transitionStartTime = Instant.now(),
                     rolloverDate = null,
@@ -440,6 +452,7 @@ class ManagedIndexUtilsTests : OpenSearchTestCase() {
                 TransitionConditionContext(
                     indexCreationDate = Instant.now(),
                     numDocs = null,
+                    primaryShardNumDocs = null,
                     indexSize = null,
                     transitionStartTime = Instant.now(),
                     rolloverDate = null,

--- a/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/util/ManagedIndexUtilsTests.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/util/ManagedIndexUtilsTests.kt
@@ -368,6 +368,40 @@ class ManagedIndexUtilsTests : OpenSearchTestCase() {
                 ),
         )
 
+        val primaryShardDocCountTransition =
+            Transition(
+                stateName = "some_state",
+                conditions = Conditions(primaryShardDocCount = 10),
+            )
+        assertFalse(
+            "Not enough documents in primary shard should not pass",
+            primaryShardDocCountTransition
+                .evaluateConditions(
+                    TransitionConditionContext(
+                        indexCreationDate = Instant.now(),
+                        numDocs = null,
+                        primaryShardNumDocs = 5,
+                        indexSize = null,
+                        transitionStartTime = Instant.now(),
+                        rolloverDate = null,
+                    ),
+                ),
+        )
+        assertTrue(
+            "Enough documents in primary shard should not pass",
+            primaryShardDocCountTransition
+                .evaluateConditions(
+                    TransitionConditionContext(
+                        indexCreationDate = Instant.now(),
+                        numDocs = null,
+                        primaryShardNumDocs = 10,
+                        indexSize = null,
+                        transitionStartTime = Instant.now(),
+                        rolloverDate = null,
+                    ),
+                ),
+        )
+
         // Test noAlias = true: should only transition if there are no aliases
         val noAliasTransition = Transition(
             stateName = "next_state",

--- a/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/util/ManagedIndexUtilsTests.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/util/ManagedIndexUtilsTests.kt
@@ -388,7 +388,7 @@ class ManagedIndexUtilsTests : OpenSearchTestCase() {
                 ),
         )
         assertTrue(
-            "Enough documents in primary shard should not pass",
+            "Enough documents in primary shard should pass",
             primaryShardDocCountTransition
                 .evaluateConditions(
                     TransitionConditionContext(

--- a/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/util/ManagedIndexUtilsTests.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/util/ManagedIndexUtilsTests.kt
@@ -129,112 +129,112 @@ class ManagedIndexUtilsTests : OpenSearchTestCase() {
     }
 
     fun `test rollover action config evaluate conditions`() {
-        val noConditionsConfig = RolloverAction(minSize = null, minDocs = null, minAge = null, minPrimaryShardSize = null, preventEmptyRollover = false, index = 0)
+        val noConditionsConfig = RolloverAction(minSize = null, minDocs = null, minPrimaryShardDocs = null, minAge = null, minPrimaryShardSize = null, preventEmptyRollover = false, index = 0)
         assertTrue(
             "No conditions should always pass",
             noConditionsConfig
-                .evaluateConditions(indexAgeTimeValue = TimeValue.timeValueMillis(0), numDocs = 0, indexSize = ByteSizeValue.ZERO, primaryShardSize = ByteSizeValue.ZERO),
+                .evaluateConditions(indexAgeTimeValue = TimeValue.timeValueMillis(0), numDocs = 0, primaryShardNumDocs = 0, indexSize = ByteSizeValue.ZERO, primaryShardSize = ByteSizeValue.ZERO),
         )
         assertTrue(
             "No conditions should always pass",
             noConditionsConfig
-                .evaluateConditions(indexAgeTimeValue = TimeValue.timeValueMillis(100), numDocs = 5, indexSize = ByteSizeValue(5), primaryShardSize = ByteSizeValue(5)),
+                .evaluateConditions(indexAgeTimeValue = TimeValue.timeValueMillis(100), numDocs = 5, primaryShardNumDocs = 5, indexSize = ByteSizeValue(5), primaryShardSize = ByteSizeValue(5)),
         )
         assertTrue(
             "No conditions should always pass",
             noConditionsConfig
-                .evaluateConditions(indexAgeTimeValue = TimeValue.timeValueMillis(6000), numDocs = 5, indexSize = ByteSizeValue(5), primaryShardSize = ByteSizeValue(5)),
+                .evaluateConditions(indexAgeTimeValue = TimeValue.timeValueMillis(6000), numDocs = 5, primaryShardNumDocs = 5, indexSize = ByteSizeValue(5), primaryShardSize = ByteSizeValue(5)),
         )
 
-        val minSizeConfig = RolloverAction(minSize = ByteSizeValue(5), minDocs = null, minAge = null, minPrimaryShardSize = null, preventEmptyRollover = false, index = 0)
+        val minSizeConfig = RolloverAction(minSize = ByteSizeValue(5), minDocs = null, minPrimaryShardDocs = null, minAge = null, minPrimaryShardSize = null, preventEmptyRollover = false, index = 0)
         assertFalse(
             "Less bytes should not pass",
             minSizeConfig
-                .evaluateConditions(indexAgeTimeValue = TimeValue.timeValueMillis(1000), numDocs = 0, indexSize = ByteSizeValue.ZERO, primaryShardSize = ByteSizeValue.ZERO),
+                .evaluateConditions(indexAgeTimeValue = TimeValue.timeValueMillis(1000), numDocs = 0, primaryShardNumDocs = 0, indexSize = ByteSizeValue.ZERO, primaryShardSize = ByteSizeValue.ZERO),
         )
         assertTrue(
             "Equal bytes should pass",
             minSizeConfig
-                .evaluateConditions(indexAgeTimeValue = TimeValue.timeValueMillis(1000), numDocs = 0, indexSize = ByteSizeValue(5), primaryShardSize = ByteSizeValue(5)),
+                .evaluateConditions(indexAgeTimeValue = TimeValue.timeValueMillis(1000), numDocs = 0, primaryShardNumDocs = 0, indexSize = ByteSizeValue(5), primaryShardSize = ByteSizeValue(5)),
         )
         assertTrue(
             "More bytes should pass",
             minSizeConfig
-                .evaluateConditions(indexAgeTimeValue = TimeValue.timeValueMillis(1000), numDocs = 0, indexSize = ByteSizeValue(10), primaryShardSize = ByteSizeValue(10)),
+                .evaluateConditions(indexAgeTimeValue = TimeValue.timeValueMillis(1000), numDocs = 0, primaryShardNumDocs = 0, indexSize = ByteSizeValue(10), primaryShardSize = ByteSizeValue(10)),
         )
 
-        val minPrimarySizeConfig = RolloverAction(minSize = null, minDocs = null, minAge = null, minPrimaryShardSize = ByteSizeValue(5), preventEmptyRollover = false, index = 0)
+        val minPrimarySizeConfig = RolloverAction(minSize = null, minDocs = null, minPrimaryShardDocs = null, minAge = null, minPrimaryShardSize = ByteSizeValue(5), preventEmptyRollover = false, index = 0)
         assertFalse(
             "Less primary bytes should not pass",
             minPrimarySizeConfig
-                .evaluateConditions(indexAgeTimeValue = TimeValue.timeValueMillis(1000), numDocs = 0, indexSize = ByteSizeValue.ZERO, primaryShardSize = ByteSizeValue.ZERO),
+                .evaluateConditions(indexAgeTimeValue = TimeValue.timeValueMillis(1000), numDocs = 0, primaryShardNumDocs = 0, indexSize = ByteSizeValue.ZERO, primaryShardSize = ByteSizeValue.ZERO),
         )
         assertTrue(
             "Equal primary bytes should pass",
             minPrimarySizeConfig
-                .evaluateConditions(indexAgeTimeValue = TimeValue.timeValueMillis(1000), numDocs = 0, indexSize = ByteSizeValue(5), primaryShardSize = ByteSizeValue(5)),
+                .evaluateConditions(indexAgeTimeValue = TimeValue.timeValueMillis(1000), numDocs = 0, primaryShardNumDocs = 0, indexSize = ByteSizeValue(5), primaryShardSize = ByteSizeValue(5)),
         )
         assertTrue(
             "More primary bytes should pass",
             minPrimarySizeConfig
-                .evaluateConditions(indexAgeTimeValue = TimeValue.timeValueMillis(1000), numDocs = 0, indexSize = ByteSizeValue(10), primaryShardSize = ByteSizeValue(10)),
+                .evaluateConditions(indexAgeTimeValue = TimeValue.timeValueMillis(1000), numDocs = 0, primaryShardNumDocs = 0, indexSize = ByteSizeValue(10), primaryShardSize = ByteSizeValue(10)),
         )
 
-        val minDocsConfig = RolloverAction(minSize = null, minDocs = 5, minAge = null, minPrimaryShardSize = null, preventEmptyRollover = false, index = 0)
+        val minDocsConfig = RolloverAction(minSize = null, minDocs = 5, minPrimaryShardDocs = null, minAge = null, minPrimaryShardSize = null, preventEmptyRollover = false, index = 0)
         assertFalse(
             "Less docs should not pass",
             minDocsConfig
-                .evaluateConditions(indexAgeTimeValue = TimeValue.timeValueMillis(1000), numDocs = 0, indexSize = ByteSizeValue.ZERO, primaryShardSize = ByteSizeValue.ZERO),
+                .evaluateConditions(indexAgeTimeValue = TimeValue.timeValueMillis(1000), numDocs = 0, primaryShardNumDocs = 0, indexSize = ByteSizeValue.ZERO, primaryShardSize = ByteSizeValue.ZERO),
         )
         assertTrue(
             "Equal docs should pass",
             minDocsConfig
-                .evaluateConditions(indexAgeTimeValue = TimeValue.timeValueMillis(1000), numDocs = 5, indexSize = ByteSizeValue.ZERO, primaryShardSize = ByteSizeValue.ZERO),
+                .evaluateConditions(indexAgeTimeValue = TimeValue.timeValueMillis(1000), numDocs = 5, primaryShardNumDocs = 5, indexSize = ByteSizeValue.ZERO, primaryShardSize = ByteSizeValue.ZERO),
         )
         assertTrue(
             "More docs should pass",
             minDocsConfig
-                .evaluateConditions(indexAgeTimeValue = TimeValue.timeValueMillis(1000), numDocs = 10, indexSize = ByteSizeValue.ZERO, primaryShardSize = ByteSizeValue.ZERO),
+                .evaluateConditions(indexAgeTimeValue = TimeValue.timeValueMillis(1000), numDocs = 10, primaryShardNumDocs = 1, indexSize = ByteSizeValue.ZERO, primaryShardSize = ByteSizeValue.ZERO),
         )
 
-        val minAgeConfig = RolloverAction(minSize = null, minDocs = null, minAge = TimeValue.timeValueSeconds(5), minPrimaryShardSize = null, preventEmptyRollover = false, index = 0)
+        val minAgeConfig = RolloverAction(minSize = null, minDocs = null, minPrimaryShardDocs = null, minAge = TimeValue.timeValueSeconds(5), minPrimaryShardSize = null, preventEmptyRollover = false, index = 0)
         assertFalse(
             "Index age that is too young should not pass",
             minAgeConfig
-                .evaluateConditions(indexAgeTimeValue = TimeValue.timeValueMillis(1000), numDocs = 0, indexSize = ByteSizeValue.ZERO, primaryShardSize = ByteSizeValue.ZERO),
+                .evaluateConditions(indexAgeTimeValue = TimeValue.timeValueMillis(1000), numDocs = 0, primaryShardNumDocs = 0, indexSize = ByteSizeValue.ZERO, primaryShardSize = ByteSizeValue.ZERO),
         )
         assertTrue(
             "Index age that is older should pass",
             minAgeConfig
-                .evaluateConditions(indexAgeTimeValue = TimeValue.timeValueMillis(10000), numDocs = 0, indexSize = ByteSizeValue.ZERO, primaryShardSize = ByteSizeValue.ZERO),
+                .evaluateConditions(indexAgeTimeValue = TimeValue.timeValueMillis(10000), numDocs = 0, primaryShardNumDocs = 0, indexSize = ByteSizeValue.ZERO, primaryShardSize = ByteSizeValue.ZERO),
         )
 
-        val multiConfig = RolloverAction(minSize = ByteSizeValue(1), minDocs = 1, minAge = TimeValue.timeValueSeconds(5), minPrimaryShardSize = ByteSizeValue(1), preventEmptyRollover = false, index = 0)
+        val multiConfig = RolloverAction(minSize = ByteSizeValue(1), minDocs = 1, minPrimaryShardDocs = 1000, minAge = TimeValue.timeValueSeconds(5), minPrimaryShardSize = ByteSizeValue(1), preventEmptyRollover = false, index = 0)
         assertFalse(
             "No conditions met should not pass",
             multiConfig
-                .evaluateConditions(indexAgeTimeValue = TimeValue.timeValueMillis(0), numDocs = 0, indexSize = ByteSizeValue.ZERO, primaryShardSize = ByteSizeValue.ZERO),
+                .evaluateConditions(indexAgeTimeValue = TimeValue.timeValueMillis(0), numDocs = 0, primaryShardNumDocs = 0, indexSize = ByteSizeValue.ZERO, primaryShardSize = ByteSizeValue.ZERO),
         )
         assertTrue(
             "Multi condition, age should pass",
             multiConfig
-                .evaluateConditions(indexAgeTimeValue = TimeValue.timeValueMillis(10000), numDocs = 0, indexSize = ByteSizeValue.ZERO, primaryShardSize = ByteSizeValue.ZERO),
+                .evaluateConditions(indexAgeTimeValue = TimeValue.timeValueMillis(10000), numDocs = 0, primaryShardNumDocs = 0, indexSize = ByteSizeValue.ZERO, primaryShardSize = ByteSizeValue.ZERO),
         )
         assertTrue(
             "Multi condition, docs should pass",
             multiConfig
-                .evaluateConditions(indexAgeTimeValue = TimeValue.timeValueMillis(0), numDocs = 2, indexSize = ByteSizeValue.ZERO, primaryShardSize = ByteSizeValue.ZERO),
+                .evaluateConditions(indexAgeTimeValue = TimeValue.timeValueMillis(0), numDocs = 2, primaryShardNumDocs = 0, indexSize = ByteSizeValue.ZERO, primaryShardSize = ByteSizeValue.ZERO),
         )
         assertTrue(
             "Multi condition, size should pass",
             multiConfig
-                .evaluateConditions(indexAgeTimeValue = TimeValue.timeValueMillis(0), numDocs = 0, indexSize = ByteSizeValue(2), primaryShardSize = ByteSizeValue.ZERO),
+                .evaluateConditions(indexAgeTimeValue = TimeValue.timeValueMillis(0), numDocs = 0, primaryShardNumDocs = 0, indexSize = ByteSizeValue(2), primaryShardSize = ByteSizeValue.ZERO),
         )
 
         assertTrue(
             "Multi condition, primary size should pass",
             multiConfig
-                .evaluateConditions(indexAgeTimeValue = TimeValue.timeValueMillis(0), numDocs = 0, indexSize = ByteSizeValue.ZERO, primaryShardSize = ByteSizeValue(2)),
+                .evaluateConditions(indexAgeTimeValue = TimeValue.timeValueMillis(0), numDocs = 0, primaryShardNumDocs = 0, indexSize = ByteSizeValue.ZERO, primaryShardSize = ByteSizeValue(2)),
         )
     }
 

--- a/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/util/ManagedIndexUtilsTests.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/util/ManagedIndexUtilsTests.kt
@@ -194,7 +194,24 @@ class ManagedIndexUtilsTests : OpenSearchTestCase() {
         assertTrue(
             "More docs should pass",
             minDocsConfig
-                .evaluateConditions(indexAgeTimeValue = TimeValue.timeValueMillis(1000), numDocs = 10, primaryShardNumDocs = 1, indexSize = ByteSizeValue.ZERO, primaryShardSize = ByteSizeValue.ZERO),
+                .evaluateConditions(indexAgeTimeValue = TimeValue.timeValueMillis(1000), numDocs = 10, primaryShardNumDocs = 10, indexSize = ByteSizeValue.ZERO, primaryShardSize = ByteSizeValue.ZERO),
+        )
+
+        val minPrimaryDocsConfig = RolloverAction(minSize = null, minDocs = null, minPrimaryShardDocs = 5, minAge = null, minPrimaryShardSize = null, preventEmptyRollover = false, index = 0)
+        assertFalse(
+            "Less docs should not pass",
+            minPrimaryDocsConfig
+                .evaluateConditions(indexAgeTimeValue = TimeValue.timeValueMillis(1000), numDocs = 3, primaryShardNumDocs = 1, indexSize = ByteSizeValue.ZERO, primaryShardSize = ByteSizeValue.ZERO),
+        )
+        assertTrue(
+            "Equal docs should pass",
+            minPrimaryDocsConfig
+                .evaluateConditions(indexAgeTimeValue = TimeValue.timeValueMillis(1000), numDocs = 15, primaryShardNumDocs = 5, indexSize = ByteSizeValue.ZERO, primaryShardSize = ByteSizeValue.ZERO),
+        )
+        assertTrue(
+            "More docs should pass",
+            minPrimaryDocsConfig
+                .evaluateConditions(indexAgeTimeValue = TimeValue.timeValueMillis(1000), numDocs = 30, primaryShardNumDocs = 10, indexSize = ByteSizeValue.ZERO, primaryShardSize = ByteSizeValue.ZERO),
         )
 
         val minAgeConfig = RolloverAction(minSize = null, minDocs = null, minPrimaryShardDocs = null, minAge = TimeValue.timeValueSeconds(5), minPrimaryShardSize = null, preventEmptyRollover = false, index = 0)

--- a/src/test/resources/mappings/cached-opendistro-ism-config.json
+++ b/src/test/resources/mappings/cached-opendistro-ism-config.json
@@ -243,6 +243,9 @@
                     "min_doc_count": {
                       "type": "keyword"
                     },
+                    "min_primary_shard_doc_count": {
+                      "type": "keyword"
+                    },
                     "min_primary_shard_size": {
                       "type": "keyword"
                     },


### PR DESCRIPTION
### Context
Having no response on https://github.com/opensearch-project/index-management/issues/1528 I took the initiative to submit this PR.


### Description
This PR adds a new `min_primary_shard_doc_count` condition to rollover and transitions.


### Related Issues
Resolves [#[1528]](https://github.com/opensearch-project/index-management/issues/1528)
https://github.com/opensearch-project/index-management/issues/1124

<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/index-management/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
