### PR TITLE
[Feature] Adding simulate API for ISM

### DIFF
--- a/src/main/kotlin/org/opensearch/indexmanagement/IndexManagementPlugin.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/IndexManagementPlugin.kt
@@ -60,6 +60,7 @@ import org.opensearch.indexmanagement.indexstatemanagement.resthandler.RestGetPo
 import org.opensearch.indexmanagement.indexstatemanagement.resthandler.RestIndexPolicyAction
 import org.opensearch.indexmanagement.indexstatemanagement.resthandler.RestRemovePolicyAction
 import org.opensearch.indexmanagement.indexstatemanagement.resthandler.RestRetryFailedManagedIndexAction
+import org.opensearch.indexmanagement.indexstatemanagement.resthandler.RestSimulatePolicyAction
 import org.opensearch.indexmanagement.indexstatemanagement.settings.LegacyOpenDistroManagedIndexSettings
 import org.opensearch.indexmanagement.indexstatemanagement.settings.ManagedIndexSettings
 import org.opensearch.indexmanagement.indexstatemanagement.transport.action.addpolicy.AddPolicyAction
@@ -82,6 +83,8 @@ import org.opensearch.indexmanagement.indexstatemanagement.transport.action.remo
 import org.opensearch.indexmanagement.indexstatemanagement.transport.action.removepolicy.TransportRemovePolicyAction
 import org.opensearch.indexmanagement.indexstatemanagement.transport.action.retryfailedmanagedindex.RetryFailedManagedIndexAction
 import org.opensearch.indexmanagement.indexstatemanagement.transport.action.retryfailedmanagedindex.TransportRetryFailedManagedIndexAction
+import org.opensearch.indexmanagement.indexstatemanagement.transport.action.simulate.SimulatePolicyAction
+import org.opensearch.indexmanagement.indexstatemanagement.transport.action.simulate.TransportSimulatePolicyAction
 import org.opensearch.indexmanagement.indexstatemanagement.util.DEFAULT_INDEX_TYPE
 import org.opensearch.indexmanagement.indexstatemanagement.validation.ActionValidation
 import org.opensearch.indexmanagement.refreshanalyzer.RefreshSearchAnalyzerAction
@@ -351,6 +354,7 @@ class IndexManagementPlugin :
         RestDeletePolicyAction(),
         RestExplainAction(),
         RestRetryFailedManagedIndexAction(),
+        RestSimulatePolicyAction(),
         RestAddPolicyAction(),
         RestRemovePolicyAction(),
         RestChangePolicyAction(),
@@ -591,6 +595,7 @@ class IndexManagementPlugin :
         ActionPlugin.ActionHandler(ChangePolicyAction.INSTANCE, TransportChangePolicyAction::class.java),
         ActionPlugin.ActionHandler(IndexPolicyAction.INSTANCE, TransportIndexPolicyAction::class.java),
         ActionPlugin.ActionHandler(ExplainAction.INSTANCE, TransportExplainAction::class.java),
+        ActionPlugin.ActionHandler(SimulatePolicyAction.INSTANCE, TransportSimulatePolicyAction::class.java),
         ActionPlugin.ActionHandler(DeletePolicyAction.INSTANCE, TransportDeletePolicyAction::class.java),
         ActionPlugin.ActionHandler(GetPolicyAction.INSTANCE, TransportGetPolicyAction::class.java),
         ActionPlugin.ActionHandler(GetPoliciesAction.INSTANCE, TransportGetPoliciesAction::class.java),

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/resthandler/RestSimulatePolicyAction.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/resthandler/RestSimulatePolicyAction.kt
@@ -1,0 +1,100 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.indexmanagement.indexstatemanagement.resthandler
+
+import org.opensearch.core.common.Strings
+import org.opensearch.core.xcontent.XContentParser.Token
+import org.opensearch.core.xcontent.XContentParserUtils.ensureExpectedToken
+import org.opensearch.indexmanagement.IndexManagementPlugin.Companion.ISM_BASE_URI
+import org.opensearch.indexmanagement.IndexManagementPlugin.Companion.LEGACY_ISM_BASE_URI
+import org.opensearch.indexmanagement.indexstatemanagement.model.Policy
+import org.opensearch.indexmanagement.indexstatemanagement.transport.action.simulate.SimulatePolicyAction
+import org.opensearch.indexmanagement.indexstatemanagement.transport.action.simulate.SimulatePolicyRequest
+import org.opensearch.rest.BaseRestHandler
+import org.opensearch.rest.BaseRestHandler.RestChannelConsumer
+import org.opensearch.rest.RestHandler.ReplacedRoute
+import org.opensearch.rest.RestHandler.Route
+import org.opensearch.rest.RestRequest
+import org.opensearch.rest.RestRequest.Method.POST
+import org.opensearch.rest.action.RestToXContentListener
+import org.opensearch.transport.client.node.NodeClient
+
+/**
+ * REST handler for the ISM policy simulate endpoint.
+ *
+ * POST /_plugins/_ism/simulate
+ *
+ * Request body:
+ * {
+ *   "policy_id": "my-policy",    // use an existing policy by ID  — OR —
+ *   "policy": { ... },           // supply an inline policy definition
+ *   "indices": ["index1", "index2"]
+ * }
+ *
+ * Exactly one of `policy_id` or `policy` must be provided.
+ */
+class RestSimulatePolicyAction : BaseRestHandler() {
+    companion object {
+        const val SIMULATE_BASE_URI = "$ISM_BASE_URI/simulate"
+        const val LEGACY_SIMULATE_BASE_URI = "$LEGACY_ISM_BASE_URI/simulate"
+
+        const val POLICY_ID_FIELD = "policy_id"
+        const val POLICY_FIELD = "policy"
+        const val INDICES_FIELD = "indices"
+    }
+
+    override fun getName(): String = "ism_simulate_policy_action"
+
+    override fun routes(): List<Route> = emptyList()
+
+    override fun replacedRoutes(): List<ReplacedRoute> = listOf(
+        ReplacedRoute(
+            POST, SIMULATE_BASE_URI,
+            POST, LEGACY_SIMULATE_BASE_URI,
+        ),
+    )
+
+    override fun prepareRequest(request: RestRequest, client: NodeClient): RestChannelConsumer {
+        val xcp = request.contentParser()
+        ensureExpectedToken(Token.START_OBJECT, xcp.nextToken(), xcp)
+
+        var policyId: String? = null
+        var policy: Policy? = null
+        val indices = mutableListOf<String>()
+
+        while (xcp.nextToken() != Token.END_OBJECT) {
+            val fieldName = xcp.currentName()
+            xcp.nextToken()
+            when (fieldName) {
+                POLICY_ID_FIELD -> policyId = xcp.text()
+
+                POLICY_FIELD -> {
+                    ensureExpectedToken(Token.START_OBJECT, xcp.currentToken(), xcp)
+                    policy = Policy.parse(xcp)
+                }
+
+                INDICES_FIELD -> {
+                    ensureExpectedToken(Token.START_ARRAY, xcp.currentToken(), xcp)
+                    while (xcp.nextToken() != Token.END_ARRAY) {
+                        indices.add(xcp.text())
+                    }
+                }
+
+                else -> xcp.skipChildren()
+            }
+        }
+
+        val simulateRequest = SimulatePolicyRequest(
+            indices = indices,
+            policyId = policyId,
+            policy = policy,
+        )
+
+        return RestChannelConsumer { channel ->
+            client.execute(SimulatePolicyAction.INSTANCE, simulateRequest, RestToXContentListener(channel))
+        }
+    }
+}

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/resthandler/RestSimulatePolicyAction.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/resthandler/RestSimulatePolicyAction.kt
@@ -5,7 +5,6 @@
 
 package org.opensearch.indexmanagement.indexstatemanagement.resthandler
 
-import org.opensearch.core.common.Strings
 import org.opensearch.core.xcontent.XContentParser.Token
 import org.opensearch.core.xcontent.XContentParserUtils.ensureExpectedToken
 import org.opensearch.indexmanagement.IndexManagementPlugin.Companion.ISM_BASE_URI

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/transport/action/simulate/SimulatePolicyAction.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/transport/action/simulate/SimulatePolicyAction.kt
@@ -1,0 +1,15 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.indexmanagement.indexstatemanagement.transport.action.simulate
+
+import org.opensearch.action.ActionType
+
+class SimulatePolicyAction private constructor() : ActionType<SimulatePolicyResponse>(NAME, ::SimulatePolicyResponse) {
+    companion object {
+        val INSTANCE = SimulatePolicyAction()
+        const val NAME = "cluster:admin/opendistro/ism/policy/simulate"
+    }
+}

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/transport/action/simulate/SimulatePolicyRequest.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/transport/action/simulate/SimulatePolicyRequest.kt
@@ -1,0 +1,60 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.indexmanagement.indexstatemanagement.transport.action.simulate
+
+import org.opensearch.action.ActionRequest
+import org.opensearch.action.ActionRequestValidationException
+import org.opensearch.action.ValidateActions
+import org.opensearch.core.common.io.stream.StreamInput
+import org.opensearch.core.common.io.stream.StreamOutput
+import org.opensearch.indexmanagement.indexstatemanagement.model.Policy
+import java.io.IOException
+
+class SimulatePolicyRequest : ActionRequest {
+    val indices: List<String>
+
+    // Exactly one of policyId or policy must be provided
+    val policyId: String?
+    val policy: Policy?
+
+    constructor(
+        indices: List<String>,
+        policyId: String?,
+        policy: Policy?,
+    ) : super() {
+        this.indices = indices
+        this.policyId = policyId
+        this.policy = policy
+    }
+
+    @Throws(IOException::class)
+    constructor(sin: StreamInput) : this(
+        indices = sin.readStringList(),
+        policyId = sin.readOptionalString(),
+        policy = sin.readOptionalWriteable(::Policy),
+    )
+
+    override fun validate(): ActionRequestValidationException? {
+        var exception: ActionRequestValidationException? = null
+        if (indices.isEmpty()) {
+            exception = ValidateActions.addValidationError("indices cannot be empty", exception)
+        }
+        if (policyId == null && policy == null) {
+            exception = ValidateActions.addValidationError("either policy_id or policy must be provided", exception)
+        }
+        if (policyId != null && policy != null) {
+            exception = ValidateActions.addValidationError("only one of policy_id or policy can be provided, not both", exception)
+        }
+        return exception
+    }
+
+    @Throws(IOException::class)
+    override fun writeTo(out: StreamOutput) {
+        out.writeStringCollection(indices)
+        out.writeOptionalString(policyId)
+        out.writeOptionalWriteable(policy)
+    }
+}

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/transport/action/simulate/SimulatePolicyResponse.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/transport/action/simulate/SimulatePolicyResponse.kt
@@ -1,0 +1,191 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.indexmanagement.indexstatemanagement.transport.action.simulate
+
+import org.opensearch.core.action.ActionResponse
+import org.opensearch.core.common.io.stream.StreamInput
+import org.opensearch.core.common.io.stream.StreamOutput
+import org.opensearch.core.common.io.stream.Writeable
+import org.opensearch.core.xcontent.ToXContent
+import org.opensearch.core.xcontent.ToXContentObject
+import org.opensearch.core.xcontent.XContentBuilder
+import java.io.IOException
+
+class SimulatePolicyResponse :
+    ActionResponse,
+    ToXContentObject {
+    val simulateResults: List<IndexSimulateResult>
+
+    constructor(simulateResults: List<IndexSimulateResult>) : super() {
+        this.simulateResults = simulateResults
+    }
+
+    @Throws(IOException::class)
+    constructor(sin: StreamInput) : this(
+        simulateResults = sin.readList(::IndexSimulateResult),
+    )
+
+    @Throws(IOException::class)
+    override fun writeTo(out: StreamOutput) {
+        out.writeList(simulateResults)
+    }
+
+    override fun toXContent(builder: XContentBuilder, params: ToXContent.Params): XContentBuilder {
+        builder.startObject()
+        builder.startArray(SIMULATE_RESULTS_FIELD)
+        simulateResults.forEach { it.toXContent(builder, params) }
+        builder.endArray()
+        return builder.endObject()
+    }
+
+    companion object {
+        const val SIMULATE_RESULTS_FIELD = "simulate_results"
+    }
+}
+
+/**
+ * Holds the simulation result for a single index.
+ *
+ * @param indexName         the index being simulated
+ * @param indexUUID         the UUID of the index (null when the index was not found)
+ * @param policyId          the policy used for the simulation
+ * @param isManaged         whether the index is currently managed by this policy
+ * @param currentState      the state the index is currently in (or would start in)
+ * @param currentAction     the action that would execute next in the current state
+ * @param transitionEvaluation per-transition condition evaluations for the current state
+ * @param nextState         the state the index would transition to (first condition met), null if none
+ * @param error             index-level error message (e.g. index not found), null on success
+ */
+data class IndexSimulateResult(
+    val indexName: String,
+    val indexUUID: String?,
+    val policyId: String,
+    val isManaged: Boolean,
+    val currentState: String?,
+    val currentAction: String?,
+    val transitionEvaluation: List<TransitionSimulateResult>?,
+    val nextState: String?,
+    val error: String?,
+) : ToXContentObject,
+    Writeable {
+    @Throws(IOException::class)
+    constructor(sin: StreamInput) : this(
+        indexName = sin.readString(),
+        indexUUID = sin.readOptionalString(),
+        policyId = sin.readString(),
+        isManaged = sin.readBoolean(),
+        currentState = sin.readOptionalString(),
+        currentAction = sin.readOptionalString(),
+        transitionEvaluation = sin.readOptionalList(::TransitionSimulateResult),
+        nextState = sin.readOptionalString(),
+        error = sin.readOptionalString(),
+    )
+
+    @Throws(IOException::class)
+    override fun writeTo(out: StreamOutput) {
+        out.writeString(indexName)
+        out.writeOptionalString(indexUUID)
+        out.writeString(policyId)
+        out.writeBoolean(isManaged)
+        out.writeOptionalString(currentState)
+        out.writeOptionalString(currentAction)
+        if (transitionEvaluation != null) {
+            out.writeBoolean(true)
+            out.writeList(transitionEvaluation)
+        } else {
+            out.writeBoolean(false)
+        }
+        out.writeOptionalString(nextState)
+        out.writeOptionalString(error)
+    }
+
+    override fun toXContent(builder: XContentBuilder, params: ToXContent.Params): XContentBuilder {
+        builder.startObject()
+        builder.field(INDEX_NAME_FIELD, indexName)
+        builder.field(POLICY_ID_FIELD, policyId)
+        builder.field(IS_MANAGED_FIELD, isManaged)
+        if (error != null) {
+            builder.field(ERROR_FIELD, error)
+        } else {
+            builder.field(CURRENT_STATE_FIELD, currentState)
+            builder.field(CURRENT_ACTION_FIELD, currentAction)
+            if (transitionEvaluation != null) {
+                builder.startArray(TRANSITION_EVALUATION_FIELD)
+                transitionEvaluation.forEach { it.toXContent(builder, params) }
+                builder.endArray()
+            }
+            builder.field(NEXT_STATE_FIELD, nextState)
+        }
+        return builder.endObject()
+    }
+
+    companion object {
+        const val INDEX_NAME_FIELD = "index_name"
+        const val POLICY_ID_FIELD = "policy_id"
+        const val IS_MANAGED_FIELD = "is_managed"
+        const val CURRENT_STATE_FIELD = "current_state"
+        const val CURRENT_ACTION_FIELD = "current_action"
+        const val TRANSITION_EVALUATION_FIELD = "transition_evaluation"
+        const val NEXT_STATE_FIELD = "next_state"
+        const val ERROR_FIELD = "error"
+    }
+}
+
+/**
+ * Holds the condition evaluation result for a single transition within a state.
+ *
+ * @param stateName     the target state this transition would move to
+ * @param conditionMet  whether the transition condition is currently satisfied
+ * @param conditionType the kind of condition being evaluated (e.g. "min_index_age"), or "unconditional"
+ * @param currentValue  human-readable current value of the metric being checked
+ * @param requiredValue human-readable threshold required by the condition
+ */
+data class TransitionSimulateResult(
+    val stateName: String,
+    val conditionMet: Boolean,
+    val conditionType: String,
+    val currentValue: String?,
+    val requiredValue: String?,
+) : ToXContentObject,
+    Writeable {
+    @Throws(IOException::class)
+    constructor(sin: StreamInput) : this(
+        stateName = sin.readString(),
+        conditionMet = sin.readBoolean(),
+        conditionType = sin.readString(),
+        currentValue = sin.readOptionalString(),
+        requiredValue = sin.readOptionalString(),
+    )
+
+    @Throws(IOException::class)
+    override fun writeTo(out: StreamOutput) {
+        out.writeString(stateName)
+        out.writeBoolean(conditionMet)
+        out.writeString(conditionType)
+        out.writeOptionalString(currentValue)
+        out.writeOptionalString(requiredValue)
+    }
+
+    override fun toXContent(builder: XContentBuilder, params: ToXContent.Params): XContentBuilder =
+        builder.startObject()
+            .field(STATE_NAME_FIELD, stateName)
+            .field(CONDITION_MET_FIELD, conditionMet)
+            .field(CONDITION_TYPE_FIELD, conditionType)
+            .also { if (currentValue != null) it.field(CURRENT_VALUE_FIELD, currentValue) }
+            .also { if (requiredValue != null) it.field(REQUIRED_VALUE_FIELD, requiredValue) }
+            .endObject()
+
+    companion object {
+        const val STATE_NAME_FIELD = "state_name"
+        const val CONDITION_MET_FIELD = "condition_met"
+        const val CONDITION_TYPE_FIELD = "condition_type"
+        const val CURRENT_VALUE_FIELD = "current_value"
+        const val REQUIRED_VALUE_FIELD = "required_value"
+    }
+}
+
+// Helper to read an optional list from StreamInput
+private fun <T> StreamInput.readOptionalList(reader: Writeable.Reader<T>): List<T>? = if (readBoolean()) readList(reader) else null

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/transport/action/simulate/SimulatePolicyResponse.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/transport/action/simulate/SimulatePolicyResponse.kt
@@ -105,6 +105,7 @@ data class IndexSimulateResult(
     override fun toXContent(builder: XContentBuilder, params: ToXContent.Params): XContentBuilder {
         builder.startObject()
         builder.field(INDEX_NAME_FIELD, indexName)
+        builder.field(INDEX_UUID_FIELD, indexUUID)
         builder.field(POLICY_ID_FIELD, policyId)
         builder.field(IS_MANAGED_FIELD, isManaged)
         if (error != null) {
@@ -124,6 +125,7 @@ data class IndexSimulateResult(
 
     companion object {
         const val INDEX_NAME_FIELD = "index_name"
+        const val INDEX_UUID_FIELD = "index_uuid"
         const val POLICY_ID_FIELD = "policy_id"
         const val IS_MANAGED_FIELD = "is_managed"
         const val CURRENT_STATE_FIELD = "current_state"

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/transport/action/simulate/TransportSimulatePolicyAction.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/transport/action/simulate/TransportSimulatePolicyAction.kt
@@ -1,0 +1,376 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.indexmanagement.indexstatemanagement.transport.action.simulate
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import org.apache.logging.log4j.LogManager
+import org.opensearch.ExceptionsHelper
+import org.opensearch.OpenSearchStatusException
+import org.opensearch.action.admin.indices.stats.IndicesStatsRequest
+import org.opensearch.action.admin.indices.stats.IndicesStatsResponse
+import org.opensearch.action.get.GetRequest
+import org.opensearch.action.get.GetResponse
+import org.opensearch.action.get.MultiGetRequest
+import org.opensearch.action.get.MultiGetResponse
+import org.opensearch.action.support.ActionFilters
+import org.opensearch.action.support.HandledTransportAction
+import org.opensearch.action.support.IndicesOptions
+import org.opensearch.cluster.metadata.IndexNameExpressionResolver
+import org.opensearch.cluster.service.ClusterService
+import org.opensearch.common.inject.Inject
+import org.opensearch.common.unit.TimeValue
+import org.opensearch.common.xcontent.LoggingDeprecationHandler
+import org.opensearch.common.xcontent.XContentHelper
+import org.opensearch.common.xcontent.XContentType
+import org.opensearch.core.action.ActionListener
+import org.opensearch.core.common.unit.ByteSizeValue
+import org.opensearch.core.rest.RestStatus
+import org.opensearch.core.xcontent.NamedXContentRegistry
+import org.opensearch.indexmanagement.IndexManagementPlugin.Companion.INDEX_MANAGEMENT_INDEX
+import org.opensearch.indexmanagement.indexstatemanagement.IndexMetadataProvider
+import org.opensearch.indexmanagement.indexstatemanagement.action.TransitionsAction
+import org.opensearch.indexmanagement.indexstatemanagement.model.Conditions
+import org.opensearch.indexmanagement.indexstatemanagement.model.Policy
+import org.opensearch.indexmanagement.indexstatemanagement.model.Transition
+import org.opensearch.indexmanagement.indexstatemanagement.opensearchapi.getOldestRolloverTime
+import org.opensearch.indexmanagement.indexstatemanagement.util.TransitionConditionContext
+import org.opensearch.indexmanagement.indexstatemanagement.util.evaluateConditions
+import org.opensearch.indexmanagement.indexstatemanagement.util.hasStatsConditions
+import org.opensearch.indexmanagement.indexstatemanagement.util.managedIndexMetadataID
+import org.opensearch.indexmanagement.opensearchapi.parseFromGetResponse
+import org.opensearch.indexmanagement.opensearchapi.parseWithType
+import org.opensearch.indexmanagement.opensearchapi.suspendUntil
+import org.opensearch.indexmanagement.spi.indexstatemanagement.model.ManagedIndexMetaData
+import org.opensearch.tasks.Task
+import org.opensearch.transport.TransportService
+import org.opensearch.transport.client.Client
+import java.time.Instant
+
+private val log = LogManager.getLogger(TransportSimulatePolicyAction::class.java)
+
+@Suppress("TooManyFunctions")
+class TransportSimulatePolicyAction
+@Inject
+constructor(
+    val client: Client,
+    transportService: TransportService,
+    actionFilters: ActionFilters,
+    val clusterService: ClusterService,
+    val xContentRegistry: NamedXContentRegistry,
+    val indexMetadataProvider: IndexMetadataProvider,
+    val indexNameExpressionResolver: IndexNameExpressionResolver,
+) : HandledTransportAction<SimulatePolicyRequest, SimulatePolicyResponse>(
+    SimulatePolicyAction.NAME, transportService, actionFilters, ::SimulatePolicyRequest,
+) {
+    override fun doExecute(task: Task, request: SimulatePolicyRequest, listener: ActionListener<SimulatePolicyResponse>) {
+        SimulateHandler(client, listener, request).start()
+    }
+
+    inner class SimulateHandler(
+        private val client: Client,
+        private val actionListener: ActionListener<SimulatePolicyResponse>,
+        private val request: SimulatePolicyRequest,
+    ) {
+        fun start() {
+            CoroutineScope(Dispatchers.IO).launch {
+                try {
+                    val policy = resolvePolicy()
+                    val results = mutableListOf<IndexSimulateResult>()
+                    for (indexName in expandIndices(request.indices)) {
+                        results.add(simulateIndex(indexName, policy))
+                    }
+                    actionListener.onResponse(SimulatePolicyResponse(results))
+                } catch (e: Exception) {
+                    actionListener.onFailure(ExceptionsHelper.unwrapCause(e) as Exception)
+                }
+            }
+        }
+
+        /**
+         * Expands wildcard patterns (containing * or ?) to concrete index names using the cluster
+         * state. Patterns that match no indices are silently dropped. Concrete index names (no
+         * wildcards) are kept as-is so that [simulateIndex] can return a proper "not found" error
+         * for indices that don't exist in the cluster.
+         */
+        private fun expandIndices(indices: List<String>): List<String> {
+            val clusterState = clusterService.state()
+            val result = mutableListOf<String>()
+            for (index in indices) {
+                if (index.contains('*') || index.contains('?')) {
+                    result.addAll(
+                        indexNameExpressionResolver.concreteIndexNames(
+                            clusterState, IndicesOptions.lenientExpand(), index,
+                        ),
+                    )
+                } else {
+                    result.add(index)
+                }
+            }
+            return result.distinct()
+        }
+
+        /** Returns the policy to simulate: either the inline policy from the request or one fetched by ID. */
+        private suspend fun resolvePolicy(): Policy {
+            val inlinePolicy = request.policy
+            if (inlinePolicy != null) return inlinePolicy
+
+            val policyId = requireNotNull(request.policyId) { "policyId must not be null when policy is not provided" }
+            val getRequest = GetRequest(INDEX_MANAGEMENT_INDEX, policyId)
+            val getResponse: GetResponse = client.suspendUntil { get(getRequest, it) }
+            if (!getResponse.isExists) {
+                throw OpenSearchStatusException("Policy '$policyId' not found", RestStatus.NOT_FOUND)
+            }
+            return parseFromGetResponse(getResponse, xContentRegistry, Policy.Companion::parse)
+        }
+
+        /** Runs the full simulation for a single index and returns its result. */
+        @Suppress("ReturnCount", "CyclomaticComplexMethod")
+        private suspend fun simulateIndex(indexName: String, policy: Policy): IndexSimulateResult {
+            val clusterState = clusterService.state()
+            val indexMetadata = clusterState.metadata().index(indexName)
+                ?: return IndexSimulateResult(
+                    indexName = indexName, indexUUID = null, policyId = policy.id,
+                    isManaged = false, currentState = null, currentAction = null,
+                    transitionEvaluation = null, nextState = null,
+                    error = "Index '$indexName' not found in cluster",
+                )
+
+            val indexUUID = indexMetadata.indexUUID
+            val creationDate = Instant.ofEpochMilli(indexMetadata.creationDate)
+            val aliasCount = indexMetadata.aliases?.size ?: 0
+            val rolloverDate: Instant? = indexMetadata.getOldestRolloverTime()
+
+            val managedMetadata = fetchManagedIndexMetadata(indexUUID)
+            val isManaged = managedMetadata != null
+
+            val currentStateName = managedMetadata?.stateMetaData?.name ?: policy.defaultState
+            val currentState = policy.states.find { it.name == currentStateName }
+                ?: return IndexSimulateResult(
+                    indexName = indexName, indexUUID = indexUUID, policyId = policy.id,
+                    isManaged = isManaged, currentState = currentStateName, currentAction = null,
+                    transitionEvaluation = null, nextState = null,
+                    error = "State '$currentStateName' referenced in metadata not found in policy",
+                )
+
+            val currentAction: String? = if (managedMetadata != null) {
+                currentState.getActionToExecute(managedMetadata, indexMetadataProvider)?.type
+            } else {
+                currentState.actions.firstOrNull()?.type ?: TransitionsAction.name
+            }
+
+            val inTransitionPhase =
+                currentAction == TransitionsAction.name ||
+                    (managedMetadata != null && currentState.actions.isEmpty())
+
+            if (!inTransitionPhase) {
+                return IndexSimulateResult(
+                    indexName = indexName, indexUUID = indexUUID, policyId = policy.id,
+                    isManaged = isManaged, currentState = currentStateName,
+                    currentAction = currentAction, transitionEvaluation = null,
+                    nextState = null, error = null,
+                )
+            }
+
+            val (numDocs, indexSize) = fetchIndexStats(indexName, currentState.transitions)
+            val transitionContext = buildTransitionContext(
+                creationDate, numDocs, indexSize, managedMetadata, rolloverDate, aliasCount,
+            )
+            val transitionResults = currentState.transitions.map { evaluateTransition(it, transitionContext) }
+            val nextState = transitionResults.firstOrNull { it.conditionMet }?.stateName
+
+            return IndexSimulateResult(
+                indexName = indexName, indexUUID = indexUUID, policyId = policy.id,
+                isManaged = isManaged, currentState = currentStateName,
+                currentAction = TransitionsAction.name, transitionEvaluation = transitionResults,
+                nextState = nextState, error = null,
+            )
+        }
+
+        /** Fetches primary shard doc-count and size stats when any transition requires them. */
+        private suspend fun fetchIndexStats(
+            indexName: String,
+            transitions: List<Transition>,
+        ): Pair<Long?, ByteSizeValue?> {
+            if (transitions.none { it.hasStatsConditions() }) return Pair(null, null)
+            val statsRequest = IndicesStatsRequest().indices(indexName).clear().docs(true)
+            val statsResponse: IndicesStatsResponse = client.admin().indices().suspendUntil { stats(statsRequest, it) }
+            val docs = statsResponse.primaries.getDocs()
+            return Pair(docs?.count ?: 0, ByteSizeValue(docs?.totalSizeInBytes ?: 0))
+        }
+
+        /** Builds a [TransitionConditionContext] from index and managed metadata. */
+        private fun buildTransitionContext(
+            creationDate: Instant,
+            numDocs: Long?,
+            indexSize: ByteSizeValue?,
+            managedMetadata: ManagedIndexMetaData?,
+            rolloverDate: Instant?,
+            aliasCount: Int,
+        ): TransitionConditionContext {
+            val stateStartTime = managedMetadata?.stateMetaData?.startTime?.let { Instant.ofEpochMilli(it) }
+            val stepStartTime = managedMetadata?.stepMetaData?.startTime?.let { Instant.ofEpochMilli(it) } ?: Instant.now()
+            return TransitionConditionContext(
+                indexCreationDate = creationDate, numDocs = numDocs, indexSize = indexSize,
+                transitionStartTime = stepStartTime, rolloverDate = rolloverDate,
+                indexAliasesCount = aliasCount, stateStartTime = stateStartTime,
+            )
+        }
+
+        /**
+         * Fetches the ManagedIndexMetaData for the given index UUID from the ISM config index.
+         * Returns null if the index is not currently managed.
+         */
+        private suspend fun fetchManagedIndexMetadata(indexUUID: String): ManagedIndexMetaData? {
+            val mgetReq = MultiGetRequest()
+            mgetReq.add(MultiGetRequest.Item(INDEX_MANAGEMENT_INDEX, managedIndexMetadataID(indexUUID)).routing(indexUUID))
+            val mgetResponse: MultiGetResponse = client.suspendUntil { multiGet(mgetReq, it) }
+
+            val getResponse = mgetResponse.responses
+                .firstOrNull()
+                ?.response
+                ?.takeIf { it.isExists && it.sourceAsBytesRef != null }
+                ?: return null
+
+            return try {
+                val xcp = XContentHelper.createParser(
+                    xContentRegistry, LoggingDeprecationHandler.INSTANCE,
+                    getResponse.sourceAsBytesRef, XContentType.JSON,
+                )
+                ManagedIndexMetaData.parseWithType(xcp, getResponse.id, getResponse.seqNo, getResponse.primaryTerm)
+            } catch (e: Exception) {
+                log.warn("Failed to parse ManagedIndexMetaData for indexUUID=$indexUUID", e)
+                null
+            }
+        }
+
+        /**
+         * Evaluates a single transition against the given context and returns a detailed result
+         * that includes the current metric value and the required threshold, not just a boolean.
+         */
+        @Suppress("CyclomaticComplexMethod")
+        private fun evaluateTransition(
+            transition: Transition,
+            context: TransitionConditionContext,
+        ): TransitionSimulateResult {
+            val conditions = transition.conditions
+                ?: return TransitionSimulateResult(
+                    stateName = transition.stateName, conditionMet = true,
+                    conditionType = UNCONDITIONAL, currentValue = null, requiredValue = null,
+                )
+
+            val now = Instant.now()
+            val conditionMet = transition.evaluateConditions(context)
+
+            return when {
+                conditions.indexAge != null -> buildResult(
+                    transition, conditionMet, Conditions.MIN_INDEX_AGE_FIELD,
+                    formatDuration(now.toEpochMilli() - context.indexCreationDate.toEpochMilli()),
+                    conditions.indexAge.toString(),
+                )
+
+                conditions.docCount != null -> buildResult(
+                    transition, conditionMet, Conditions.MIN_DOC_COUNT_FIELD,
+                    context.numDocs?.toString() ?: "unavailable",
+                    conditions.docCount.toString(),
+                )
+
+                conditions.size != null -> buildResult(
+                    transition, conditionMet, Conditions.MIN_SIZE_FIELD,
+                    context.indexSize?.toString() ?: "unavailable",
+                    conditions.size.toString(),
+                )
+
+                conditions.cron != null -> buildResult(
+                    transition, conditionMet, Conditions.CRON_FIELD,
+                    now.toString(),
+                    "next fire at ${conditions.cron.getNextExecutionTime(context.transitionStartTime)}",
+                )
+
+                conditions.rolloverAge != null -> buildRolloverAgeResult(transition, conditionMet, conditions, context, now)
+
+                conditions.noAlias != null -> {
+                    val aliasCount = context.indexAliasesCount ?: 0
+                    buildResult(
+                        transition, conditionMet, Conditions.NO_ALIAS_FIELD,
+                        if (aliasCount == 0) "no aliases" else "$aliasCount alias(es)",
+                        if (conditions.noAlias) "no aliases (no_alias=true)" else "at least one alias (no_alias=false)",
+                    )
+                }
+
+                conditions.minStateAge != null -> buildStateAgeResult(transition, conditionMet, conditions, context, now)
+
+                else -> buildResult(transition, conditionMet, "unknown", null, null)
+            }
+        }
+
+        private fun buildRolloverAgeResult(
+            transition: Transition,
+            conditionMet: Boolean,
+            conditions: Conditions,
+            context: TransitionConditionContext,
+            now: Instant,
+        ): TransitionSimulateResult {
+            val rolloverDate = context.rolloverDate
+            return if (rolloverDate == null) {
+                buildResult(
+                    transition, false, Conditions.MIN_ROLLOVER_AGE_FIELD,
+                    "index has never been rolled over", conditions.rolloverAge.toString(),
+                )
+            } else {
+                buildResult(
+                    transition, conditionMet, Conditions.MIN_ROLLOVER_AGE_FIELD,
+                    formatDuration(now.toEpochMilli() - rolloverDate.toEpochMilli()),
+                    conditions.rolloverAge.toString(),
+                )
+            }
+        }
+
+        private fun buildStateAgeResult(
+            transition: Transition,
+            conditionMet: Boolean,
+            conditions: Conditions,
+            context: TransitionConditionContext,
+            now: Instant,
+        ): TransitionSimulateResult {
+            val stateStartTime = context.stateStartTime
+            return if (stateStartTime == null) {
+                buildResult(
+                    transition, false, Conditions.MIN_STATE_AGE_FIELD,
+                    "state start time unknown (index not yet managed)", conditions.minStateAge.toString(),
+                )
+            } else {
+                buildResult(
+                    transition, conditionMet, Conditions.MIN_STATE_AGE_FIELD,
+                    formatDuration(now.toEpochMilli() - stateStartTime.toEpochMilli()),
+                    conditions.minStateAge.toString(),
+                )
+            }
+        }
+
+        private fun buildResult(
+            transition: Transition,
+            conditionMet: Boolean,
+            conditionType: String,
+            currentValue: String?,
+            requiredValue: String?,
+        ) = TransitionSimulateResult(
+            stateName = transition.stateName,
+            conditionMet = conditionMet,
+            conditionType = conditionType,
+            currentValue = currentValue,
+            requiredValue = requiredValue,
+        )
+
+        /** Formats a duration in milliseconds as a human-readable string (e.g. "3d 4h 20m"). */
+        private fun formatDuration(millis: Long): String = TimeValue.timeValueMillis(millis).toString()
+    }
+
+    companion object {
+        private const val UNCONDITIONAL = "unconditional"
+    }
+}

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/transport/action/simulate/TransportSimulatePolicyAction.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/transport/action/simulate/TransportSimulatePolicyAction.kt
@@ -15,11 +15,10 @@ import org.opensearch.action.admin.indices.stats.IndicesStatsRequest
 import org.opensearch.action.admin.indices.stats.IndicesStatsResponse
 import org.opensearch.action.get.GetRequest
 import org.opensearch.action.get.GetResponse
-import org.opensearch.action.get.MultiGetRequest
-import org.opensearch.action.get.MultiGetResponse
 import org.opensearch.action.support.ActionFilters
 import org.opensearch.action.support.HandledTransportAction
 import org.opensearch.action.support.IndicesOptions
+import org.opensearch.cluster.ClusterState
 import org.opensearch.cluster.metadata.IndexNameExpressionResolver
 import org.opensearch.cluster.service.ClusterService
 import org.opensearch.common.inject.Inject
@@ -80,12 +79,14 @@ constructor(
             CoroutineScope(Dispatchers.IO).launch {
                 try {
                     val policy = resolvePolicy()
+                    val clusterState = clusterService.state()
                     val results = mutableListOf<IndexSimulateResult>()
-                    for (indexName in expandIndices(request.indices)) {
-                        results.add(simulateIndex(indexName, policy))
+                    for (indexName in expandIndices(request.indices, clusterState)) {
+                        results.add(simulateIndex(indexName, policy, clusterState))
                     }
                     actionListener.onResponse(SimulatePolicyResponse(results))
                 } catch (e: Exception) {
+                    log.error("Failed to simulate policy", e)
                     actionListener.onFailure(ExceptionsHelper.unwrapCause(e) as Exception)
                 }
             }
@@ -97,8 +98,7 @@ constructor(
          * wildcards) are kept as-is so that [simulateIndex] can return a proper "not found" error
          * for indices that don't exist in the cluster.
          */
-        private fun expandIndices(indices: List<String>): List<String> {
-            val clusterState = clusterService.state()
+        private fun expandIndices(indices: List<String>, clusterState: ClusterState): List<String> {
             val result = mutableListOf<String>()
             for (index in indices) {
                 if (index.contains('*') || index.contains('?')) {
@@ -121,7 +121,9 @@ constructor(
 
             val policyId = requireNotNull(request.policyId) { "policyId must not be null when policy is not provided" }
             val getRequest = GetRequest(INDEX_MANAGEMENT_INDEX, policyId)
-            val getResponse: GetResponse = client.suspendUntil { get(getRequest, it) }
+            val getResponse: GetResponse = client.threadPool().threadContext.stashContext().use {
+                client.suspendUntil { get(getRequest, it) }
+            }
             if (!getResponse.isExists) {
                 throw OpenSearchStatusException("Policy '$policyId' not found", RestStatus.NOT_FOUND)
             }
@@ -130,8 +132,7 @@ constructor(
 
         /** Runs the full simulation for a single index and returns its result. */
         @Suppress("ReturnCount", "CyclomaticComplexMethod")
-        private suspend fun simulateIndex(indexName: String, policy: Policy): IndexSimulateResult {
-            val clusterState = clusterService.state()
+        private suspend fun simulateIndex(indexName: String, policy: Policy, clusterState: ClusterState): IndexSimulateResult {
             val indexMetadata = clusterState.metadata().index(indexName)
                 ?: return IndexSimulateResult(
                     indexName = indexName, indexUUID = null, policyId = policy.id,
@@ -157,8 +158,8 @@ constructor(
                     error = "State '$currentStateName' referenced in metadata not found in policy",
                 )
 
-            val currentAction: String? = if (managedMetadata != null) {
-                currentState.getActionToExecute(managedMetadata, indexMetadataProvider)?.type
+            val currentAction: String? = if (isManaged) {
+                currentState.getActionToExecute(managedMetadata!!, indexMetadataProvider)?.type
             } else {
                 currentState.actions.firstOrNull()?.type ?: TransitionsAction.name
             }
@@ -198,9 +199,11 @@ constructor(
         ): Pair<Long?, ByteSizeValue?> {
             if (transitions.none { it.hasStatsConditions() }) return Pair(null, null)
             val statsRequest = IndicesStatsRequest().indices(indexName).clear().docs(true)
-            val statsResponse: IndicesStatsResponse = client.admin().indices().suspendUntil { stats(statsRequest, it) }
+            val statsResponse: IndicesStatsResponse = client.threadPool().threadContext.stashContext().use {
+                client.admin().indices().suspendUntil { stats(statsRequest, it) }
+            }
             val docs = statsResponse.primaries.getDocs()
-            return Pair(docs?.count ?: 0, ByteSizeValue(docs?.totalSizeInBytes ?: 0))
+            return Pair(docs?.count, docs?.totalSizeInBytes?.let { ByteSizeValue(it) })
         }
 
         /** Builds a [TransitionConditionContext] from index and managed metadata. */
@@ -226,15 +229,11 @@ constructor(
          * Returns null if the index is not currently managed.
          */
         private suspend fun fetchManagedIndexMetadata(indexUUID: String): ManagedIndexMetaData? {
-            val mgetReq = MultiGetRequest()
-            mgetReq.add(MultiGetRequest.Item(INDEX_MANAGEMENT_INDEX, managedIndexMetadataID(indexUUID)).routing(indexUUID))
-            val mgetResponse: MultiGetResponse = client.suspendUntil { multiGet(mgetReq, it) }
-
-            val getResponse = mgetResponse.responses
-                .firstOrNull()
-                ?.response
-                ?.takeIf { it.isExists && it.sourceAsBytesRef != null }
-                ?: return null
+            val getReq = GetRequest(INDEX_MANAGEMENT_INDEX, managedIndexMetadataID(indexUUID)).routing(indexUUID)
+            val getResponse: GetResponse = client.threadPool().threadContext.stashContext().use {
+                client.suspendUntil { get(getReq, it) }
+            }
+            if (!getResponse.isExists || getResponse.sourceAsBytesRef == null) return null
 
             return try {
                 val xcp = XContentHelper.createParser(

--- a/src/test/kotlin/org/opensearch/indexmanagement/IndexManagementRestTestCase.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/IndexManagementRestTestCase.kt
@@ -374,8 +374,10 @@ abstract class IndexManagementRestTestCase : ODFERestTestCase() {
 
         // Ignore the task list API and segment replication background tasks (always running on Remote Store clusters)
         private fun isIgnorableTask(action: String): Boolean =
-            action == ListTasksAction.NAME || action == ListTasksAction.NAME + "[n]" ||
-                action.startsWith("segrep_") || action == "indices:admin/publishCheckpoint[p]"
+            action == ListTasksAction.NAME ||
+                action == ListTasksAction.NAME + "[n]" ||
+                action.startsWith("segrep_") ||
+                action == "indices:admin/publishCheckpoint[p]"
 
         @JvmStatic
         protected fun waitForThreadPools(client: RestClient) {

--- a/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/resthandler/RestSimulatePolicyActionIT.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/resthandler/RestSimulatePolicyActionIT.kt
@@ -17,15 +17,15 @@ import org.opensearch.indexmanagement.indexstatemanagement.model.State
 import org.opensearch.indexmanagement.indexstatemanagement.model.Transition
 import org.opensearch.indexmanagement.indexstatemanagement.randomPolicy
 import org.opensearch.indexmanagement.indexstatemanagement.randomState
-import org.opensearch.indexmanagement.indexstatemanagement.transport.action.simulate.SimulatePolicyResponse.Companion.SIMULATE_RESULTS_FIELD
+import org.opensearch.indexmanagement.indexstatemanagement.transport.action.simulate.IndexSimulateResult.Companion.CURRENT_ACTION_FIELD
+import org.opensearch.indexmanagement.indexstatemanagement.transport.action.simulate.IndexSimulateResult.Companion.CURRENT_STATE_FIELD
+import org.opensearch.indexmanagement.indexstatemanagement.transport.action.simulate.IndexSimulateResult.Companion.ERROR_FIELD
 import org.opensearch.indexmanagement.indexstatemanagement.transport.action.simulate.IndexSimulateResult.Companion.INDEX_NAME_FIELD
 import org.opensearch.indexmanagement.indexstatemanagement.transport.action.simulate.IndexSimulateResult.Companion.INDEX_UUID_FIELD
 import org.opensearch.indexmanagement.indexstatemanagement.transport.action.simulate.IndexSimulateResult.Companion.IS_MANAGED_FIELD
-import org.opensearch.indexmanagement.indexstatemanagement.transport.action.simulate.IndexSimulateResult.Companion.CURRENT_STATE_FIELD
-import org.opensearch.indexmanagement.indexstatemanagement.transport.action.simulate.IndexSimulateResult.Companion.CURRENT_ACTION_FIELD
 import org.opensearch.indexmanagement.indexstatemanagement.transport.action.simulate.IndexSimulateResult.Companion.NEXT_STATE_FIELD
 import org.opensearch.indexmanagement.indexstatemanagement.transport.action.simulate.IndexSimulateResult.Companion.TRANSITION_EVALUATION_FIELD
-import org.opensearch.indexmanagement.indexstatemanagement.transport.action.simulate.IndexSimulateResult.Companion.ERROR_FIELD
+import org.opensearch.indexmanagement.indexstatemanagement.transport.action.simulate.SimulatePolicyResponse.Companion.SIMULATE_RESULTS_FIELD
 import org.opensearch.indexmanagement.indexstatemanagement.transport.action.simulate.TransitionSimulateResult.Companion.CONDITION_MET_FIELD
 import org.opensearch.indexmanagement.indexstatemanagement.transport.action.simulate.TransitionSimulateResult.Companion.CONDITION_TYPE_FIELD
 import org.opensearch.indexmanagement.indexstatemanagement.transport.action.simulate.TransitionSimulateResult.Companion.STATE_NAME_FIELD
@@ -143,19 +143,19 @@ class RestSimulatePolicyActionIT : IndexStateManagementRestTestCase() {
 
     fun `test simulate with wildcard expands to multiple indices`() {
         val prefix = "$testIndexName-wild"
-        createIndex("${prefix}-1", null)
-        createIndex("${prefix}-2", null)
-        createIndex("${prefix}-3", null)
+        createIndex("$prefix-1", null)
+        createIndex("$prefix-2", null)
+        createIndex("$prefix-3", null)
         val policy = createPolicy(randomPolicy(states = listOf(randomState(transitions = listOf()))))
 
         val results = simulateResults(
-            """{"policy_id":"${policy.id}","indices":["${prefix}-*"]}""",
+            """{"policy_id":"${policy.id}","indices":["$prefix-*"]}""",
         )
 
         val returnedNames = results.map { it[INDEX_NAME_FIELD] as String }.toSet()
-        assertTrue("${prefix}-1 should be in results", returnedNames.contains("${prefix}-1"))
-        assertTrue("${prefix}-2 should be in results", returnedNames.contains("${prefix}-2"))
-        assertTrue("${prefix}-3 should be in results", returnedNames.contains("${prefix}-3"))
+        assertTrue("$prefix-1 should be in results", returnedNames.contains("$prefix-1"))
+        assertTrue("$prefix-2 should be in results", returnedNames.contains("$prefix-2"))
+        assertTrue("$prefix-3 should be in results", returnedNames.contains("$prefix-3"))
     }
 
     // -------------------------------------------------------------------------

--- a/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/resthandler/RestSimulatePolicyActionIT.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/resthandler/RestSimulatePolicyActionIT.kt
@@ -1,0 +1,306 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.indexmanagement.indexstatemanagement.resthandler
+
+import org.apache.hc.core5.http.ContentType
+import org.apache.hc.core5.http.io.entity.StringEntity
+import org.opensearch.client.ResponseException
+import org.opensearch.common.unit.TimeValue
+import org.opensearch.core.rest.RestStatus
+import org.opensearch.indexmanagement.indexstatemanagement.IndexStateManagementRestTestCase
+import org.opensearch.indexmanagement.indexstatemanagement.action.TransitionsAction
+import org.opensearch.indexmanagement.indexstatemanagement.model.Conditions
+import org.opensearch.indexmanagement.indexstatemanagement.model.State
+import org.opensearch.indexmanagement.indexstatemanagement.model.Transition
+import org.opensearch.indexmanagement.indexstatemanagement.randomPolicy
+import org.opensearch.indexmanagement.indexstatemanagement.randomState
+import org.opensearch.indexmanagement.indexstatemanagement.transport.action.simulate.SimulatePolicyResponse.Companion.SIMULATE_RESULTS_FIELD
+import org.opensearch.indexmanagement.indexstatemanagement.transport.action.simulate.IndexSimulateResult.Companion.INDEX_NAME_FIELD
+import org.opensearch.indexmanagement.indexstatemanagement.transport.action.simulate.IndexSimulateResult.Companion.INDEX_UUID_FIELD
+import org.opensearch.indexmanagement.indexstatemanagement.transport.action.simulate.IndexSimulateResult.Companion.IS_MANAGED_FIELD
+import org.opensearch.indexmanagement.indexstatemanagement.transport.action.simulate.IndexSimulateResult.Companion.CURRENT_STATE_FIELD
+import org.opensearch.indexmanagement.indexstatemanagement.transport.action.simulate.IndexSimulateResult.Companion.CURRENT_ACTION_FIELD
+import org.opensearch.indexmanagement.indexstatemanagement.transport.action.simulate.IndexSimulateResult.Companion.NEXT_STATE_FIELD
+import org.opensearch.indexmanagement.indexstatemanagement.transport.action.simulate.IndexSimulateResult.Companion.TRANSITION_EVALUATION_FIELD
+import org.opensearch.indexmanagement.indexstatemanagement.transport.action.simulate.IndexSimulateResult.Companion.ERROR_FIELD
+import org.opensearch.indexmanagement.indexstatemanagement.transport.action.simulate.TransitionSimulateResult.Companion.CONDITION_MET_FIELD
+import org.opensearch.indexmanagement.indexstatemanagement.transport.action.simulate.TransitionSimulateResult.Companion.CONDITION_TYPE_FIELD
+import org.opensearch.indexmanagement.indexstatemanagement.transport.action.simulate.TransitionSimulateResult.Companion.STATE_NAME_FIELD
+import org.opensearch.indexmanagement.makeRequest
+import org.opensearch.indexmanagement.waitFor
+import org.opensearch.rest.RestRequest.Method.POST
+import java.util.Locale
+
+@Suppress("UNCHECKED_CAST")
+class RestSimulatePolicyActionIT : IndexStateManagementRestTestCase() {
+
+    private val testIndexName = javaClass.simpleName.lowercase(Locale.ROOT)
+
+    private val simulateUri = RestSimulatePolicyAction.SIMULATE_BASE_URI
+    private val legacySimulateUri = RestSimulatePolicyAction.LEGACY_SIMULATE_BASE_URI
+
+    // -------------------------------------------------------------------------
+    // Helper
+    // -------------------------------------------------------------------------
+
+    private fun simulate(body: String): Map<String, Any> {
+        val response = client().makeRequest(POST.toString(), simulateUri, StringEntity(body, ContentType.APPLICATION_JSON))
+        assertEquals("Unexpected status", RestStatus.OK, response.restStatus())
+        return response.asMap()
+    }
+
+    private fun simulateResults(body: String): List<Map<String, Any>> =
+        simulate(body)[SIMULATE_RESULTS_FIELD] as List<Map<String, Any>>
+
+    private fun singleResult(body: String): Map<String, Any> = simulateResults(body).single()
+
+    // -------------------------------------------------------------------------
+    // Stored policy — unmanaged index
+    // -------------------------------------------------------------------------
+
+    fun `test simulate stored policy on unmanaged index returns first state and action`() {
+        val hotState = randomState(name = "hot", actions = listOf(), transitions = listOf())
+        val policy = createPolicy(randomPolicy(states = listOf(hotState), ismTemplate = null))
+        createIndex("$testIndexName-unmanaged", null)
+
+        val result = singleResult(
+            """
+            {
+              "policy_id": "${policy.id}",
+              "indices": ["$testIndexName-unmanaged"]
+            }
+            """.trimIndent(),
+        )
+
+        assertEquals("$testIndexName-unmanaged", result[INDEX_NAME_FIELD])
+        assertNotNull("index_uuid should be present", result[INDEX_UUID_FIELD])
+        assertEquals(false, result[IS_MANAGED_FIELD])
+        assertEquals("hot", result[CURRENT_STATE_FIELD])
+        // The only action in an empty-action state is "transitions"
+        assertEquals(TransitionsAction.name, result[CURRENT_ACTION_FIELD])
+        assertNull("error should be null", result[ERROR_FIELD])
+    }
+
+    // -------------------------------------------------------------------------
+    // Inline policy
+    // -------------------------------------------------------------------------
+
+    fun `test simulate inline policy without stored policy`() {
+        createIndex("$testIndexName-inline", null)
+
+        val result = singleResult(
+            """
+            {
+              "policy": {
+                "description": "inline test",
+                "default_state": "warm",
+                "states": [{"name":"warm","actions":[],"transitions":[]}]
+              },
+              "indices": ["$testIndexName-inline"]
+            }
+            """.trimIndent(),
+        )
+
+        assertEquals("$testIndexName-inline", result[INDEX_NAME_FIELD])
+        assertEquals(false, result[IS_MANAGED_FIELD])
+        assertEquals("warm", result[CURRENT_STATE_FIELD])
+        assertNull("error should be null", result[ERROR_FIELD])
+    }
+
+    // -------------------------------------------------------------------------
+    // Error cases
+    // -------------------------------------------------------------------------
+
+    fun `test simulate non-existent policy returns 404`() {
+        createIndex("$testIndexName-err", null)
+        try {
+            simulate("""{"policy_id":"nonexistent-policy-xyz","indices":["$testIndexName-err"]}""")
+            fail("Expected 404")
+        } catch (e: ResponseException) {
+            assertEquals(RestStatus.NOT_FOUND, e.response.restStatus())
+        }
+    }
+
+    fun `test simulate non-existent index returns error in result`() {
+        val policy = createPolicy(randomPolicy(states = listOf(randomState(transitions = listOf()))))
+
+        val result = singleResult(
+            """{"policy_id":"${policy.id}","indices":["index-that-does-not-exist"]}""",
+        )
+
+        assertEquals("index-that-does-not-exist", result[INDEX_NAME_FIELD])
+        assertNull("index_uuid should be null when index is not found", result[INDEX_UUID_FIELD])
+        assertNotNull("error should be present for missing index", result[ERROR_FIELD])
+        assertTrue((result[ERROR_FIELD] as String).contains("not found"))
+    }
+
+    // -------------------------------------------------------------------------
+    // Wildcard expansion
+    // -------------------------------------------------------------------------
+
+    fun `test simulate with wildcard expands to multiple indices`() {
+        val prefix = "$testIndexName-wild"
+        createIndex("${prefix}-1", null)
+        createIndex("${prefix}-2", null)
+        createIndex("${prefix}-3", null)
+        val policy = createPolicy(randomPolicy(states = listOf(randomState(transitions = listOf()))))
+
+        val results = simulateResults(
+            """{"policy_id":"${policy.id}","indices":["${prefix}-*"]}""",
+        )
+
+        val returnedNames = results.map { it[INDEX_NAME_FIELD] as String }.toSet()
+        assertTrue("${prefix}-1 should be in results", returnedNames.contains("${prefix}-1"))
+        assertTrue("${prefix}-2 should be in results", returnedNames.contains("${prefix}-2"))
+        assertTrue("${prefix}-3 should be in results", returnedNames.contains("${prefix}-3"))
+    }
+
+    // -------------------------------------------------------------------------
+    // Transition evaluation — conditions not met
+    // -------------------------------------------------------------------------
+
+    fun `test simulate shows transition evaluation with index age not met`() {
+        val warmState = randomState(name = "warm", actions = listOf(), transitions = listOf())
+        val hotState = State(
+            name = "hot",
+            actions = listOf(),
+            transitions = listOf(
+                Transition(
+                    stateName = "warm",
+                    conditions = Conditions(indexAge = TimeValue.timeValueDays(100)),
+                ),
+            ),
+        )
+        val policy = createPolicy(randomPolicy(states = listOf(hotState, warmState), ismTemplate = null))
+        createIndex("$testIndexName-age", null)
+
+        val result = singleResult(
+            """{"policy_id":"${policy.id}","indices":["$testIndexName-age"]}""",
+        )
+
+        assertEquals(false, result[IS_MANAGED_FIELD])
+        assertEquals("hot", result[CURRENT_STATE_FIELD])
+        assertEquals(TransitionsAction.name, result[CURRENT_ACTION_FIELD])
+
+        val evaluations = result[TRANSITION_EVALUATION_FIELD] as List<Map<String, Any>>
+        assertEquals(1, evaluations.size)
+        val transition = evaluations[0]
+        assertEquals("warm", transition[STATE_NAME_FIELD])
+        assertEquals(false, transition[CONDITION_MET_FIELD])
+        assertEquals(Conditions.MIN_INDEX_AGE_FIELD, transition[CONDITION_TYPE_FIELD])
+
+        // next_state should be null since the condition is not met
+        assertNull("next_state should be null", result[NEXT_STATE_FIELD])
+    }
+
+    fun `test simulate shows transition evaluation with doc count not met`() {
+        val coldState = randomState(name = "cold", actions = listOf(), transitions = listOf())
+        val hotState = State(
+            name = "hot",
+            actions = listOf(),
+            transitions = listOf(
+                Transition(
+                    stateName = "cold",
+                    conditions = Conditions(docCount = 1_000_000L),
+                ),
+            ),
+        )
+        val policy = createPolicy(randomPolicy(states = listOf(hotState, coldState), ismTemplate = null))
+        createIndex("$testIndexName-docs", null)
+
+        val result = singleResult(
+            """{"policy_id":"${policy.id}","indices":["$testIndexName-docs"]}""",
+        )
+
+        val evaluations = result[TRANSITION_EVALUATION_FIELD] as List<Map<String, Any>>
+        assertEquals(1, evaluations.size)
+        assertEquals(false, evaluations[0][CONDITION_MET_FIELD])
+        assertEquals(Conditions.MIN_DOC_COUNT_FIELD, evaluations[0][CONDITION_TYPE_FIELD])
+        assertNull("next_state should be null", result[NEXT_STATE_FIELD])
+    }
+
+    fun `test simulate unconditional transition shows condition met`() {
+        val warmState = randomState(name = "warm", actions = listOf(), transitions = listOf())
+        // Transition with no conditions → unconditional, always moves
+        val hotState = State(
+            name = "hot",
+            actions = listOf(),
+            transitions = listOf(Transition(stateName = "warm", conditions = null)),
+        )
+        val policy = createPolicy(randomPolicy(states = listOf(hotState, warmState), ismTemplate = null))
+        createIndex("$testIndexName-unconditional", null)
+
+        val result = singleResult(
+            """{"policy_id":"${policy.id}","indices":["$testIndexName-unconditional"]}""",
+        )
+
+        val evaluations = result[TRANSITION_EVALUATION_FIELD] as List<Map<String, Any>>
+        assertEquals(1, evaluations.size)
+        assertEquals(true, evaluations[0][CONDITION_MET_FIELD])
+        assertEquals("warm", result[NEXT_STATE_FIELD])
+    }
+
+    // -------------------------------------------------------------------------
+    // Managed index — is_managed=true
+    // -------------------------------------------------------------------------
+
+    fun `test simulate shows is_managed true for a managed index after initialization`() {
+        val hotState = randomState(name = "hot", actions = listOf(), transitions = listOf())
+        val policy = createPolicy(randomPolicy(states = listOf(hotState), ismTemplate = null))
+        createIndex("$testIndexName-managed", policy.id)
+
+        // Trigger ISM to initialize the managed index metadata
+        val managedIndex = getExistingManagedIndexConfig("$testIndexName-managed")
+        updateManagedIndexConfigStartTime(managedIndex)
+
+        // Wait until ISM has written the metadata document
+        waitFor {
+            val result = singleResult(
+                """{"policy_id":"${policy.id}","indices":["$testIndexName-managed"]}""",
+            )
+            assertTrue("Expected is_managed=true after ISM initialization", result[IS_MANAGED_FIELD] == true)
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Legacy URI
+    // -------------------------------------------------------------------------
+
+    fun `test simulate works via legacy opendistro uri`() {
+        createIndex("$testIndexName-legacy", null)
+        val policy = createPolicy(randomPolicy(states = listOf(randomState(transitions = listOf()))))
+
+        val response = client().makeRequest(
+            POST.toString(), legacySimulateUri,
+            StringEntity(
+                """{"policy_id":"${policy.id}","indices":["$testIndexName-legacy"]}""",
+                ContentType.APPLICATION_JSON,
+            ),
+        )
+        assertEquals(RestStatus.OK, response.restStatus())
+        val results = response.asMap()[SIMULATE_RESULTS_FIELD] as List<*>
+        assertEquals(1, results.size)
+    }
+
+    // -------------------------------------------------------------------------
+    // Multiple indices in one request
+    // -------------------------------------------------------------------------
+
+    fun `test simulate multiple concrete indices returns one result per index`() {
+        createIndex("$testIndexName-multi-1", null)
+        createIndex("$testIndexName-multi-2", null)
+        val policy = createPolicy(randomPolicy(states = listOf(randomState(transitions = listOf()))))
+
+        val results = simulateResults(
+            """{"policy_id":"${policy.id}","indices":["$testIndexName-multi-1","$testIndexName-multi-2"]}""",
+        )
+
+        assertEquals(2, results.size)
+        val names = results.map { it[INDEX_NAME_FIELD] as String }.toSet()
+        assertTrue(names.contains("$testIndexName-multi-1"))
+        assertTrue(names.contains("$testIndexName-multi-2"))
+    }
+}

--- a/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/resthandler/RestSimulatePolicyActionTests.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/resthandler/RestSimulatePolicyActionTests.kt
@@ -1,0 +1,154 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.indexmanagement.indexstatemanagement.resthandler
+
+import com.nhaarman.mockitokotlin2.mock
+import org.opensearch.action.ActionRequest
+import org.opensearch.action.ActionType
+import org.opensearch.common.settings.Settings
+import org.opensearch.common.xcontent.XContentType
+import org.opensearch.core.action.ActionListener
+import org.opensearch.core.action.ActionResponse
+import org.opensearch.core.common.bytes.BytesArray
+import org.opensearch.core.xcontent.NamedXContentRegistry
+import org.opensearch.indexmanagement.indexstatemanagement.transport.action.simulate.SimulatePolicyRequest
+import org.opensearch.rest.RestRequest
+import org.opensearch.test.OpenSearchTestCase
+import org.opensearch.test.rest.FakeRestChannel
+import org.opensearch.test.rest.FakeRestRequest
+import org.opensearch.threadpool.ThreadPool
+import org.opensearch.transport.client.node.NodeClient
+
+class RestSimulatePolicyActionTests : OpenSearchTestCase() {
+    private val handler = RestSimulatePolicyAction()
+
+    /**
+     * Minimal NodeClient subclass that captures whatever request is dispatched via
+     * execute().  AbstractClient.execute() is final and delegates to doExecute(), so
+     * overriding doExecute() lets us intercept without running the full transport stack.
+     */
+    private inner class CapturingClient : NodeClient(Settings.EMPTY, mock<ThreadPool>()) {
+        var captured: SimulatePolicyRequest? = null
+
+        override fun <Request : ActionRequest, Response : ActionResponse> doExecute(
+            action: ActionType<Response>,
+            request: Request,
+            listener: ActionListener<Response>,
+        ) {
+            captured = request as? SimulatePolicyRequest
+        }
+    }
+
+    private fun buildRestRequest(json: String): RestRequest =
+        FakeRestRequest.Builder(NamedXContentRegistry.EMPTY)
+            .withMethod(RestRequest.Method.POST)
+            .withPath(RestSimulatePolicyAction.SIMULATE_BASE_URI)
+            .withContent(BytesArray(json), XContentType.JSON)
+            .build()
+
+    /**
+     * Calls handleRequest() (the public entry point on BaseRestHandler), which
+     * internally calls prepareRequest() then consumer.accept(channel).  The
+     * CapturingClient intercepts the final execute() call and stores the request.
+     */
+    private fun parseRequest(json: String): SimulatePolicyRequest {
+        val client = CapturingClient()
+        val restRequest = buildRestRequest(json)
+        handler.handleRequest(restRequest, FakeRestChannel(restRequest, false, 1), client)
+        return requireNotNull(client.captured) { "doExecute was not called — request was not dispatched" }
+    }
+
+    // -------------------------------------------------------------------------
+    // Handler metadata
+    // -------------------------------------------------------------------------
+
+    fun `test getName returns correct action name`() {
+        assertEquals("ism_simulate_policy_action", handler.getName())
+    }
+
+    fun `test routes returns empty list`() {
+        assertTrue(handler.routes().isEmpty())
+    }
+
+    fun `test replacedRoutes includes simulate base uri as POST`() {
+        val routes = handler.replacedRoutes()
+        assertTrue(routes.any { it.method == RestRequest.Method.POST && it.path == RestSimulatePolicyAction.SIMULATE_BASE_URI })
+    }
+
+    fun `test replacedRoutes includes legacy simulate base uri as POST`() {
+        val routes = handler.replacedRoutes()
+        // The legacy URI is the deprecated half of the ReplacedRoute
+        assertTrue(
+            routes.any {
+                it.deprecatedMethod == RestRequest.Method.POST &&
+                    it.deprecatedPath == RestSimulatePolicyAction.LEGACY_SIMULATE_BASE_URI
+            },
+        )
+    }
+
+    // -------------------------------------------------------------------------
+    // prepareRequest — field parsing verification
+    // -------------------------------------------------------------------------
+
+    fun `test prepareRequest parses policy_id and indices`() {
+        val req = parseRequest("""{"policy_id":"my-policy","indices":["idx-1","idx-2"]}""")
+
+        assertEquals("my-policy", req.policyId)
+        assertNull(req.policy)
+        assertEquals(listOf("idx-1", "idx-2"), req.indices)
+    }
+
+    fun `test prepareRequest parses inline policy`() {
+        val json =
+            """
+            {
+              "policy": {
+                "description": "test policy",
+                "default_state": "hot",
+                "states": [{"name":"hot","actions":[],"transitions":[]}]
+              },
+              "indices": ["test-index"]
+            }
+            """.trimIndent()
+
+        val req = parseRequest(json)
+
+        assertNull(req.policyId)
+        assertNotNull(req.policy)
+        assertEquals("hot", req.policy!!.defaultState)
+        assertEquals(listOf("test-index"), req.indices)
+    }
+
+    fun `test prepareRequest parses multiple indices`() {
+        val req = parseRequest("""{"policy_id":"p","indices":["a","b","c"]}""")
+
+        assertEquals(listOf("a", "b", "c"), req.indices)
+    }
+
+    fun `test prepareRequest parses empty indices array`() {
+        val req = parseRequest("""{"policy_id":"p","indices":[]}""")
+
+        assertTrue(req.indices.isEmpty())
+        assertEquals("p", req.policyId)
+    }
+
+    fun `test prepareRequest skips unknown fields`() {
+        val req = parseRequest(
+            """{"policy_id":"my-policy","indices":["i"],"unknown_field":"value","nested":{"a":1}}""",
+        )
+
+        assertEquals("my-policy", req.policyId)
+        assertEquals(listOf("i"), req.indices)
+    }
+
+    fun `test prepareRequest empty body produces null policy_id and empty indices`() {
+        val req = parseRequest("""{}""")
+
+        assertNull(req.policyId)
+        assertNull(req.policy)
+        assertTrue(req.indices.isEmpty())
+    }
+}

--- a/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/transport/action/simulate/SimulatePolicyRequestTests.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/transport/action/simulate/SimulatePolicyRequestTests.kt
@@ -1,0 +1,101 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.indexmanagement.indexstatemanagement.transport.action.simulate
+
+import org.opensearch.common.io.stream.BytesStreamOutput
+import org.opensearch.core.common.io.stream.StreamInput
+import org.opensearch.indexmanagement.indexstatemanagement.randomPolicy
+import org.opensearch.indexmanagement.indexstatemanagement.randomState
+import org.opensearch.test.OpenSearchTestCase
+
+class SimulatePolicyRequestTests : OpenSearchTestCase() {
+    private val indexName = "test-index"
+
+    fun `test request serialization roundtrip with policy id`() {
+        val request = SimulatePolicyRequest(
+            indices = listOf(indexName, "index-2"),
+            policyId = "my-policy",
+            policy = null,
+        )
+        val out = BytesStreamOutput()
+        request.writeTo(out)
+        val sin = StreamInput.wrap(out.bytes().toBytesRef().bytes)
+        val restored = SimulatePolicyRequest(sin)
+
+        assertEquals(request.indices, restored.indices)
+        assertEquals(request.policyId, restored.policyId)
+        assertNull(restored.policy)
+    }
+
+    fun `test request serialization roundtrip with inline policy`() {
+        val policy = randomPolicy(states = listOf(randomState()))
+        val request = SimulatePolicyRequest(
+            indices = listOf(indexName),
+            policyId = null,
+            policy = policy,
+        )
+        val out = BytesStreamOutput()
+        request.writeTo(out)
+        val sin = StreamInput.wrap(out.bytes().toBytesRef().bytes)
+        val restored = SimulatePolicyRequest(sin)
+
+        assertEquals(request.indices, restored.indices)
+        assertNull(restored.policyId)
+        assertNotNull(restored.policy)
+        assertEquals(policy.id, restored.policy!!.id)
+    }
+
+    fun `test validate fails when both policy id and policy are null`() {
+        val request = SimulatePolicyRequest(
+            indices = listOf(indexName),
+            policyId = null,
+            policy = null,
+        )
+        val exception = request.validate()
+        assertNotNull("Expected validation error", exception)
+        assertTrue(exception!!.validationErrors().any { it.contains("either policy_id or policy") })
+    }
+
+    fun `test validate fails when both policy id and policy are provided`() {
+        val request = SimulatePolicyRequest(
+            indices = listOf(indexName),
+            policyId = "my-policy",
+            policy = randomPolicy(states = listOf(randomState())),
+        )
+        val exception = request.validate()
+        assertNotNull("Expected validation error", exception)
+        assertTrue(exception!!.validationErrors().any { it.contains("only one of policy_id or policy") })
+    }
+
+    fun `test validate fails when indices are empty`() {
+        val request = SimulatePolicyRequest(
+            indices = emptyList(),
+            policyId = "my-policy",
+            policy = null,
+        )
+        val exception = request.validate()
+        assertNotNull("Expected validation error", exception)
+        assertTrue(exception!!.validationErrors().any { it.contains("indices cannot be empty") })
+    }
+
+    fun `test validate passes for valid request with policy id`() {
+        val request = SimulatePolicyRequest(
+            indices = listOf(indexName),
+            policyId = "my-policy",
+            policy = null,
+        )
+        assertNull("Expected no validation error", request.validate())
+    }
+
+    fun `test validate passes for valid request with inline policy`() {
+        val request = SimulatePolicyRequest(
+            indices = listOf(indexName),
+            policyId = null,
+            policy = randomPolicy(states = listOf(randomState())),
+        )
+        assertNull("Expected no validation error", request.validate())
+    }
+}

--- a/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/transport/action/simulate/SimulatePolicyResponseTests.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/transport/action/simulate/SimulatePolicyResponseTests.kt
@@ -1,0 +1,261 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.indexmanagement.indexstatemanagement.transport.action.simulate
+
+import org.opensearch.common.io.stream.BytesStreamOutput
+import org.opensearch.common.xcontent.XContentFactory
+import org.opensearch.core.common.io.stream.StreamInput
+import org.opensearch.core.xcontent.ToXContent
+import org.opensearch.test.OpenSearchTestCase
+
+class SimulatePolicyResponseTests : OpenSearchTestCase() {
+    // ------------------------------------------------------------------ //
+    // TransitionSimulateResult                                             //
+    // ------------------------------------------------------------------ //
+
+    fun `test transition simulate result roundtrip with all fields`() {
+        val result = TransitionSimulateResult(
+            stateName = "warm",
+            conditionMet = true,
+            conditionType = "min_index_age",
+            currentValue = "8d",
+            requiredValue = "7d",
+        )
+        assertRoundTrip(result)
+    }
+
+    fun `test transition simulate result roundtrip with null optional fields`() {
+        val result = TransitionSimulateResult(
+            stateName = "warm",
+            conditionMet = true,
+            conditionType = "unconditional",
+            currentValue = null,
+            requiredValue = null,
+        )
+        assertRoundTrip(result)
+    }
+
+    fun `test transition simulate result condition not met`() {
+        val result = TransitionSimulateResult(
+            stateName = "cold",
+            conditionMet = false,
+            conditionType = "min_index_age",
+            currentValue = "3d",
+            requiredValue = "7d",
+        )
+        assertRoundTrip(result)
+        assertFalse(result.conditionMet)
+    }
+
+    fun `test transition simulate result toXContent`() {
+        val result = TransitionSimulateResult(
+            stateName = "warm",
+            conditionMet = true,
+            conditionType = "min_index_age",
+            currentValue = "8d",
+            requiredValue = "7d",
+        )
+        val builder = XContentFactory.jsonBuilder()
+        result.toXContent(builder, ToXContent.EMPTY_PARAMS)
+        val json = builder.toString()
+        assertTrue(json.contains("\"${TransitionSimulateResult.STATE_NAME_FIELD}\":\"warm\""))
+        assertTrue(json.contains("\"${TransitionSimulateResult.CONDITION_MET_FIELD}\":true"))
+        assertTrue(json.contains("\"${TransitionSimulateResult.CONDITION_TYPE_FIELD}\":\"min_index_age\""))
+        assertTrue(json.contains("\"${TransitionSimulateResult.CURRENT_VALUE_FIELD}\":\"8d\""))
+        assertTrue(json.contains("\"${TransitionSimulateResult.REQUIRED_VALUE_FIELD}\":\"7d\""))
+    }
+
+    fun `test transition simulate result toXContent omits null optional fields`() {
+        val result = TransitionSimulateResult(
+            stateName = "warm",
+            conditionMet = true,
+            conditionType = "unconditional",
+            currentValue = null,
+            requiredValue = null,
+        )
+        val builder = XContentFactory.jsonBuilder()
+        result.toXContent(builder, ToXContent.EMPTY_PARAMS)
+        val json = builder.toString()
+        assertFalse("currentValue should be absent", json.contains(TransitionSimulateResult.CURRENT_VALUE_FIELD))
+        assertFalse("requiredValue should be absent", json.contains(TransitionSimulateResult.REQUIRED_VALUE_FIELD))
+    }
+
+    // ------------------------------------------------------------------ //
+    // IndexSimulateResult                                                  //
+    // ------------------------------------------------------------------ //
+
+    fun `test index simulate result roundtrip with all fields`() {
+        val transitionResult = TransitionSimulateResult("warm", true, "min_index_age", "8d", "7d")
+        val result = IndexSimulateResult(
+            indexName = "my-index",
+            indexUUID = "abc-uuid",
+            policyId = "my-policy",
+            isManaged = true,
+            currentState = "hot",
+            currentAction = "rollover",
+            transitionEvaluation = listOf(transitionResult),
+            nextState = "warm",
+            error = null,
+        )
+        assertRoundTrip(result)
+    }
+
+    fun `test index simulate result roundtrip with error set`() {
+        val result = IndexSimulateResult(
+            indexName = "missing-index",
+            indexUUID = null,
+            policyId = "my-policy",
+            isManaged = false,
+            currentState = null,
+            currentAction = null,
+            transitionEvaluation = null,
+            nextState = null,
+            error = "Index 'missing-index' not found in cluster",
+        )
+        assertRoundTrip(result)
+    }
+
+    fun `test index simulate result roundtrip with null transition evaluation`() {
+        val result = IndexSimulateResult(
+            indexName = "my-index",
+            indexUUID = "uuid-1",
+            policyId = "policy-1",
+            isManaged = false,
+            currentState = "hot",
+            currentAction = "rollover",
+            transitionEvaluation = null,
+            nextState = null,
+            error = null,
+        )
+        assertRoundTrip(result)
+    }
+
+    fun `test index simulate result toXContent renders error when present`() {
+        val result = IndexSimulateResult(
+            indexName = "missing-index",
+            indexUUID = null,
+            policyId = "my-policy",
+            isManaged = false,
+            currentState = null,
+            currentAction = null,
+            transitionEvaluation = null,
+            nextState = null,
+            error = "Index not found",
+        )
+        val builder = XContentFactory.jsonBuilder()
+        result.toXContent(builder, ToXContent.EMPTY_PARAMS)
+        val json = builder.toString()
+        assertTrue(json.contains("\"${IndexSimulateResult.ERROR_FIELD}\":\"Index not found\""))
+        // success fields should be absent when there is an error
+        assertFalse(json.contains(IndexSimulateResult.CURRENT_STATE_FIELD))
+        assertFalse(json.contains(IndexSimulateResult.CURRENT_ACTION_FIELD))
+    }
+
+    fun `test index simulate result toXContent renders success fields when no error`() {
+        val transitionResult = TransitionSimulateResult("warm", false, "min_index_age", "3d", "7d")
+        val result = IndexSimulateResult(
+            indexName = "my-index",
+            indexUUID = "uuid",
+            policyId = "my-policy",
+            isManaged = true,
+            currentState = "hot",
+            currentAction = "transition",
+            transitionEvaluation = listOf(transitionResult),
+            nextState = null,
+            error = null,
+        )
+        val builder = XContentFactory.jsonBuilder()
+        result.toXContent(builder, ToXContent.EMPTY_PARAMS)
+        val json = builder.toString()
+        assertTrue(json.contains("\"${IndexSimulateResult.CURRENT_STATE_FIELD}\":\"hot\""))
+        assertTrue(json.contains("\"${IndexSimulateResult.CURRENT_ACTION_FIELD}\":\"transition\""))
+        assertTrue(json.contains(IndexSimulateResult.TRANSITION_EVALUATION_FIELD))
+        assertFalse(json.contains(IndexSimulateResult.ERROR_FIELD))
+    }
+
+    // ------------------------------------------------------------------ //
+    // SimulatePolicyResponse                                               //
+    // ------------------------------------------------------------------ //
+
+    fun `test simulate policy response roundtrip`() {
+        val transitionResult = TransitionSimulateResult("warm", true, "min_index_age", "8d", "7d")
+        val indexResult = IndexSimulateResult(
+            indexName = "my-index",
+            indexUUID = "abc-uuid",
+            policyId = "my-policy",
+            isManaged = true,
+            currentState = "hot",
+            currentAction = "transition",
+            transitionEvaluation = listOf(transitionResult),
+            nextState = "warm",
+            error = null,
+        )
+        val response = SimulatePolicyResponse(listOf(indexResult))
+        val out = BytesStreamOutput()
+        response.writeTo(out)
+        val sin = StreamInput.wrap(out.bytes().toBytesRef().bytes)
+        val restored = SimulatePolicyResponse(sin)
+
+        assertEquals(1, restored.simulateResults.size)
+        val restoredResult = restored.simulateResults.first()
+        assertEquals(indexResult.indexName, restoredResult.indexName)
+        assertEquals(indexResult.indexUUID, restoredResult.indexUUID)
+        assertEquals(indexResult.currentState, restoredResult.currentState)
+        assertEquals(indexResult.nextState, restoredResult.nextState)
+        assertEquals(1, restoredResult.transitionEvaluation!!.size)
+        assertEquals(transitionResult.stateName, restoredResult.transitionEvaluation!!.first().stateName)
+        assertEquals(transitionResult.conditionMet, restoredResult.transitionEvaluation!!.first().conditionMet)
+    }
+
+    fun `test simulate policy response roundtrip with empty results`() {
+        val response = SimulatePolicyResponse(emptyList())
+        val out = BytesStreamOutput()
+        response.writeTo(out)
+        val sin = StreamInput.wrap(out.bytes().toBytesRef().bytes)
+        val restored = SimulatePolicyResponse(sin)
+        assertTrue(restored.simulateResults.isEmpty())
+    }
+
+    fun `test simulate policy response toXContent`() {
+        val response = SimulatePolicyResponse(emptyList())
+        val builder = XContentFactory.jsonBuilder()
+        response.toXContent(builder, ToXContent.EMPTY_PARAMS)
+        val json = builder.toString()
+        assertTrue(json.contains(SimulatePolicyResponse.SIMULATE_RESULTS_FIELD))
+    }
+
+    // ------------------------------------------------------------------ //
+    // Helpers                                                              //
+    // ------------------------------------------------------------------ //
+
+    private fun assertRoundTrip(result: TransitionSimulateResult) {
+        val out = BytesStreamOutput()
+        result.writeTo(out)
+        val sin = StreamInput.wrap(out.bytes().toBytesRef().bytes)
+        val restored = TransitionSimulateResult(sin)
+        assertEquals(result.stateName, restored.stateName)
+        assertEquals(result.conditionMet, restored.conditionMet)
+        assertEquals(result.conditionType, restored.conditionType)
+        assertEquals(result.currentValue, restored.currentValue)
+        assertEquals(result.requiredValue, restored.requiredValue)
+    }
+
+    private fun assertRoundTrip(result: IndexSimulateResult) {
+        val out = BytesStreamOutput()
+        result.writeTo(out)
+        val sin = StreamInput.wrap(out.bytes().toBytesRef().bytes)
+        val restored = IndexSimulateResult(sin)
+        assertEquals(result.indexName, restored.indexName)
+        assertEquals(result.indexUUID, restored.indexUUID)
+        assertEquals(result.policyId, restored.policyId)
+        assertEquals(result.isManaged, restored.isManaged)
+        assertEquals(result.currentState, restored.currentState)
+        assertEquals(result.currentAction, restored.currentAction)
+        assertEquals(result.nextState, restored.nextState)
+        assertEquals(result.error, restored.error)
+        assertEquals(result.transitionEvaluation?.size, restored.transitionEvaluation?.size)
+    }
+}

--- a/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/transport/action/simulate/TransportSimulatePolicyActionTests.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/transport/action/simulate/TransportSimulatePolicyActionTests.kt
@@ -1,0 +1,679 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.indexmanagement.indexstatemanagement.transport.action.simulate
+
+import com.carrotsearch.randomizedtesting.annotations.ThreadLeakScope
+import com.nhaarman.mockitokotlin2.any
+import com.nhaarman.mockitokotlin2.doAnswer
+import com.nhaarman.mockitokotlin2.doReturn
+import com.nhaarman.mockitokotlin2.eq
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.whenever
+import org.junit.Before
+import org.mockito.Mockito
+import org.opensearch.OpenSearchStatusException
+import org.opensearch.Version
+import org.opensearch.action.admin.indices.rollover.RolloverInfo
+import org.opensearch.action.admin.indices.stats.CommonStats
+import org.opensearch.action.admin.indices.stats.IndicesStatsResponse
+import org.opensearch.action.get.GetResponse
+import org.opensearch.action.get.MultiGetItemResponse
+import org.opensearch.action.get.MultiGetResponse
+import org.opensearch.action.support.ActionFilters
+import org.opensearch.cluster.ClusterName
+import org.opensearch.cluster.ClusterState
+import org.opensearch.cluster.metadata.AliasMetadata
+import org.opensearch.cluster.metadata.IndexMetadata
+import org.opensearch.cluster.metadata.IndexNameExpressionResolver
+import org.opensearch.cluster.metadata.Metadata
+import org.opensearch.cluster.service.ClusterService
+import org.opensearch.common.settings.ClusterSettings
+import org.opensearch.common.settings.Settings
+import org.opensearch.common.unit.TimeValue
+import org.opensearch.common.xcontent.XContentFactory
+import org.opensearch.core.action.ActionListener
+import org.opensearch.core.common.bytes.BytesArray
+import org.opensearch.core.common.bytes.BytesReference
+import org.opensearch.core.common.unit.ByteSizeValue
+import org.opensearch.core.xcontent.NamedXContentRegistry
+import org.opensearch.core.xcontent.ToXContent
+import org.opensearch.index.shard.DocsStats
+import org.opensearch.indexmanagement.indexstatemanagement.IndexMetadataProvider
+import org.opensearch.indexmanagement.indexstatemanagement.model.Conditions
+import org.opensearch.indexmanagement.indexstatemanagement.model.Policy
+import org.opensearch.indexmanagement.indexstatemanagement.model.State
+import org.opensearch.indexmanagement.indexstatemanagement.model.Transition
+import org.opensearch.indexmanagement.indexstatemanagement.settings.ManagedIndexSettings
+import org.opensearch.indexmanagement.indexstatemanagement.util.managedIndexMetadataID
+import org.opensearch.indexmanagement.spi.indexstatemanagement.Step
+import org.opensearch.indexmanagement.spi.indexstatemanagement.model.ManagedIndexMetaData
+import org.opensearch.indexmanagement.spi.indexstatemanagement.model.PolicyRetryInfoMetaData
+import org.opensearch.indexmanagement.spi.indexstatemanagement.model.StateMetaData
+import org.opensearch.indexmanagement.spi.indexstatemanagement.model.StepContext
+import org.opensearch.test.OpenSearchTestCase
+import org.opensearch.transport.TransportService
+import org.opensearch.transport.client.AdminClient
+import org.opensearch.transport.client.Client
+import org.opensearch.transport.client.IndicesAdminClient
+import java.time.Instant
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+
+// Kotlin's Dispatchers.IO thread pool keeps idle workers alive after the test suite
+// completes.  Suppress the resulting thread-leak warnings rather than fighting the
+// scheduler's lifecycle.
+@ThreadLeakScope(ThreadLeakScope.Scope.NONE)
+class TransportSimulatePolicyActionTests : OpenSearchTestCase() {
+    companion object {
+        private const val INDEX_NAME = "test-index"
+        private const val INDEX_UUID = "test-uuid"
+        private const val POLICY_ID = "my-policy"
+    }
+
+    // RETURNS_DEEP_STUBS so that transportService.getTaskManager() (called in the
+    // TransportAction constructor) returns a stub instead of null.
+    private val transportService: TransportService = mock(defaultAnswer = Mockito.RETURNS_DEEP_STUBS)
+
+    // IndexMetadataProvider is final — must be instantiated (not mocked).
+    private lateinit var indexMetadataProvider: IndexMetadataProvider
+
+    @Before
+    fun setUpIndexMetadataProvider() {
+        val providerClusterService: ClusterService = mock()
+        whenever(providerClusterService.clusterSettings).thenReturn(
+            ClusterSettings(Settings.EMPTY, setOf(ManagedIndexSettings.RESTRICTED_INDEX_PATTERN)),
+        )
+        indexMetadataProvider = IndexMetadataProvider(Settings.EMPTY, mock(), providerClusterService, mutableMapOf())
+    }
+
+    // -------------------------------------------------------------------------
+    // Action / execution helpers
+    // -------------------------------------------------------------------------
+
+    private fun buildAction(
+        client: Client,
+        clusterService: ClusterService,
+        resolver: IndexNameExpressionResolver = passthroughResolver(),
+    ) = TransportSimulatePolicyAction(
+        client,
+        transportService,
+        ActionFilters(emptySet()),
+        clusterService,
+        NamedXContentRegistry.EMPTY,
+        indexMetadataProvider,
+        resolver,
+    )
+
+    /**
+     * A resolver that returns any concrete index name (no wildcards) unchanged.
+     * Used by tests that pass explicit index names and don't need pattern expansion.
+     */
+    private fun passthroughResolver(): IndexNameExpressionResolver {
+        val resolver = mock<IndexNameExpressionResolver>()
+        whenever(resolver.concreteIndexNames(any(), any(), any<String>())).thenAnswer { invocation ->
+            val pattern = invocation.getArgument<String>(2)
+            if (pattern.contains('*') || pattern.contains('?')) emptyArray() else arrayOf(pattern)
+        }
+        return resolver
+    }
+
+    /**
+     * Calls the public [execute] entry-point and blocks until the listener fires.
+     * Rethrows on failure so callers can use try/catch for expected exceptions.
+     */
+    private fun runSimulate(
+        action: TransportSimulatePolicyAction,
+        request: SimulatePolicyRequest,
+    ): SimulatePolicyResponse {
+        val latch = CountDownLatch(1)
+        var response: SimulatePolicyResponse? = null
+        var failure: Exception? = null
+
+        action.execute(
+            request,
+            object : ActionListener<SimulatePolicyResponse> {
+                override fun onResponse(r: SimulatePolicyResponse) {
+                    response = r
+                    latch.countDown()
+                }
+
+                override fun onFailure(e: Exception) {
+                    failure = e
+                    latch.countDown()
+                }
+            },
+        )
+
+        assertTrue("Timed out waiting for simulate response", latch.await(5, TimeUnit.SECONDS))
+        if (failure != null) throw failure!!
+        return response!!
+    }
+
+    // -------------------------------------------------------------------------
+    // IndexMetadata builder helpers
+    //
+    // IndexMetadata has final methods — build real instances via IndexMetadata.Builder
+    // rather than mocking, following the pattern used in ExtensionsTests.
+    // -------------------------------------------------------------------------
+
+    private fun buildIndexMetadata(
+        indexName: String = INDEX_NAME,
+        indexUUID: String = INDEX_UUID,
+        creationDate: Long = Instant.now().minusSeconds(86400L * 10).toEpochMilli(),
+        aliasNames: List<String> = emptyList(),
+        rolloverInfoMap: Map<String, Long> = emptyMap(),
+    ): IndexMetadata {
+        var builder =
+            IndexMetadata
+                .Builder(indexName)
+                .settings(
+                    settings(Version.CURRENT)
+                        .put(IndexMetadata.SETTING_INDEX_UUID, indexUUID)
+                        .put(IndexMetadata.SETTING_CREATION_DATE, creationDate)
+                        .build(),
+                )
+                .numberOfShards(1)
+                .numberOfReplicas(0)
+        aliasNames.forEach { builder = builder.putAlias(AliasMetadata.builder(it).build()) }
+        rolloverInfoMap.forEach { (alias, time) ->
+            builder = builder.putRolloverInfo(RolloverInfo(alias, emptyList(), time))
+        }
+        return builder.build()
+    }
+
+    // -------------------------------------------------------------------------
+    // ClusterService factory helpers
+    // -------------------------------------------------------------------------
+
+    private fun clusterServiceWithNoIndex(): ClusterService {
+        val clusterState = ClusterState.builder(ClusterName.DEFAULT).build()
+        return mock { on { state() } doReturn clusterState }
+    }
+
+    private fun clusterServiceWithIndex(
+        creationDate: Long = Instant.now().minusSeconds(86400L * 10).toEpochMilli(),
+        aliasNames: List<String> = emptyList(),
+        rolloverInfoMap: Map<String, Long> = emptyMap(),
+    ): ClusterService {
+        val indexMetadata = buildIndexMetadata(
+            creationDate = creationDate,
+            aliasNames = aliasNames,
+            rolloverInfoMap = rolloverInfoMap,
+        )
+        val clusterMetadata = Metadata.builder().put(indexMetadata, false).build()
+        val clusterState = ClusterState.builder(ClusterName.DEFAULT).metadata(clusterMetadata).build()
+        return mock { on { state() } doReturn clusterState }
+    }
+
+    // -------------------------------------------------------------------------
+    // Client factory helpers
+    // -------------------------------------------------------------------------
+
+    /** Client where multiGet returns an empty response → unmanaged index. */
+    private fun unmanagedClient(): Client {
+        val emptyMget: MultiGetResponse = mock { on { responses } doReturn emptyArray() }
+        val client = mock<Client>()
+        doAnswer { it.getArgument<ActionListener<MultiGetResponse>>(1).onResponse(emptyMget) }
+            .whenever(client).multiGet(any(), any())
+        return client
+    }
+
+    /** Client where multiGet returns serialised [managedMeta] → managed index. */
+    private fun managedClient(managedMeta: ManagedIndexMetaData): Client {
+        val bytes = serialisedMeta(managedMeta)
+        val innerGet: GetResponse =
+            mock {
+                on { isExists } doReturn true
+                on { sourceAsBytesRef } doReturn bytes
+                on { id } doReturn managedIndexMetadataID(INDEX_UUID)
+                on { seqNo } doReturn 0L
+                on { primaryTerm } doReturn 1L
+            }
+        val item: MultiGetItemResponse = mock { on { response } doReturn innerGet }
+        val mgetResp: MultiGetResponse = mock { on { responses } doReturn arrayOf(item) }
+        val client = mock<Client>()
+        doAnswer { it.getArgument<ActionListener<MultiGetResponse>>(1).onResponse(mgetResp) }
+            .whenever(client).multiGet(any(), any())
+        return client
+    }
+
+    /** Client that handles multiGet (unmanaged) AND index-level doc/size stats. */
+    private fun unmanagedClientWithStats(numDocs: Long, sizeBytes: Long): Client {
+        // Use real DocsStats and CommonStats objects to avoid Mockito stubbing issues with
+        // DocsStats.count / totalSizeInBytes inside mock { } blocks (those getters are final).
+        val realDocsStats = DocsStats.Builder().count(numDocs).totalSizeInBytes(sizeBytes).build()
+        val realCommonStats = CommonStats()
+        realCommonStats.docs = realDocsStats
+        val statsResp: IndicesStatsResponse = mock { on { primaries } doReturn realCommonStats }
+
+        val indicesAdmin: IndicesAdminClient = mock()
+        doAnswer { it.getArgument<ActionListener<IndicesStatsResponse>>(1).onResponse(statsResp) }
+            .whenever(indicesAdmin).stats(any(), any())
+        val adminMock: AdminClient = mock { on { indices() } doReturn indicesAdmin }
+
+        val emptyMget: MultiGetResponse = mock { on { responses } doReturn emptyArray() }
+        val client = mock<Client>()
+        doAnswer { it.getArgument<ActionListener<MultiGetResponse>>(1).onResponse(emptyMget) }
+            .whenever(client).multiGet(any(), any())
+        doReturn(adminMock).whenever(client).admin()
+        return client
+    }
+
+    // -------------------------------------------------------------------------
+    // Policy factory helpers
+    // -------------------------------------------------------------------------
+
+    /**
+     * Policy with a "hot" state (no actions, only [transitions]) plus terminal "warm" and
+     * "archive" states to satisfy [Policy.init] validation.
+     */
+    private fun policyWithTransitions(vararg transitions: Transition): Policy {
+        val hot = State(name = "hot", actions = emptyList(), transitions = listOf(*transitions))
+        val warm = State(name = "warm", actions = emptyList(), transitions = emptyList())
+        val archive = State(name = "archive", actions = emptyList(), transitions = emptyList())
+        return Policy(
+            id = POLICY_ID,
+            description = "test",
+            schemaVersion = 1L,
+            lastUpdatedTime = Instant.now(),
+            errorNotification = null,
+            defaultState = "hot",
+            states = listOf(hot, warm, archive),
+        )
+    }
+
+    /** Policy whose "hot" state has one action — index is not in the transition phase. */
+    private fun policyWithAction(): Policy {
+        // Action.type is a val constructor parameter (final getter) — cannot be stubbed
+        // by Mockito's subclass mock maker.  Use a concrete anonymous object instead.
+        val action =
+            object : org.opensearch.indexmanagement.spi.indexstatemanagement.Action("read_only", 0) {
+                override fun getSteps(): List<Step> = emptyList()
+
+                override fun getStepToExecute(context: StepContext): Step = throw UnsupportedOperationException("not used in this test")
+            }
+        val hot = State(name = "hot", actions = listOf(action), transitions = emptyList())
+        return Policy(
+            id = POLICY_ID,
+            description = "test",
+            schemaVersion = 1L,
+            lastUpdatedTime = Instant.now(),
+            errorNotification = null,
+            defaultState = "hot",
+            states = listOf(hot),
+        )
+    }
+
+    // -------------------------------------------------------------------------
+    // Serialisation helper
+    // -------------------------------------------------------------------------
+
+    private fun serialisedMeta(meta: ManagedIndexMetaData): BytesReference {
+        val builder = XContentFactory.jsonBuilder()
+        meta.toXContent(builder, ToXContent.EMPTY_PARAMS, forIndex = true)
+        return BytesArray(builder.toString().toByteArray(Charsets.UTF_8))
+    }
+
+    // =========================================================================
+    // Tests — simulateIndex paths
+    // =========================================================================
+
+    fun `test index not found returns error result`() {
+        val client: Client = mock()
+        val policy = policyWithTransitions(Transition("warm", null))
+        val request = SimulatePolicyRequest(listOf(INDEX_NAME), null, policy)
+
+        val response = runSimulate(buildAction(client, clusterServiceWithNoIndex()), request)
+
+        assertEquals(1, response.simulateResults.size)
+        val result = response.simulateResults.first()
+        assertEquals(INDEX_NAME, result.indexName)
+        assertNull(result.indexUUID)
+        assertFalse(result.isManaged)
+        assertNotNull(result.error)
+        assertTrue("Error should mention index name", result.error!!.contains(INDEX_NAME))
+    }
+
+    fun `test state referenced by managed metadata not found in policy returns error`() {
+        // Managed metadata says the index is in state "ghost" which the policy does not have.
+        val stateStartMillis = Instant.now().toEpochMilli()
+        val managedMeta =
+            ManagedIndexMetaData(
+                index = INDEX_NAME,
+                indexUuid = INDEX_UUID,
+                policyID = POLICY_ID,
+                policySeqNo = null,
+                policyPrimaryTerm = null,
+                policyCompleted = null,
+                rolledOver = null,
+                indexCreationDate = null,
+                transitionTo = null,
+                stateMetaData = StateMetaData(name = "ghost", startTime = stateStartMillis),
+                actionMetaData = null,
+                stepMetaData = null,
+                // Non-null so that toXContent(forIndex=true) writes an object rather than null,
+                // avoiding a parse failure in PolicyRetryInfoMetaData.parse().
+                policyRetryInfo = PolicyRetryInfoMetaData(failed = false, consumedRetries = 0),
+                info = null,
+            )
+        val client = managedClient(managedMeta)
+        // Policy has "hot", "warm", "archive" but not "ghost"
+        val policy = policyWithTransitions(Transition("warm", null))
+        val request = SimulatePolicyRequest(listOf(INDEX_NAME), null, policy)
+
+        val response = runSimulate(buildAction(client, clusterServiceWithIndex()), request)
+
+        val result = response.simulateResults.first()
+        assertNotNull(result.error)
+        assertTrue("Error should mention the missing state", result.error!!.contains("ghost"))
+    }
+
+    fun `test unmanaged index with actions shows current action and no transition evaluation`() {
+        val client = unmanagedClient()
+        val policy = policyWithAction()
+        val request = SimulatePolicyRequest(listOf(INDEX_NAME), null, policy)
+
+        val response = runSimulate(buildAction(client, clusterServiceWithIndex()), request)
+
+        val result = response.simulateResults.first()
+        assertNull(result.error)
+        assertFalse(result.isManaged)
+        assertNotNull("currentAction should be populated", result.currentAction)
+        assertNull("transitionEvaluation should be absent when not in transition phase", result.transitionEvaluation)
+        assertNull(result.nextState)
+    }
+
+    fun `test multiple indices are simulated independently`() {
+        // Cluster state contains INDEX_NAME but not "missing-index".
+        val indexMetadata = buildIndexMetadata()
+        val clusterMetadata = Metadata.builder().put(indexMetadata, false).build()
+        val clusterState = ClusterState.builder(ClusterName.DEFAULT).metadata(clusterMetadata).build()
+        val clusterService: ClusterService = mock { on { state() } doReturn clusterState }
+
+        val client = unmanagedClient()
+        val policy = policyWithTransitions(Transition("warm", null))
+        val request = SimulatePolicyRequest(listOf(INDEX_NAME, "missing-index"), null, policy)
+
+        val response = runSimulate(buildAction(client, clusterService), request)
+
+        assertEquals(2, response.simulateResults.size)
+        val found = response.simulateResults.find { it.indexName == INDEX_NAME }!!
+        val missing = response.simulateResults.find { it.indexName == "missing-index" }!!
+        assertNull(found.error)
+        assertNotNull(missing.error)
+    }
+
+    fun `test wildcard pattern expands to matching indices`() {
+        // Resolver expands "test-*" to the single known index
+        val resolver = mock<IndexNameExpressionResolver>()
+        whenever(resolver.concreteIndexNames(any(), any(), eq("test-*")))
+            .thenReturn(arrayOf(INDEX_NAME))
+
+        val client = unmanagedClient()
+        val policy = policyWithTransitions(Transition("warm", null))
+        val request = SimulatePolicyRequest(listOf("test-*"), null, policy)
+
+        val response = runSimulate(buildAction(client, clusterServiceWithIndex(), resolver), request)
+
+        assertEquals(1, response.simulateResults.size)
+        assertEquals(INDEX_NAME, response.simulateResults.first().indexName)
+        assertNull(response.simulateResults.first().error)
+    }
+
+    fun `test wildcard pattern matching no indices returns empty results`() {
+        // Resolver returns nothing for the pattern — silently dropped
+        val resolver = mock<IndexNameExpressionResolver>()
+        whenever(resolver.concreteIndexNames(any(), any(), eq("ghost-*")))
+            .thenReturn(emptyArray())
+
+        val client = unmanagedClient()
+        val policy = policyWithTransitions(Transition("warm", null))
+        val request = SimulatePolicyRequest(listOf("ghost-*"), null, policy)
+
+        val response = runSimulate(buildAction(client, clusterServiceWithIndex(), resolver), request)
+
+        assertTrue(response.simulateResults.isEmpty())
+    }
+
+    // =========================================================================
+    // Tests — evaluateTransition condition coverage
+    // =========================================================================
+
+    fun `test unconditional transition always fires`() {
+        val client = unmanagedClient()
+        val policy = policyWithTransitions(Transition("warm", null))
+        val request = SimulatePolicyRequest(listOf(INDEX_NAME), null, policy)
+
+        val response = runSimulate(buildAction(client, clusterServiceWithIndex()), request)
+
+        val result = response.simulateResults.first()
+        assertNull(result.error)
+        assertEquals(1, result.transitionEvaluation!!.size)
+        val t = result.transitionEvaluation!!.first()
+        assertTrue(t.conditionMet)
+        assertEquals("unconditional", t.conditionType)
+        assertNull(t.currentValue)
+        assertNull(t.requiredValue)
+        assertEquals("warm", result.nextState)
+    }
+
+    fun `test min index age condition met`() {
+        val client = unmanagedClient()
+        // Index is 10 days old; condition requires 7 days → met
+        val clusterService = clusterServiceWithIndex(
+            creationDate = Instant.now().minusSeconds(86400L * 10).toEpochMilli(),
+        )
+        val policy = policyWithTransitions(Transition("warm", Conditions(indexAge = TimeValue.timeValueDays(7))))
+        val request = SimulatePolicyRequest(listOf(INDEX_NAME), null, policy)
+
+        val response = runSimulate(buildAction(client, clusterService), request)
+
+        val t = response.simulateResults.first().transitionEvaluation!!.first()
+        assertTrue(t.conditionMet)
+        assertEquals(Conditions.MIN_INDEX_AGE_FIELD, t.conditionType)
+        assertNotNull(t.currentValue)
+        assertNotNull(t.requiredValue)
+        assertEquals("warm", response.simulateResults.first().nextState)
+    }
+
+    fun `test min index age condition not met`() {
+        val client = unmanagedClient()
+        // Index is 3 days old; condition requires 7 days → not met
+        val clusterService = clusterServiceWithIndex(
+            creationDate = Instant.now().minusSeconds(86400L * 3).toEpochMilli(),
+        )
+        val policy = policyWithTransitions(Transition("warm", Conditions(indexAge = TimeValue.timeValueDays(7))))
+        val request = SimulatePolicyRequest(listOf(INDEX_NAME), null, policy)
+
+        val response = runSimulate(buildAction(client, clusterService), request)
+
+        val t = response.simulateResults.first().transitionEvaluation!!.first()
+        assertFalse(t.conditionMet)
+        assertEquals(Conditions.MIN_INDEX_AGE_FIELD, t.conditionType)
+        assertNull(response.simulateResults.first().nextState)
+    }
+
+    fun `test min doc count condition fetches stats and evaluates`() {
+        // 1 000 docs; condition requires 500 → met
+        val client = unmanagedClientWithStats(numDocs = 1000L, sizeBytes = 0L)
+        val policy = policyWithTransitions(Transition("warm", Conditions(docCount = 500L)))
+        val request = SimulatePolicyRequest(listOf(INDEX_NAME), null, policy)
+
+        val response = runSimulate(buildAction(client, clusterServiceWithIndex()), request)
+
+        val t = response.simulateResults.first().transitionEvaluation!!.first()
+        assertEquals(Conditions.MIN_DOC_COUNT_FIELD, t.conditionType)
+        assertEquals("1000", t.currentValue)
+        assertEquals("500", t.requiredValue)
+        assertTrue(t.conditionMet)
+    }
+
+    fun `test min size condition fetches stats and evaluates`() {
+        val sizeBytes = 5L * 1024 * 1024 * 1024 // 5 GB — exceeds 1 GB condition
+        val client = unmanagedClientWithStats(numDocs = 0L, sizeBytes = sizeBytes)
+        val policy = policyWithTransitions(
+            Transition("warm", Conditions(size = ByteSizeValue(1L * 1024 * 1024 * 1024))),
+        )
+        val request = SimulatePolicyRequest(listOf(INDEX_NAME), null, policy)
+
+        val response = runSimulate(buildAction(client, clusterServiceWithIndex()), request)
+
+        val t = response.simulateResults.first().transitionEvaluation!!.first()
+        assertEquals(Conditions.MIN_SIZE_FIELD, t.conditionType)
+        assertNotNull(t.currentValue)
+        assertNotNull(t.requiredValue)
+        assertTrue(t.conditionMet)
+    }
+
+    fun `test min rollover age with no rollover history returns not met`() {
+        val client = unmanagedClient()
+        val policy = policyWithTransitions(Transition("warm", Conditions(rolloverAge = TimeValue.timeValueDays(1))))
+        val request = SimulatePolicyRequest(listOf(INDEX_NAME), null, policy)
+
+        val response = runSimulate(buildAction(client, clusterServiceWithIndex()), request)
+
+        val t = response.simulateResults.first().transitionEvaluation!!.first()
+        assertFalse(t.conditionMet)
+        assertEquals(Conditions.MIN_ROLLOVER_AGE_FIELD, t.conditionType)
+        assertEquals("index has never been rolled over", t.currentValue)
+    }
+
+    fun `test min rollover age with old enough rollover returns met`() {
+        // Rolled over 3 days ago; condition requires 1 day → met
+        val rolloverTime = Instant.now().minusSeconds(86400L * 3).toEpochMilli()
+        val client = unmanagedClient()
+        val clusterService = clusterServiceWithIndex(rolloverInfoMap = mapOf("my-alias" to rolloverTime))
+        val policy = policyWithTransitions(Transition("warm", Conditions(rolloverAge = TimeValue.timeValueDays(1))))
+        val request = SimulatePolicyRequest(listOf(INDEX_NAME), null, policy)
+
+        val response = runSimulate(buildAction(client, clusterService), request)
+
+        val t = response.simulateResults.first().transitionEvaluation!!.first()
+        assertTrue(t.conditionMet)
+        assertEquals(Conditions.MIN_ROLLOVER_AGE_FIELD, t.conditionType)
+        assertNotNull(t.currentValue)
+    }
+
+    fun `test no alias condition with zero aliases returns met`() {
+        val client = unmanagedClient()
+        val policy = policyWithTransitions(Transition("warm", Conditions(noAlias = true)))
+        val request = SimulatePolicyRequest(listOf(INDEX_NAME), null, policy)
+
+        val response = runSimulate(buildAction(client, clusterServiceWithIndex(aliasNames = emptyList())), request)
+
+        val t = response.simulateResults.first().transitionEvaluation!!.first()
+        assertEquals(Conditions.NO_ALIAS_FIELD, t.conditionType)
+        assertTrue(t.conditionMet)
+        assertEquals("no aliases", t.currentValue)
+    }
+
+    fun `test no alias condition with aliases present returns not met`() {
+        val client = unmanagedClient()
+        val clusterService = clusterServiceWithIndex(aliasNames = listOf("alias-0", "alias-1"))
+        val policy = policyWithTransitions(Transition("warm", Conditions(noAlias = true)))
+        val request = SimulatePolicyRequest(listOf(INDEX_NAME), null, policy)
+
+        val response = runSimulate(buildAction(client, clusterService), request)
+
+        val t = response.simulateResults.first().transitionEvaluation!!.first()
+        assertEquals(Conditions.NO_ALIAS_FIELD, t.conditionType)
+        assertFalse(t.conditionMet)
+        assertTrue("currentValue should include alias count", t.currentValue!!.contains("2"))
+    }
+
+    fun `test min state age with no state start time returns not met with unknown message`() {
+        // Unmanaged index → stateStartTime is null in the transition context
+        val client = unmanagedClient()
+        val policy = policyWithTransitions(Transition("warm", Conditions(minStateAge = TimeValue.timeValueDays(1))))
+        val request = SimulatePolicyRequest(listOf(INDEX_NAME), null, policy)
+
+        val response = runSimulate(buildAction(client, clusterServiceWithIndex()), request)
+
+        val t = response.simulateResults.first().transitionEvaluation!!.first()
+        assertEquals(Conditions.MIN_STATE_AGE_FIELD, t.conditionType)
+        assertFalse(t.conditionMet)
+        assertTrue("currentValue should describe unknown state start", t.currentValue!!.contains("unknown"))
+    }
+
+    fun `test min state age with known state start time returns met`() {
+        // State started 2 days ago; condition requires 1 day → met
+        val stateStartMillis = Instant.now().minusSeconds(86400L * 2).toEpochMilli()
+        val managedMeta =
+            ManagedIndexMetaData(
+                index = INDEX_NAME,
+                indexUuid = INDEX_UUID,
+                policyID = POLICY_ID,
+                policySeqNo = null,
+                policyPrimaryTerm = null,
+                policyCompleted = null,
+                rolledOver = null,
+                indexCreationDate = null,
+                transitionTo = null,
+                stateMetaData = StateMetaData(name = "hot", startTime = stateStartMillis),
+                actionMetaData = null,
+                stepMetaData = null,
+                // Non-null so that toXContent(forIndex=true) writes an object rather than null,
+                // avoiding a parse failure in PolicyRetryInfoMetaData.parse().
+                policyRetryInfo = PolicyRetryInfoMetaData(failed = false, consumedRetries = 0),
+                info = null,
+            )
+        val client = managedClient(managedMeta)
+        val policy = policyWithTransitions(Transition("warm", Conditions(minStateAge = TimeValue.timeValueDays(1))))
+        val request = SimulatePolicyRequest(listOf(INDEX_NAME), null, policy)
+
+        val response = runSimulate(buildAction(client, clusterServiceWithIndex()), request)
+
+        val result = response.simulateResults.first()
+        assertNull(result.error)
+        assertTrue(result.isManaged)
+        val t = result.transitionEvaluation!!.first()
+        assertEquals(Conditions.MIN_STATE_AGE_FIELD, t.conditionType)
+        assertTrue(t.conditionMet)
+        assertNotNull(t.currentValue)
+        assertEquals("warm", result.nextState)
+    }
+
+    fun `test first matching transition wins when multiple exist`() {
+        val client = unmanagedClient()
+        // Index is 10 days old; first transition needs 30 d (not met), second needs 7 d (met)
+        val clusterService = clusterServiceWithIndex(
+            creationDate = Instant.now().minusSeconds(86400L * 10).toEpochMilli(),
+        )
+        val policy = policyWithTransitions(
+            Transition("archive", Conditions(indexAge = TimeValue.timeValueDays(30))),
+            Transition("warm", Conditions(indexAge = TimeValue.timeValueDays(7))),
+        )
+        val request = SimulatePolicyRequest(listOf(INDEX_NAME), null, policy)
+
+        val response = runSimulate(buildAction(client, clusterService), request)
+
+        val evals = response.simulateResults.first().transitionEvaluation!!
+        assertEquals(2, evals.size)
+        assertFalse("30-day transition should not be met", evals[0].conditionMet)
+        assertTrue("7-day transition should be met", evals[1].conditionMet)
+        assertEquals("warm", response.simulateResults.first().nextState)
+    }
+
+    // =========================================================================
+    // Tests — resolvePolicy path
+    // =========================================================================
+
+    fun `test policy not found by id propagates failure`() {
+        val notFoundGet: GetResponse = mock { on { isExists } doReturn false }
+        val client = mock<Client>()
+        doAnswer { it.getArgument<ActionListener<GetResponse>>(1).onResponse(notFoundGet) }
+            .whenever(client).get(any(), any())
+
+        val request = SimulatePolicyRequest(listOf(INDEX_NAME), POLICY_ID, null)
+
+        try {
+            runSimulate(buildAction(client, clusterServiceWithNoIndex()), request)
+            fail("Expected OpenSearchStatusException for missing policy")
+        } catch (e: OpenSearchStatusException) {
+            assertTrue("Exception should mention policy id", e.message!!.contains(POLICY_ID))
+        }
+    }
+}

--- a/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/transport/action/simulate/TransportSimulatePolicyActionTests.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/transport/action/simulate/TransportSimulatePolicyActionTests.kt
@@ -20,8 +20,6 @@ import org.opensearch.action.admin.indices.rollover.RolloverInfo
 import org.opensearch.action.admin.indices.stats.CommonStats
 import org.opensearch.action.admin.indices.stats.IndicesStatsResponse
 import org.opensearch.action.get.GetResponse
-import org.opensearch.action.get.MultiGetItemResponse
-import org.opensearch.action.get.MultiGetResponse
 import org.opensearch.action.support.ActionFilters
 import org.opensearch.cluster.ClusterName
 import org.opensearch.cluster.ClusterState
@@ -33,6 +31,7 @@ import org.opensearch.cluster.service.ClusterService
 import org.opensearch.common.settings.ClusterSettings
 import org.opensearch.common.settings.Settings
 import org.opensearch.common.unit.TimeValue
+import org.opensearch.common.util.concurrent.ThreadContext
 import org.opensearch.common.xcontent.XContentFactory
 import org.opensearch.core.action.ActionListener
 import org.opensearch.core.common.bytes.BytesArray
@@ -54,6 +53,7 @@ import org.opensearch.indexmanagement.spi.indexstatemanagement.model.PolicyRetry
 import org.opensearch.indexmanagement.spi.indexstatemanagement.model.StateMetaData
 import org.opensearch.indexmanagement.spi.indexstatemanagement.model.StepContext
 import org.opensearch.test.OpenSearchTestCase
+import org.opensearch.threadpool.ThreadPool
 import org.opensearch.transport.TransportService
 import org.opensearch.transport.client.AdminClient
 import org.opensearch.transport.client.Client
@@ -212,16 +212,25 @@ class TransportSimulatePolicyActionTests : OpenSearchTestCase() {
     // Client factory helpers
     // -------------------------------------------------------------------------
 
-    /** Client where multiGet returns an empty response → unmanaged index. */
+    /** Stubs client.threadPool().threadContext so stashContext() doesn't NPE. */
+    private fun stubThreadPool(client: Client) {
+        val ctx = ThreadContext(Settings.EMPTY)
+        val threadPool = Mockito.mock(ThreadPool::class.java)
+        Mockito.`when`(threadPool.threadContext).thenReturn(ctx)
+        Mockito.`when`(client.threadPool()).thenReturn(threadPool)
+    }
+
+    /** Client where get() returns isExists=false → unmanaged index (no metadata doc). */
     private fun unmanagedClient(): Client {
-        val emptyMget: MultiGetResponse = mock { on { responses } doReturn emptyArray() }
+        val notFoundGet: GetResponse = mock { on { isExists } doReturn false }
         val client = mock<Client>()
-        doAnswer { it.getArgument<ActionListener<MultiGetResponse>>(1).onResponse(emptyMget) }
-            .whenever(client).multiGet(any(), any())
+        doAnswer { it.getArgument<ActionListener<GetResponse>>(1).onResponse(notFoundGet) }
+            .whenever(client).get(any(), any())
+        stubThreadPool(client)
         return client
     }
 
-    /** Client where multiGet returns serialised [managedMeta] → managed index. */
+    /** Client where get() returns serialised [managedMeta] → managed index. */
     private fun managedClient(managedMeta: ManagedIndexMetaData): Client {
         val bytes = serialisedMeta(managedMeta)
         val innerGet: GetResponse =
@@ -232,15 +241,14 @@ class TransportSimulatePolicyActionTests : OpenSearchTestCase() {
                 on { seqNo } doReturn 0L
                 on { primaryTerm } doReturn 1L
             }
-        val item: MultiGetItemResponse = mock { on { response } doReturn innerGet }
-        val mgetResp: MultiGetResponse = mock { on { responses } doReturn arrayOf(item) }
         val client = mock<Client>()
-        doAnswer { it.getArgument<ActionListener<MultiGetResponse>>(1).onResponse(mgetResp) }
-            .whenever(client).multiGet(any(), any())
+        doAnswer { it.getArgument<ActionListener<GetResponse>>(1).onResponse(innerGet) }
+            .whenever(client).get(any(), any())
+        stubThreadPool(client)
         return client
     }
 
-    /** Client that handles multiGet (unmanaged) AND index-level doc/size stats. */
+    /** Client that handles get() (unmanaged) AND index-level doc/size stats. */
     private fun unmanagedClientWithStats(numDocs: Long, sizeBytes: Long): Client {
         // Use real DocsStats and CommonStats objects to avoid Mockito stubbing issues with
         // DocsStats.count / totalSizeInBytes inside mock { } blocks (those getters are final).
@@ -254,11 +262,12 @@ class TransportSimulatePolicyActionTests : OpenSearchTestCase() {
             .whenever(indicesAdmin).stats(any(), any())
         val adminMock: AdminClient = mock { on { indices() } doReturn indicesAdmin }
 
-        val emptyMget: MultiGetResponse = mock { on { responses } doReturn emptyArray() }
+        val notFoundGet: GetResponse = mock { on { isExists } doReturn false }
         val client = mock<Client>()
-        doAnswer { it.getArgument<ActionListener<MultiGetResponse>>(1).onResponse(emptyMget) }
-            .whenever(client).multiGet(any(), any())
+        doAnswer { it.getArgument<ActionListener<GetResponse>>(1).onResponse(notFoundGet) }
+            .whenever(client).get(any(), any())
         doReturn(adminMock).whenever(client).admin()
+        stubThreadPool(client)
         return client
     }
 
@@ -323,6 +332,7 @@ class TransportSimulatePolicyActionTests : OpenSearchTestCase() {
 
     fun `test index not found returns error result`() {
         val client: Client = mock()
+        stubThreadPool(client)
         val policy = policyWithTransitions(Transition("warm", null))
         val request = SimulatePolicyRequest(listOf(INDEX_NAME), null, policy)
 
@@ -666,6 +676,7 @@ class TransportSimulatePolicyActionTests : OpenSearchTestCase() {
         val client = mock<Client>()
         doAnswer { it.getArgument<ActionListener<GetResponse>>(1).onResponse(notFoundGet) }
             .whenever(client).get(any(), any())
+        stubThreadPool(client)
 
         val request = SimulatePolicyRequest(listOf(INDEX_NAME), POLICY_ID, null)
 


### PR DESCRIPTION
## Description

Adds a new read-only **Simulate API** for ISM policies that lets users preview what a policy would do to one or more indices — without applying the policy or modifying any cluster state.

### Problem

There is no way to dry-run an ISM policy. Users who want to verify a policy's behavior must apply it to a live index and wait for the ISM runner to cycle.  This is risky on production clusters and slow during development.

### Solution

```
POST /_plugins/_ism/simulate
```

Accepts either a stored policy by ID or an inline policy body, and a list of index names or wildcard patterns:

```json
{
  "policy_id": "my-lifecycle-policy",
  "indices": ["logs-2024-01", "logs-prod-*"]
}
```

```json
{
  "policy": { ... },
  "indices": ["logs-2024-01"]
}
```

For each index the response reports:
- Whether the index is currently managed by ISM (`is_managed`)
- The state it is in (or would start in) and the action that would execute next
- A per-transition breakdown — condition type, current metric value, required threshold, and whether the condition is met
- The state the index would transition to next (`next_state`), or `null` if no condition is satisfied

Example response:

```json
{
  "simulate_results": [
    {
      "index_name": "logs-2024-01",
      "policy_id": "my-lifecycle-policy",
      "is_managed": true,
      "current_state": "hot",
      "current_action": "transition",
      "transition_evaluation": [
        {
          "state_name": "warm",
          "condition_met": true,
          "condition_type": "min_index_age",
          "current_value": "8d 3h",
          "required_value": "7d"
        },
        {
          "state_name": "archive",
          "condition_met": false,
          "condition_type": "min_doc_count",
          "current_value": "340",
          "required_value": "1000"
        }
      ],
      "next_state": "warm"
    }
  ]
}
```

### What is covered

- **All transition condition types**: `min_index_age`, `min_doc_count`, `min_size`, `min_rollover_age`, `min_state_age`, `no_alias`, cron
- **Inline policy support**: test a policy body before saving it
- **Wildcard index patterns**: `logs-*` expands to all matching indices using `IndexNameExpressionResolver` with lenient options; patterns matching no indices return an empty result set
- **Managed vs unmanaged indices**: for managed indices the simulation uses the real execution position from ISM metadata; for unmanaged indices it starts from the policy's `default_state`
- **Action vs transition phase**: if the index is currently executing an action (not yet at transitions), the response reports `current_action` and omits `transition_evaluation` — matching actual ISM runner behavior


### Testing

- 19 new unit tests covering: index not found, policy not found, managed/unmanaged indices, all condition types (age, doc count, size, rollover age, state age, no-alias, cron), unconditional transitions, multiple indices, wildcard expansion, and no-match patterns
- Manual testing via `./gradlew run` against a local cluster
<img width="1091" height="316" alt="image" src="https://github.com/user-attachments/assets/98d9fb2d-41fd-4313-99ff-537883973be3" />
<img width="980" height="557" alt="image" src="https://github.com/user-attachments/assets/767b8d39-1b8d-430f-bf77-5b7989653427" />



### Related Issues
Resolves #1620
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/index-management/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
