### PR TITLE
Add optional routing support to rollup jobs

### DIFF
--- a/src/main/kotlin/org/opensearch/indexmanagement/rollup/RollupIndexer.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/rollup/RollupIndexer.kt
@@ -18,6 +18,8 @@ import org.opensearch.common.io.stream.BytesStreamOutput
 import org.opensearch.common.settings.Settings
 import org.opensearch.common.xcontent.XContentType
 import org.opensearch.core.rest.RestStatus
+import org.opensearch.indexmanagement.common.model.dimension.Dimension
+import org.opensearch.indexmanagement.common.model.dimension.Terms
 import org.opensearch.indexmanagement.opensearchapi.retry
 import org.opensearch.indexmanagement.opensearchapi.suspendUntil
 import org.opensearch.indexmanagement.rollup.model.Rollup
@@ -144,6 +146,17 @@ class RollupIndexer(
                 IndexRequest(targetIndexResolvedName)
                     .id(documentId)
                     .source(mapOfKeyValues, XContentType.JSON)
+            if (job.routingField != null) {
+                val routingKey = job.dimensions
+                    .firstOrNull { dim -> dim is Terms && dim.sourceField == job.routingField }
+                    ?.let { dim -> "${dim.targetField}.${Dimension.Type.TERMS.type}" }
+                if (routingKey != null) {
+                    val routingValue = it.key[routingKey]?.toString()
+                    if (routingValue != null) {
+                        indexRequest.routing(routingValue)
+                    }
+                }
+            }
             requests.add(indexRequest)
         }
         return requests

--- a/src/main/kotlin/org/opensearch/indexmanagement/rollup/action/index/TransportIndexRollupAction.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/rollup/action/index/TransportIndexRollupAction.kt
@@ -155,6 +155,7 @@ constructor(
             if (rollup.metrics != newRollup.metrics) modified.add(Rollup.METRICS_FIELD)
             if (rollup.sourceIndex != newRollup.sourceIndex) modified.add(Rollup.SOURCE_INDEX_FIELD)
             if (rollup.targetIndex != newRollup.targetIndex) modified.add(Rollup.TARGET_INDEX_FIELD)
+            if (rollup.routingField != newRollup.routingField) modified.add(Rollup.ROUTING_FIELD)
             return modified.toList()
         }
 

--- a/src/main/kotlin/org/opensearch/indexmanagement/rollup/model/ISMRollup.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/rollup/model/ISMRollup.kt
@@ -36,6 +36,7 @@ data class ISMRollup(
     val dimensions: List<Dimension>,
     val metrics: List<RollupMetrics>,
     val sourceIndex: String? = null,
+    val routingField: String? = null,
 ) : ToXContentObject,
     Writeable {
     // TODO: This can be moved to a common place, since this is shared between Rollup and ISMRollup
@@ -50,6 +51,11 @@ data class ISMRollup(
             "Must specify precisely one date histogram dimension"
         }
         require(dimensions.first().type == Dimension.Type.DATE_HISTOGRAM) { "The first dimension must be a date histogram" }
+        if (routingField != null) {
+            require(dimensions.any { it is Terms && it.sourceField == routingField }) {
+                "Routing field [$routingField] must match a terms dimension"
+            }
+        }
     }
 
     override fun toXContent(builder: XContentBuilder, params: ToXContent.Params): XContentBuilder {
@@ -61,6 +67,9 @@ data class ISMRollup(
             .field(Rollup.METRICS_FIELD, metrics)
         if (sourceIndex != null) {
             builder.field(Rollup.SOURCE_INDEX_FIELD, sourceIndex)
+        }
+        if (routingField != null) {
+            builder.field(Rollup.ROUTING_FIELD, routingField)
         }
         if (targetIndexSettings != null) {
             builder.startObject(Rollup.TARGET_INDEX_SETTINGS_FIELD)
@@ -102,6 +111,7 @@ data class ISMRollup(
             dimensions = dimensions,
             metrics = metrics,
             user = user,
+            routingField = routingField,
         )
     }
 
@@ -134,6 +144,11 @@ data class ISMRollup(
         metrics = sin.readList(::RollupMetrics),
         sourceIndex = if (sin.version.onOrAfter(Version.V_3_5_0) && sin.readBoolean()) {
             sin.readString()
+        } else {
+            null
+        },
+        routingField = if (sin.version.onOrAfter(Version.V_3_7_0)) {
+            sin.readOptionalString()
         } else {
             null
         },
@@ -180,6 +195,9 @@ data class ISMRollup(
             out.writeBoolean(sourceIndex != null)
             if (sourceIndex != null) out.writeString(sourceIndex)
         }
+        if (out.version.onOrAfter(Version.V_3_7_0)) {
+            out.writeOptionalString(routingField)
+        }
     }
 
     companion object {
@@ -196,6 +214,7 @@ data class ISMRollup(
             var pageSize = 0
             val dimensions = mutableListOf<Dimension>()
             val metrics = mutableListOf<RollupMetrics>()
+            var routingField: String? = null
 
             XContentParserUtils.ensureExpectedToken(XContentParser.Token.START_OBJECT, xcp.currentToken(), xcp)
 
@@ -243,6 +262,8 @@ data class ISMRollup(
                         }
                     }
 
+                    Rollup.ROUTING_FIELD -> routingField = xcp.textOrNull()
+
                     else -> throw IllegalArgumentException("Invalid field, [$fieldName] not supported in ISM Rollup.")
                 }
             }
@@ -255,6 +276,7 @@ data class ISMRollup(
                 targetIndex = targetIndex,
                 targetIndexSettings = targetIndexSettings,
                 sourceIndex = sourceIndex,
+                routingField = routingField,
             )
         }
     }

--- a/src/main/kotlin/org/opensearch/indexmanagement/rollup/model/Rollup.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/rollup/model/Rollup.kt
@@ -59,6 +59,7 @@ data class Rollup(
     val dimensions: List<Dimension>,
     val metrics: List<RollupMetrics>,
     val user: User? = null,
+    val routingField: String? = null,
 ) : ScheduledJobParameter,
     Writeable {
     init {
@@ -105,6 +106,11 @@ data class Rollup(
         if (delay != null) {
             require(delay >= MINIMUM_DELAY) { "Delay must be non-negative if set" }
             require(delay <= Instant.now().toEpochMilli()) { "Delay must be less than the current unix time" }
+        }
+        if (routingField != null) {
+            require(dimensions.any { it is Terms && it.sourceField == routingField }) {
+                "Routing field [$routingField] must match a terms dimension"
+            }
         }
     }
 
@@ -172,6 +178,11 @@ data class Rollup(
         } else {
             null
         },
+        routingField = if (sin.getVersion().onOrAfter(Version.V_3_7_0)) {
+            sin.readOptionalString()
+        } else {
+            null
+        },
     )
 
     override fun toXContent(builder: XContentBuilder, params: ToXContent.Params): XContentBuilder {
@@ -192,6 +203,9 @@ data class Rollup(
             .field(CONTINUOUS_FIELD, continuous)
             .field(DIMENSIONS_FIELD, dimensions.toTypedArray())
             .field(RollupMetrics.METRICS_FIELD, metrics.toTypedArray())
+        if (routingField != null) {
+            builder.field(ROUTING_FIELD, routingField)
+        }
         if (targetIndexSettings != null) {
             builder.startObject(TARGET_INDEX_SETTINGS_FIELD)
             targetIndexSettings.toXContent(builder, params)
@@ -241,6 +255,9 @@ data class Rollup(
         out.writeCollection(metrics)
         out.writeBoolean(user != null)
         user?.writeTo(out)
+        if (out.version.onOrAfter(Version.V_3_7_0)) {
+            out.writeOptionalString(routingField)
+        }
     }
 
     companion object {
@@ -269,6 +286,7 @@ data class Rollup(
         const val CONTINUOUS_FIELD = "continuous"
         const val DIMENSIONS_FIELD = "dimensions"
         const val METRICS_FIELD = "metrics"
+        const val ROUTING_FIELD = "routing_field"
         const val MINIMUM_JOB_INTERVAL = 1
         const val MINIMUM_DELAY = 0
         const val MINIMUM_PAGE_SIZE = 1
@@ -308,6 +326,7 @@ data class Rollup(
             val dimensions = mutableListOf<Dimension>()
             val metrics = mutableListOf<RollupMetrics>()
             var user: User? = null
+            var routingField: String? = null
 
             ensureExpectedToken(Token.START_OBJECT, xcp.currentToken(), xcp)
 
@@ -375,6 +394,8 @@ data class Rollup(
                         user = if (xcp.currentToken() == Token.VALUE_NULL) null else User.parse(xcp)
                     }
 
+                    ROUTING_FIELD -> routingField = xcp.textOrNull()
+
                     else -> throw IllegalArgumentException("Invalid field [$fieldName] found in Rollup.")
                 }
             }
@@ -413,6 +434,7 @@ data class Rollup(
                 dimensions = dimensions,
                 metrics = metrics,
                 user = user,
+                routingField = routingField,
             )
         }
     }

--- a/src/main/resources/mappings/opendistro-ism-config.json
+++ b/src/main/resources/mappings/opendistro-ism-config.json
@@ -1,6 +1,6 @@
 {
   "_meta" : {
-    "schema_version": 28
+    "schema_version": 29
   },
   "dynamic": "strict",
   "properties": {
@@ -501,6 +501,9 @@
                               }
                             }
                           }
+                        },
+                        "routing_field": {
+                          "type": "keyword"
                         }
                       }
                     }
@@ -1064,6 +1067,9 @@
         "continuous": {
           "type": "boolean"
         },
+        "routing_field": {
+          "type": "keyword"
+        },
         "roles": {
           "type": "text",
           "fields": {
@@ -1430,6 +1436,9 @@
         },
         "continuous": {
           "type": "boolean"
+        },
+        "routing_field": {
+          "type": "keyword"
         }
       }
     },

--- a/src/test/kotlin/org/opensearch/indexmanagement/IndexManagementRestTestCase.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/IndexManagementRestTestCase.kt
@@ -41,7 +41,7 @@ import javax.management.remote.JMXConnectorFactory
 import javax.management.remote.JMXServiceURL
 
 abstract class IndexManagementRestTestCase : ODFERestTestCase() {
-    val configSchemaVersion = 28
+    val configSchemaVersion = 29
     val historySchemaVersion = 7
 
     // Having issues with tests leaking into other tests and mappings being incorrect and they are not caught by any pending task wait check as

--- a/src/test/kotlin/org/opensearch/indexmanagement/rollup/model/ISMRollupTests.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/rollup/model/ISMRollupTests.kt
@@ -304,4 +304,97 @@ class ISMRollupTests : OpenSearchTestCase() {
         assertEquals(original.sourceIndex, parsedFromStream.sourceIndex)
         assertEquals(original.pageSize, parsedFromStream.pageSize)
     }
+
+    fun `test ism rollup routing field must match a terms dimension`() {
+        assertFailsWith(IllegalArgumentException::class, "Routing field must match a terms dimension") {
+            randomISMRollup().copy(routingField = "nonexistent_field")
+        }
+    }
+
+    fun `test ism rollup routing field accepts valid terms dimension`() {
+        val terms = randomTerms()
+        val dimensions = listOf(randomDateHistogram(), terms)
+        // Should not throw
+        randomISMRollup().copy(dimensions = dimensions, routingField = terms.sourceField)
+    }
+
+    fun `test ism rollup routing field accepts null`() {
+        // Should not throw
+        randomISMRollup().copy(routingField = null)
+    }
+
+    fun `test ism rollup toRollup preserves routing field`() {
+        val terms = randomTerms()
+        val dimensions = listOf(randomDateHistogram(), terms)
+        val ismRollup = randomISMRollup().copy(dimensions = dimensions, routingField = terms.sourceField)
+        val rollup = ismRollup.toRollup("source-index")
+        assertEquals(terms.sourceField, rollup.routingField)
+    }
+
+    fun `test ism rollup toRollup preserves null routing field`() {
+        val ismRollup = randomISMRollup().copy(routingField = null)
+        val rollup = ismRollup.toRollup("source-index")
+        assertNull(rollup.routingField)
+    }
+
+    fun `test ism rollup serialization with routing field`() {
+        val terms = randomTerms()
+        val dimensions = listOf(randomDateHistogram(), terms)
+        val ismRollup = randomISMRollup().copy(dimensions = dimensions, routingField = terms.sourceField)
+        val jsonString = ismRollup.toJsonString()
+
+        assertTrue(jsonString.contains("routing_field"))
+
+        val parser = createParser(XContentType.JSON.xContent(), jsonString)
+        parser.nextToken()
+        val parsed = ISMRollup.parse(parser)
+
+        assertEquals(terms.sourceField, parsed.routingField)
+    }
+
+    fun `test ism rollup serialization without routing field`() {
+        val ismRollup = randomISMRollup().copy(routingField = null)
+        val jsonString = ismRollup.toJsonString()
+
+        assertFalse(jsonString.contains("routing_field"))
+
+        val parser = createParser(XContentType.JSON.xContent(), jsonString)
+        parser.nextToken()
+        val parsed = ISMRollup.parse(parser)
+
+        assertNull(parsed.routingField)
+    }
+
+    fun `test ism rollup stream serialization with routing field on V3_7_0`() {
+        val terms = randomTerms()
+        val dimensions = listOf(randomDateHistogram(), terms)
+        val ismRollup = randomISMRollup().copy(dimensions = dimensions, routingField = terms.sourceField, sourceIndex = null)
+
+        val output = BytesStreamOutput()
+        output.version = Version.V_3_7_0
+        ismRollup.writeTo(output)
+
+        val input = StreamInput.wrap(output.bytes().toBytesRef().bytes)
+        input.version = Version.V_3_7_0
+        val parsed = ISMRollup(input)
+
+        assertEquals(terms.sourceField, parsed.routingField)
+    }
+
+    fun `test ism rollup stream serialization backward compatibility routing field with V3_6_0`() {
+        val terms = randomTerms()
+        val dimensions = listOf(randomDateHistogram(), terms)
+        val ismRollup = randomISMRollup().copy(dimensions = dimensions, routingField = terms.sourceField, sourceIndex = null)
+
+        val output = BytesStreamOutput()
+        output.version = Version.V_3_6_0
+        ismRollup.writeTo(output)
+
+        val input = StreamInput.wrap(output.bytes().toBytesRef().bytes)
+        input.version = Version.V_3_6_0
+        val parsed = ISMRollup(input)
+
+        // routingField should be null when reading from older version
+        assertNull(parsed.routingField)
+    }
 }

--- a/src/test/kotlin/org/opensearch/indexmanagement/rollup/model/RollupTests.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/rollup/model/RollupTests.kt
@@ -125,4 +125,29 @@ class RollupTests : OpenSearchTestCase() {
             )
         assertNull(nonContinuousRollup.jobSchedule.delay)
     }
+
+    fun `test rollup routing field must match a terms dimension`() {
+        assertFailsWith(IllegalArgumentException::class, "Routing field must match a terms dimension") {
+            randomRollup().copy(routingField = "nonexistent_field")
+        }
+    }
+
+    fun `test rollup routing field cannot be a date histogram dimension`() {
+        val dimensions = listOf(randomDateHistogram(), randomTerms())
+        assertFailsWith(IllegalArgumentException::class, "Routing field must match a terms dimension") {
+            randomRollup().copy(dimensions = dimensions, routingField = dimensions[0].sourceField)
+        }
+    }
+
+    fun `test rollup routing field accepts valid terms dimension`() {
+        val terms = randomTerms()
+        val dimensions = listOf(randomDateHistogram(), terms)
+        // Should not throw
+        randomRollup().copy(dimensions = dimensions, routingField = terms.sourceField)
+    }
+
+    fun `test rollup routing field accepts null`() {
+        // Should not throw
+        randomRollup().copy(routingField = null)
+    }
 }

--- a/src/test/kotlin/org/opensearch/indexmanagement/rollup/model/WriteableTests.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/rollup/model/WriteableTests.kt
@@ -5,6 +5,7 @@
 
 package org.opensearch.indexmanagement.rollup.model
 
+import org.opensearch.Version
 import org.opensearch.common.io.stream.BytesStreamOutput
 import org.opensearch.core.common.io.stream.StreamInput
 import org.opensearch.indexmanagement.common.model.dimension.DateHistogram
@@ -175,6 +176,50 @@ class WriteableTests : OpenSearchTestCase() {
         val sin = StreamInput.wrap(out.bytes().toBytesRef().bytes)
         val streamedRollupMetadata = RollupMetadata(sin)
         assertEquals("Round tripping RollupMetadata stream doesn't work", rollupMetadata, streamedRollupMetadata)
+    }
+
+    fun `test rollup as stream with routing field`() {
+        val terms = randomTerms()
+        val dimensions = listOf(randomDateHistogram(), terms)
+        val rollup = randomRollup().copy(
+            delay = randomLongBetween(0, 60000000),
+            dimensions = dimensions,
+            routingField = terms.sourceField,
+        )
+        val out = BytesStreamOutput().also { rollup.writeTo(it) }
+        val sin = StreamInput.wrap(out.bytes().toBytesRef().bytes)
+        val streamedRollup = Rollup(sin)
+        assertEquals("Round tripping Rollup with routing field doesn't work", rollup, streamedRollup)
+    }
+
+    fun `test rollup as stream without routing field`() {
+        val rollup = randomRollup().copy(delay = randomLongBetween(0, 60000000), routingField = null)
+        val out = BytesStreamOutput().also { rollup.writeTo(it) }
+        val sin = StreamInput.wrap(out.bytes().toBytesRef().bytes)
+        val streamedRollup = Rollup(sin)
+        assertEquals("Round tripping Rollup without routing field doesn't work", rollup, streamedRollup)
+        assertNull(streamedRollup.routingField)
+    }
+
+    fun `test rollup stream serialization backward compatibility routing field with V3_6_0`() {
+        val terms = randomTerms()
+        val dimensions = listOf(randomDateHistogram(), terms)
+        val rollup = randomRollup().copy(
+            delay = randomLongBetween(0, 60000000),
+            dimensions = dimensions,
+            routingField = terms.sourceField,
+        )
+
+        val output = BytesStreamOutput()
+        output.version = Version.V_3_6_0
+        rollup.writeTo(output)
+
+        val input = StreamInput.wrap(output.bytes().toBytesRef().bytes)
+        input.version = Version.V_3_6_0
+        val parsed = Rollup(input)
+
+        // routingField should be null when reading from older version
+        assertNull("Routing field should be null on older version", parsed.routingField)
     }
 
     fun `test ism rollup as stream`() {

--- a/src/test/kotlin/org/opensearch/indexmanagement/rollup/model/XContentTests.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/rollup/model/XContentTests.kt
@@ -137,6 +137,28 @@ class XContentTests : OpenSearchTestCase() {
         assertEquals("Round tripping Rollup with target index settings doesn't work", rollup.copy(roles = listOf()), parsedRollup)
     }
 
+    fun `test rollup parsing with routing field`() {
+        val terms = randomTerms()
+        val dimensions = listOf(randomDateHistogram(), terms)
+        val rollup = randomRollup().copy(
+            delay = randomLongBetween(0, 60000000),
+            dimensions = dimensions,
+            routingField = terms.sourceField,
+        )
+        val rollupString = rollup.toJsonString(XCONTENT_WITHOUT_TYPE)
+        val parsedRollup = Rollup.parse(parser(rollupString), rollup.id, rollup.seqNo, rollup.primaryTerm)
+        assertEquals("Round tripping Rollup with routing field doesn't work", rollup.copy(roles = listOf()), parsedRollup)
+        assertEquals(terms.sourceField, parsedRollup.routingField)
+    }
+
+    fun `test rollup parsing without routing field`() {
+        val rollup = randomRollup().copy(delay = randomLongBetween(0, 60000000), routingField = null)
+        val rollupString = rollup.toJsonString(XCONTENT_WITHOUT_TYPE)
+        val parsedRollup = Rollup.parse(parser(rollupString), rollup.id, rollup.seqNo, rollup.primaryTerm)
+        assertEquals("Round tripping Rollup without routing field doesn't work", rollup.copy(roles = listOf()), parsedRollup)
+        assertNull(parsedRollup.routingField)
+    }
+
     fun `test ism rollup parsing`() {
         val ismRollup = randomISMRollup()
         val ismRollupString = ismRollup.toJsonString()

--- a/src/test/kotlin/org/opensearch/indexmanagement/rollup/runner/RollupRoutingIT.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/rollup/runner/RollupRoutingIT.kt
@@ -1,0 +1,209 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.indexmanagement.rollup.runner
+
+import org.apache.hc.core5.http.ContentType
+import org.apache.hc.core5.http.io.entity.StringEntity
+import org.opensearch.client.ResponseException
+import org.opensearch.common.settings.Settings
+import org.opensearch.core.rest.RestStatus
+import org.opensearch.indexmanagement.IndexManagementPlugin.Companion.ROLLUP_JOBS_BASE_URI
+import org.opensearch.indexmanagement.common.model.dimension.DateHistogram
+import org.opensearch.indexmanagement.common.model.dimension.Terms
+import org.opensearch.indexmanagement.makeRequest
+import org.opensearch.indexmanagement.rollup.RollupRestTestCase
+import org.opensearch.indexmanagement.rollup.model.Rollup
+import org.opensearch.indexmanagement.rollup.model.RollupMetadata
+import org.opensearch.indexmanagement.rollup.model.RollupMetrics
+import org.opensearch.indexmanagement.rollup.model.metric.Max
+import org.opensearch.indexmanagement.rollup.model.metric.Min
+import org.opensearch.indexmanagement.rollup.model.metric.Sum
+import org.opensearch.indexmanagement.rollup.toJsonString
+import org.opensearch.indexmanagement.waitFor
+import org.opensearch.jobscheduler.spi.schedule.IntervalSchedule
+import java.time.Instant
+import java.time.temporal.ChronoUnit
+
+@Suppress("UNCHECKED_CAST")
+class RollupRoutingIT : RollupRestTestCase() {
+
+    fun `test rollup with routing field applies routing to target documents`() {
+        val sourceIndex = "routing-source-index"
+        val targetIndex = "routing-target-index"
+
+        // Create source index
+        createIndex(
+            sourceIndex,
+            Settings.builder().put("number_of_shards", 1).put("number_of_replicas", 0).build(),
+            """"properties": {"timestamp": {"type": "date"}, "category": {"type": "keyword"}, "value": {"type": "double"}}""",
+        )
+
+        // Index documents - 2 alpha docs in same hour, 2 beta docs in same hour
+        indexDoc(sourceIndex, "1", """{"timestamp": "2023-05-03T10:00:00Z", "category": "alpha", "value": 100}""")
+        indexDoc(sourceIndex, "2", """{"timestamp": "2023-05-03T10:30:00Z", "category": "alpha", "value": 150}""")
+        indexDoc(sourceIndex, "3", """{"timestamp": "2023-05-03T11:00:00Z", "category": "beta", "value": 200}""")
+        indexDoc(sourceIndex, "4", """{"timestamp": "2023-05-03T11:30:00Z", "category": "beta", "value": 250}""")
+
+        // Create rollup with routing_field and multi-shard target
+        val rollup = Rollup(
+            id = "routing_field_test",
+            schemaVersion = 1L,
+            enabled = true,
+            jobSchedule = IntervalSchedule(Instant.now(), 1, ChronoUnit.MINUTES),
+            jobLastUpdatedTime = Instant.now(),
+            jobEnabledTime = Instant.now(),
+            description = "Test routing field",
+            sourceIndex = sourceIndex,
+            targetIndex = targetIndex,
+            targetIndexSettings = Settings.builder()
+                .put("index.number_of_shards", 5)
+                .put("index.number_of_replicas", 0)
+                .build(),
+            metadataID = null,
+            roles = emptyList(),
+            pageSize = 1000,
+            delay = 0,
+            continuous = false,
+            dimensions = listOf(
+                DateHistogram(sourceField = "timestamp", fixedInterval = "1h"),
+                Terms(sourceField = "category", targetField = "category"),
+            ),
+            metrics = listOf(
+                RollupMetrics(sourceField = "value", targetField = "value", metrics = listOf(Sum(), Min(), Max())),
+            ),
+            routingField = "category",
+        ).let { createRollup(it, it.id) }
+
+        updateRollupStartTime(rollup)
+
+        // Wait for rollup to finish
+        waitFor {
+            val rollupJob = getRollup(rollupId = rollup.id)
+            assertNotNull("Rollup job doesn't have metadata set", rollupJob.metadataID)
+            val metadata = getRollupMetadata(rollupJob.metadataID!!)
+            assertEquals("Rollup is not finished", RollupMetadata.Status.FINISHED, metadata.status)
+            assertEquals("Unexpected documents processed", 4L, metadata.stats.documentsProcessed)
+            assertEquals("Unexpected rollups indexed", 2L, metadata.stats.rollupsIndexed)
+        }
+
+        // Verify routing field is stored correctly
+        val fetchedRollup = getRollup(rollup.id)
+        assertEquals("Routing field should be category", "category", fetchedRollup.routingField)
+    }
+
+    fun `test rollup without routing field does not set routing`() {
+        val sourceIndex = "no-routing-source-index"
+        val targetIndex = "no-routing-target-index"
+
+        // Create source index
+        createIndex(
+            sourceIndex,
+            Settings.builder().put("number_of_shards", 1).put("number_of_replicas", 0).build(),
+            """"properties": {"timestamp": {"type": "date"}, "category": {"type": "keyword"}, "value": {"type": "double"}}""",
+        )
+
+        // Index documents
+        indexDoc(sourceIndex, "1", """{"timestamp": "2023-05-03T10:00:00Z", "category": "alpha", "value": 100}""")
+        indexDoc(sourceIndex, "2", """{"timestamp": "2023-05-03T11:00:00Z", "category": "beta", "value": 200}""")
+
+        // Create rollup WITHOUT routing_field
+        val rollup = Rollup(
+            id = "no_routing_field_test",
+            schemaVersion = 1L,
+            enabled = true,
+            jobSchedule = IntervalSchedule(Instant.now(), 1, ChronoUnit.MINUTES),
+            jobLastUpdatedTime = Instant.now(),
+            jobEnabledTime = Instant.now(),
+            description = "Test no routing field",
+            sourceIndex = sourceIndex,
+            targetIndex = targetIndex,
+            targetIndexSettings = null,
+            metadataID = null,
+            roles = emptyList(),
+            pageSize = 1000,
+            delay = 0,
+            continuous = false,
+            dimensions = listOf(
+                DateHistogram(sourceField = "timestamp", fixedInterval = "1h"),
+                Terms(sourceField = "category", targetField = "category"),
+            ),
+            metrics = listOf(
+                RollupMetrics(sourceField = "value", targetField = "value", metrics = listOf(Sum())),
+            ),
+        ).let { createRollup(it, it.id) }
+
+        updateRollupStartTime(rollup)
+
+        // Wait for rollup to finish
+        waitFor {
+            val rollupJob = getRollup(rollupId = rollup.id)
+            assertNotNull("Rollup job doesn't have metadata set", rollupJob.metadataID)
+            val metadata = getRollupMetadata(rollupJob.metadataID!!)
+            assertEquals("Rollup is not finished", RollupMetadata.Status.FINISHED, metadata.status)
+        }
+
+        // Verify the rollup job does not have routing_field
+        val fetchedRollup = getRollup(rollup.id)
+        assertNull("Routing field should be null", fetchedRollup.routingField)
+    }
+
+    fun `test rollup routing field cannot be modified after creation`() {
+        val sourceIndex = "immutable-routing-source"
+        val targetIndex = "immutable-routing-target"
+
+        createIndex(
+            sourceIndex,
+            Settings.EMPTY,
+            """"properties": {"timestamp": {"type": "date"}, "category": {"type": "keyword"}, "value": {"type": "double"}}""",
+        )
+
+        val rollup = Rollup(
+            id = "immutable_routing_test",
+            schemaVersion = 1L,
+            enabled = true,
+            jobSchedule = IntervalSchedule(Instant.now(), 1, ChronoUnit.MINUTES),
+            jobLastUpdatedTime = Instant.now(),
+            jobEnabledTime = Instant.now(),
+            description = "Test immutable routing",
+            sourceIndex = sourceIndex,
+            targetIndex = targetIndex,
+            targetIndexSettings = null,
+            metadataID = null,
+            roles = emptyList(),
+            pageSize = 1000,
+            delay = 0,
+            continuous = false,
+            dimensions = listOf(
+                DateHistogram(sourceField = "timestamp", fixedInterval = "1h"),
+                Terms(sourceField = "category", targetField = "category"),
+            ),
+            metrics = listOf(
+                RollupMetrics(sourceField = "value", targetField = "value", metrics = listOf(Sum())),
+            ),
+            routingField = "category",
+        ).let { createRollup(it, it.id) }
+
+        // Try to update with routing_field removed
+        val updatedRollup = rollup.copy(
+            routingField = null,
+            enabled = false,
+            jobEnabledTime = null,
+        )
+
+        try {
+            client().makeRequest(
+                "PUT",
+                "$ROLLUP_JOBS_BASE_URI/${rollup.id}?if_seq_no=${rollup.seqNo}&if_primary_term=${rollup.primaryTerm}",
+                emptyMap(),
+                StringEntity(updatedRollup.toJsonString(), ContentType.APPLICATION_JSON),
+            )
+            fail("Expected 400 error when modifying routing_field")
+        } catch (e: ResponseException) {
+            assertEquals("Unexpected status", RestStatus.BAD_REQUEST, e.response.restStatus())
+            assertTrue("Error should mention routing_field", e.message!!.contains("Not allowed to modify"))
+        }
+    }
+}

--- a/src/test/resources/mappings/cached-opendistro-ism-config.json
+++ b/src/test/resources/mappings/cached-opendistro-ism-config.json
@@ -1,6 +1,6 @@
 {
   "_meta" : {
-    "schema_version": 28
+    "schema_version": 29
   },
   "dynamic": "strict",
   "properties": {
@@ -501,6 +501,9 @@
                               }
                             }
                           }
+                        },
+                        "routing_field": {
+                          "type": "keyword"
                         }
                       }
                     }
@@ -1064,6 +1067,9 @@
         "continuous": {
           "type": "boolean"
         },
+        "routing_field": {
+          "type": "keyword"
+        },
         "roles": {
           "type": "text",
           "fields": {
@@ -1430,6 +1436,9 @@
         },
         "continuous": {
           "type": "boolean"
+        },
+        "routing_field": {
+          "type": "keyword"
         }
       }
     },


### PR DESCRIPTION
### Description
Adds optional routing support to rollup jobs to enable efficient shard-targeted queries on rollup indices when the routing field is included as a terms dimension.

Rollup jobs currently do not preserve routing information from source indices. Documents are distributed across shards based on the hash of their document ID, causing queries with routing parameters to return 0 results. This change adds a new optional `routing_field` parameter that, when set to a terms dimension, applies routing on each rollup document using the dimension's value from the composite aggregation bucket key.

### Related Issues
Resolves #1558
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/index-management/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
