### PR TITLE
Support querying across rollup indices with different dimension schemas

### DIFF
--- a/src/main/kotlin/org/opensearch/indexmanagement/rollup/interceptor/RollupInterceptor.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/rollup/interceptor/RollupInterceptor.kt
@@ -210,23 +210,32 @@ class RollupInterceptor(
     }
 
     /*
-     * Validate that all indices have rollup job which matches field mappings from request
-     * TODO return compiled list of issues here instead of just throwing exception
+     * Validate that at least one index has a rollup job which matches field mappings from request.
+     * Indices whose rollup jobs don't cover the queried fields are skipped, allowing queries across
+     * multiple rollup indices with different dimension schemas.
      * */
-    private fun validateIndicies(concreteIndices: Array<String>, fieldMappings: Set<RollupFieldMapping>): Map<Rollup, Set<RollupFieldMapping>> {
+    internal fun validateIndicies(concreteIndices: Array<String>, fieldMappings: Set<RollupFieldMapping>): Map<Rollup, Set<RollupFieldMapping>> {
         var allMatchingRollupJobs: Map<Rollup, Set<RollupFieldMapping>> = mapOf()
+        var lastIssues: Set<String> = emptySet()
         for (concreteIndex in concreteIndices) {
             val rollupJobs = clusterService.state().metadata.index(concreteIndex).getRollupJobs()
             if (rollupJobs != null) {
                 val (matchingRollupJobs, issues) = findMatchingRollupJobs(fieldMappings, rollupJobs)
-                if (issues.isNotEmpty() || matchingRollupJobs.isEmpty()) {
-                    throw IllegalArgumentException("Could not find a rollup job that can answer this query because $issues")
+                if (matchingRollupJobs.isNotEmpty()) {
+                    allMatchingRollupJobs += matchingRollupJobs
+                } else {
+                    lastIssues = issues
+                    logger.debug("Skipping rollup index [$concreteIndex] as it does not match query fields: $issues")
                 }
-                allMatchingRollupJobs += matchingRollupJobs
             } else if (!searchRawRollupIndices) {
                 throw IllegalArgumentException("Not all indices have rollup job")
             }
         }
+
+        if (allMatchingRollupJobs.isEmpty()) {
+            throw IllegalArgumentException("Could not find a rollup job that can answer this query because $lastIssues")
+        }
+
         return allMatchingRollupJobs
     }
 
@@ -363,7 +372,7 @@ class RollupInterceptor(
 
     // TODO: How does this job matching work with roles/security?
     @Suppress("CyclomaticComplexMethod")
-    private fun findMatchingRollupJobs(
+    internal fun findMatchingRollupJobs(
         fieldMappings: Set<RollupFieldMapping>,
         rollupJobs: List<Rollup>,
     ): Pair<Map<Rollup, Set<RollupFieldMapping>>, Set<String>> {

--- a/src/test/kotlin/org/opensearch/indexmanagement/rollup/interceptor/RollupInterceptorTests.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/rollup/interceptor/RollupInterceptorTests.kt
@@ -12,8 +12,13 @@ import org.opensearch.cluster.metadata.IndexNameExpressionResolver
 import org.opensearch.cluster.service.ClusterService
 import org.opensearch.common.settings.ClusterSettings
 import org.opensearch.common.settings.Settings
+import org.opensearch.indexmanagement.common.model.dimension.DateHistogram
+import org.opensearch.indexmanagement.common.model.dimension.Dimension
+import org.opensearch.indexmanagement.common.model.dimension.Terms
 import org.opensearch.indexmanagement.rollup.interceptor.RollupInterceptor.Companion.BYPASS_ROLLUP_SEARCH
 import org.opensearch.indexmanagement.rollup.interceptor.RollupInterceptor.Companion.BYPASS_SIZE_CHECK
+import org.opensearch.indexmanagement.rollup.model.RollupFieldMapping
+import org.opensearch.indexmanagement.rollup.randomRollup
 import org.opensearch.indexmanagement.rollup.settings.RollupSettings
 import org.opensearch.search.builder.SearchSourceBuilder
 import org.opensearch.search.fetch.subphase.FetchSourceContext
@@ -121,6 +126,71 @@ class RollupInterceptorTests : OpenSearchTestCase() {
         val bypassLevel = interceptor.getBypassFromFetchSource(request)
 
         assertNull(bypassLevel)
+    }
+
+    fun `test findMatchingRollupJobs returns match when rollup job covers all queried fields`() {
+        val rollup = randomRollup().copy(
+            dimensions = listOf(
+                DateHistogram(sourceField = "timestamp", fixedInterval = "1h"),
+                Terms("field1", "field1"),
+                Terms("field2", "field2"),
+            ),
+        )
+        val fieldMappings = setOf(
+            RollupFieldMapping(RollupFieldMapping.Companion.FieldType.DIMENSION, "field1", Dimension.Type.TERMS.type),
+        )
+
+        val (matchingJobs, issues) = interceptor.findMatchingRollupJobs(fieldMappings, listOf(rollup))
+
+        assertTrue("Expected matching jobs but got none", matchingJobs.isNotEmpty())
+        assertTrue("Expected no issues but got $issues", issues.isEmpty())
+    }
+
+    fun `test findMatchingRollupJobs returns no match when rollup job missing queried field`() {
+        val rollup = randomRollup().copy(
+            dimensions = listOf(
+                DateHistogram(sourceField = "timestamp", fixedInterval = "1h"),
+                Terms("field1", "field1"),
+            ),
+        )
+        val fieldMappings = setOf(
+            RollupFieldMapping(RollupFieldMapping.Companion.FieldType.DIMENSION, "field2", Dimension.Type.TERMS.type),
+        )
+
+        val (matchingJobs, issues) = interceptor.findMatchingRollupJobs(fieldMappings, listOf(rollup))
+
+        assertTrue("Expected no matching jobs", matchingJobs.isEmpty())
+        assertTrue("Expected issues to be reported", issues.isNotEmpty())
+    }
+
+    fun `test findMatchingRollupJobs with multiple jobs only matches superset job`() {
+        val rollupWithField1Only = randomRollup().copy(
+            id = "rollup_1",
+            dimensions = listOf(
+                DateHistogram(sourceField = "timestamp", fixedInterval = "1h"),
+                Terms("field1", "field1"),
+            ),
+        )
+        val rollupWithBothFields = randomRollup().copy(
+            id = "rollup_2",
+            dimensions = listOf(
+                DateHistogram(sourceField = "timestamp", fixedInterval = "1h"),
+                Terms("field1", "field1"),
+                Terms("field2", "field2"),
+            ),
+        )
+        val fieldMappings = setOf(
+            RollupFieldMapping(RollupFieldMapping.Companion.FieldType.DIMENSION, "field2", Dimension.Type.TERMS.type),
+        )
+
+        val (matchingJobs, issues) = interceptor.findMatchingRollupJobs(
+            fieldMappings,
+            listOf(rollupWithField1Only, rollupWithBothFields),
+        )
+
+        assertEquals("Only the job with field2 should match", 1, matchingJobs.size)
+        assertTrue("rollup_2 should be in matching jobs", matchingJobs.keys.any { it.id == "rollup_2" })
+        assertTrue("Expected no issues", issues.isEmpty())
     }
 
     // Helper method to create interceptor instance


### PR DESCRIPTION
### Description
When multiple rollup indices with different dimension schemas are aliased together, queries referencing fields that don't exist in all indices now succeed instead of failing. Indices that cannot answer the query are skipped, and the query    
proceeds as long as at least one index can answer it.

### Related Issues
Resolves #1559
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/index-management/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
