### PR TITLE
Fix _refresh_search_analyzers blocked on indices with METADATA_WRITE block

### DIFF
--- a/src/main/kotlin/org/opensearch/indexmanagement/refreshanalyzer/TransportRefreshSearchAnalyzerAction.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/refreshanalyzer/TransportRefreshSearchAnalyzerAction.kt
@@ -10,7 +10,6 @@ import org.opensearch.action.support.ActionFilters
 import org.opensearch.action.support.broadcast.node.TransportBroadcastByNodeAction
 import org.opensearch.cluster.ClusterState
 import org.opensearch.cluster.block.ClusterBlockException
-import org.opensearch.cluster.block.ClusterBlockLevel
 import org.opensearch.cluster.metadata.IndexNameExpressionResolver
 import org.opensearch.cluster.routing.ShardRouting
 import org.opensearch.cluster.routing.ShardsIterator
@@ -91,9 +90,8 @@ class TransportRefreshSearchAnalyzerAction :
     override fun shards(clusterState: ClusterState, request: RefreshSearchAnalyzerRequest?, concreteIndices: Array<String?>?): ShardsIterator? =
         clusterState.routingTable().allShards(concreteIndices)
 
-    override fun checkGlobalBlock(state: ClusterState, request: RefreshSearchAnalyzerRequest?): ClusterBlockException? =
-        state.blocks().globalBlockedException(ClusterBlockLevel.METADATA_WRITE)
+    // No block check needed: this action only reloads synonym files from disk into memory.
+    override fun checkGlobalBlock(state: ClusterState, request: RefreshSearchAnalyzerRequest?): ClusterBlockException? = null
 
-    override fun checkRequestBlock(state: ClusterState, request: RefreshSearchAnalyzerRequest?, concreteIndices: Array<String?>?): ClusterBlockException? =
-        state.blocks().indicesBlockedException(ClusterBlockLevel.METADATA_WRITE, concreteIndices)
+    override fun checkRequestBlock(state: ClusterState, request: RefreshSearchAnalyzerRequest?, concreteIndices: Array<String?>?): ClusterBlockException? = null
 }

--- a/src/test/kotlin/org/opensearch/indexmanagement/refreshanalyzer/RefreshSearchAnalyzerActionIT.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/refreshanalyzer/RefreshSearchAnalyzerActionIT.kt
@@ -175,6 +175,50 @@ class RefreshSearchAnalyzerActionIT : IndexManagementRestTestCase() {
         }
     }
 
+    fun `test refresh succeeds with metadata write block`() {
+        val buildDir = System.getProperty("buildDir")
+        val numNodes = System.getProperty("cluster.number_of_nodes", "1").toInt()
+        val indexName = "${testIndexName}_index_4"
+
+        for (i in 0 until numNodes) {
+            writeToFile("$buildDir/testclusters/integTest-$i/config/pacman_synonyms.txt", "hello, hola")
+        }
+
+        val settings: Settings = Settings.builder()
+            .loadFromSource(getSearchAnalyzerSettings(), XContentType.JSON)
+            .build()
+        createIndex(indexName, settings, getAnalyzerMapping())
+        ingestData(indexName)
+
+        // Verify initial synonym works
+        assertTrue(queryData(indexName, "hola").contains("hello world"))
+
+        // Add read_only block (levels: WRITE + METADATA_WRITE), simulates CCR follower block
+        val addBlockRequest = Request("PUT", "/$indexName/_settings")
+        addBlockRequest.setJsonEntity("""{"index.blocks.read_only": true}""")
+        client().performRequest(addBlockRequest)
+
+        // Update synonym file on disk
+        for (i in 0 until numNodes) {
+            writeToFile("$buildDir/testclusters/integTest-$i/config/pacman_synonyms.txt", "hello, hola, namaste")
+        }
+
+        // Refresh should succeed despite the METADATA_WRITE block
+        refreshAnalyzer(indexName)
+
+        // New synonym should be active in search
+        assertTrue(queryData(indexName, "namaste").contains("hello world"))
+
+        // Remove block and clean up
+        val removeBlockRequest = Request("PUT", "/$indexName/_settings")
+        removeBlockRequest.setJsonEntity("""{"index.blocks.read_only": false}""")
+        client().performRequest(removeBlockRequest)
+
+        for (i in 0 until numNodes) {
+            deleteFile("$buildDir/testclusters/integTest-$i/config/pacman_synonyms.txt")
+        }
+    }
+
     companion object {
         fun writeToFile(filePath: String, contents: String) {
             val path = org.opensearch.common.io.PathUtils.get(filePath)


### PR DESCRIPTION
### Description

`_refresh_search_analyzers` fails with HTTP 403 (`ClusterBlockException`) on any index that has a `METADATA_WRITE`-level block, such as CCR follower indices.

The root cause is that `TransportRefreshSearchAnalyzerAction` declares it requires `METADATA_WRITE` permission via `checkGlobalBlock`/`checkRequestBlock`, but the action only reloads synonym files from disk into shard-local memory — it does not mutate index metadata or cluster state.

### Changes

- Remove `ClusterBlockLevel.METADATA_WRITE` checks from `checkGlobalBlock` and `checkRequestBlock` (return `null`)
- Remove unused `ClusterBlockLevel` import
- Add integration test verifying refresh succeeds on an index with a read-only block

### Testing

- Added `test refresh succeeds with metadata write block` in `RefreshSearchAnalyzerActionIT`
- Existing tests pass (synonym reload on normal indices unaffected)

### Check List

- [x] New functionality includes testing
- [x] New functionality has been documented above
- [x] Commits are signed off (DCO)