### PR TITLE
Don't fail transition condition verification on zero size set

### DIFF
--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/model/Transition.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/model/Transition.kt
@@ -87,7 +87,7 @@ data class Conditions(
     Writeable {
     init {
         val conditionsList = listOf(indexAge, docCount, size, cron, rolloverAge, noAlias, minStateAge)
-        require(conditionsList.filterNotNull().size == 1) { "Cannot provide more than one Transition condition" }
+        require(conditionsList.filterNotNull().size <= 1) { "Cannot provide more than one Transition condition" }
 
         // Validate doc count condition
         if (docCount != null) require(docCount > 0) { "Transition doc count condition must be greater than 0" }


### PR DESCRIPTION
If one provides `conditions = {}` instead of Null the check fails, providing the user with a confusing error message. This fixes that, empty condition sets should be valid.
