### PR TITLE
feat: Disable rollup and transform for pluggable dataformat indices

### DIFF
--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/rollup/AttemptCreateRollupJobStep.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/rollup/AttemptCreateRollupJobStep.kt
@@ -24,6 +24,7 @@ import org.opensearch.indexmanagement.spi.indexstatemanagement.model.ActionPrope
 import org.opensearch.indexmanagement.spi.indexstatemanagement.model.ManagedIndexMetaData
 import org.opensearch.indexmanagement.spi.indexstatemanagement.model.StepContext
 import org.opensearch.indexmanagement.spi.indexstatemanagement.model.StepMetaData
+import org.opensearch.indexmanagement.util.PluggableDataFormatUtils
 import org.opensearch.transport.RemoteTransportException
 import org.opensearch.transport.client.Client
 
@@ -68,7 +69,7 @@ class AttemptCreateRollupJobStep(private val action: RollupAction) : Step(name) 
 
             // Validate resolved indices to ensure they are valid and different.
             // This catches configuration errors early before attempting to create the rollup job.
-            validateResolvedIndices(resolvedSourceIndex, resolvedTargetIndex)
+            validateResolvedIndices(resolvedSourceIndex, resolvedTargetIndex, context)
 
             logger.info(
                 "Executing rollup from source [$resolvedSourceIndex] to target [$resolvedTargetIndex] " +
@@ -122,7 +123,7 @@ class AttemptCreateRollupJobStep(private val action: RollupAction) : Step(name) 
      * @param targetIndex The resolved target index name (after template resolution)
      * @throws IllegalArgumentException if any validation rule fails, with a descriptive error message
      */
-    private fun validateResolvedIndices(sourceIndex: String, targetIndex: String) {
+    private fun validateResolvedIndices(sourceIndex: String, targetIndex: String, context: StepContext) {
         require(sourceIndex.isNotBlank()) {
             "Resolved source_index cannot be empty"
         }
@@ -131,6 +132,14 @@ class AttemptCreateRollupJobStep(private val action: RollupAction) : Step(name) 
         }
         require(sourceIndex != targetIndex) {
             "Source and target indices must be different: $sourceIndex"
+        }
+        require(
+            !PluggableDataFormatUtils.hasPluggableDataFormatEnabled(
+                context.clusterService.state().metadata(),
+                arrayOf(sourceIndex),
+            ),
+        ) {
+            "Rollup is not supported with Optimized Engine currently"
         }
     }
 

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/transform/AttemptCreateTransformJobStep.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/transform/AttemptCreateTransformJobStep.kt
@@ -24,6 +24,7 @@ import org.opensearch.indexmanagement.transform.action.index.IndexTransformReque
 import org.opensearch.indexmanagement.transform.action.index.IndexTransformResponse
 import org.opensearch.indexmanagement.transform.action.start.StartTransformAction
 import org.opensearch.indexmanagement.transform.action.start.StartTransformRequest
+import org.opensearch.indexmanagement.util.PluggableDataFormatUtils
 import org.opensearch.transport.RemoteTransportException
 import org.opensearch.transport.client.Client
 
@@ -49,6 +50,15 @@ class AttemptCreateTransformJobStep(
         val indexTransformRequest = IndexTransformRequest(transform, WriteRequest.RefreshPolicy.IMMEDIATE)
 
         try {
+            require(
+                !PluggableDataFormatUtils.hasPluggableDataFormatEnabled(
+                    context.clusterService.state().metadata(),
+                    arrayOf(indexName),
+                ),
+            ) {
+                "Transform is not supported with Optimized Engine currently"
+            }
+
             val response: IndexTransformResponse = context.client.suspendUntil { execute(IndexTransformAction.INSTANCE, indexTransformRequest, it) }
             logger.info("Received status ${response.status.status} on trying to create transform job $transformId")
 

--- a/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/transport/action/addpolicy/TransportAddPolicyAction.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/transport/action/addpolicy/TransportAddPolicyAction.kt
@@ -40,6 +40,8 @@ import org.opensearch.indexmanagement.IndexManagementPlugin.Companion.INDEX_MANA
 import org.opensearch.indexmanagement.indexstatemanagement.DefaultIndexMetadataService
 import org.opensearch.indexmanagement.indexstatemanagement.IndexMetadataProvider
 import org.opensearch.indexmanagement.indexstatemanagement.IndexMetadataProvider.Companion.EVALUATION_FAILURE_MESSAGE
+import org.opensearch.indexmanagement.indexstatemanagement.action.RollupAction
+import org.opensearch.indexmanagement.indexstatemanagement.action.TransformAction
 import org.opensearch.indexmanagement.indexstatemanagement.model.Policy
 import org.opensearch.indexmanagement.indexstatemanagement.opensearchapi.getUuidsForClosedIndices
 import org.opensearch.indexmanagement.indexstatemanagement.settings.ManagedIndexSettings
@@ -57,6 +59,7 @@ import org.opensearch.indexmanagement.opensearchapi.withClosableContext
 import org.opensearch.indexmanagement.settings.IndexManagementSettings
 import org.opensearch.indexmanagement.spi.indexstatemanagement.model.ISMIndexMetadata
 import org.opensearch.indexmanagement.util.IndexUtils
+import org.opensearch.indexmanagement.util.PluggableDataFormatUtils
 import org.opensearch.indexmanagement.util.SecurityUtils.Companion.buildUser
 import org.opensearch.indexmanagement.util.SecurityUtils.Companion.userHasPermissionForResource
 import org.opensearch.indexmanagement.util.SecurityUtils.Companion.validateUserConfiguration
@@ -273,6 +276,24 @@ constructor(
                 }
                 shouldRemove
             }
+
+            // Reject indices with pluggable dataformat if policy has rollup or transform actions
+            val hasRollupOrTransform = policy.states.any { state ->
+                state.actions.any { it.type == RollupAction.name || it.type == TransformAction.name }
+            }
+            if (hasRollupOrTransform) {
+                val metadata = clusterService.state().metadata()
+                indicesToAdd.entries.removeIf { (uuid, indexName) ->
+                    val blocked = PluggableDataFormatUtils.hasPluggableDataFormatEnabled(metadata, arrayOf(indexName))
+                    if (blocked) {
+                        failedIndices.add(
+                            FailedIndex(indexName, uuid, "Rollup/Transform is not supported with Optimized Engine currently"),
+                        )
+                    }
+                    blocked
+                }
+            }
+
             if (indicesToAdd.isEmpty()) {
                 actionListener.onResponse(ISMStatusResponse(0, failedIndices))
                 return

--- a/src/main/kotlin/org/opensearch/indexmanagement/rollup/action/index/TransportIndexRollupAction.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/rollup/action/index/TransportIndexRollupAction.kt
@@ -14,7 +14,9 @@ import org.opensearch.action.index.IndexRequest
 import org.opensearch.action.index.IndexResponse
 import org.opensearch.action.support.ActionFilters
 import org.opensearch.action.support.HandledTransportAction
+import org.opensearch.action.support.IndicesOptions
 import org.opensearch.action.support.clustermanager.AcknowledgedResponse
+import org.opensearch.cluster.metadata.IndexNameExpressionResolver
 import org.opensearch.cluster.service.ClusterService
 import org.opensearch.common.inject.Inject
 import org.opensearch.common.settings.Settings
@@ -32,6 +34,7 @@ import org.opensearch.indexmanagement.rollup.util.RollupFieldValueExpressionReso
 import org.opensearch.indexmanagement.rollup.util.parseRollup
 import org.opensearch.indexmanagement.settings.IndexManagementSettings
 import org.opensearch.indexmanagement.util.IndexUtils
+import org.opensearch.indexmanagement.util.PluggableDataFormatUtils
 import org.opensearch.indexmanagement.util.SecurityUtils
 import org.opensearch.indexmanagement.util.SecurityUtils.Companion.buildUser
 import org.opensearch.indexmanagement.util.SecurityUtils.Companion.validateUserConfiguration
@@ -49,6 +52,7 @@ constructor(
     actionFilters: ActionFilters,
     val indexManagementIndices: IndexManagementIndices,
     val clusterService: ClusterService,
+    val indexNameExpressionResolver: IndexNameExpressionResolver,
     val settings: Settings,
     val xContentRegistry: NamedXContentRegistry,
 ) : HandledTransportAction<IndexRollupRequest, IndexRollupResponse>(
@@ -83,6 +87,14 @@ constructor(
             client.threadPool().threadContext.stashContext().use {
                 if (!validateUserConfiguration(user, filterByEnabled, actionListener)) {
                     return
+                }
+                if (hasPluggableDataFormatSource(request.rollup.sourceIndex)) {
+                    return actionListener.onFailure(
+                        OpenSearchStatusException(
+                            "Rollup is not supported with Optimized Engine currently",
+                            RestStatus.BAD_REQUEST,
+                        ),
+                    )
                 }
                 indexManagementIndices.checkAndUpdateIMConfigIndex(ActionListener.wrap(::onCreateMappingsResponse, actionListener::onFailure))
             }
@@ -194,5 +206,12 @@ constructor(
             val targetIndexResolvedName = RollupFieldValueExpressionResolver.resolve(request.rollup, request.rollup.targetIndex)
             return !targetIndexResolvedName.contains("*") && !targetIndexResolvedName.contains("?")
         }
+    }
+
+    private fun hasPluggableDataFormatSource(sourceIndex: String): Boolean {
+        val state = clusterService.state()
+        val concreteIndices =
+            indexNameExpressionResolver.concreteIndexNames(state, IndicesOptions.lenientExpand(), true, sourceIndex)
+        return PluggableDataFormatUtils.hasPluggableDataFormatEnabled(state.metadata(), concreteIndices)
     }
 }

--- a/src/main/kotlin/org/opensearch/indexmanagement/transform/action/index/TransportIndexTransformAction.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/transform/action/index/TransportIndexTransformAction.kt
@@ -37,6 +37,7 @@ import org.opensearch.indexmanagement.settings.IndexManagementSettings
 import org.opensearch.indexmanagement.transform.TransformValidator
 import org.opensearch.indexmanagement.transform.model.Transform
 import org.opensearch.indexmanagement.util.IndexUtils
+import org.opensearch.indexmanagement.util.PluggableDataFormatUtils
 import org.opensearch.indexmanagement.util.SecurityUtils.Companion.buildUser
 import org.opensearch.indexmanagement.util.SecurityUtils.Companion.userHasPermissionForResource
 import org.opensearch.indexmanagement.util.SecurityUtils.Companion.validateUserConfiguration
@@ -190,6 +191,16 @@ constructor(
                 )
             if (concreteIndices.isEmpty()) {
                 actionListener.onFailure(OpenSearchStatusException("No specified source index exist in the cluster", RestStatus.NOT_FOUND))
+                return
+            }
+
+            if (PluggableDataFormatUtils.hasPluggableDataFormatEnabled(clusterService.state().metadata(), concreteIndices)) {
+                actionListener.onFailure(
+                    OpenSearchStatusException(
+                        "Transform is not supported with Optimized Engine currently",
+                        RestStatus.BAD_REQUEST,
+                    ),
+                )
                 return
             }
 

--- a/src/main/kotlin/org/opensearch/indexmanagement/util/PluggableDataFormatUtils.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/util/PluggableDataFormatUtils.kt
@@ -1,0 +1,23 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.indexmanagement.util
+
+import org.opensearch.cluster.metadata.Metadata
+
+/**
+ * Utility to check if indices have pluggable dataformat enabled.
+ */
+object PluggableDataFormatUtils {
+    private const val PLUGGABLE_DATAFORMAT_ENABLED_KEY = "index.pluggable.dataformat.enabled"
+
+    // TODO: Replace with IndexSettings.isPluggableDataFormatEnabled() once the OpenSearch core dependency is updated
+    fun hasPluggableDataFormatEnabled(metadata: Metadata, concreteIndices: Array<String>): Boolean =
+        concreteIndices.any { indexName ->
+            val indexMetadata = metadata.index(indexName)
+            indexMetadata != null &&
+                indexMetadata.settings.getAsBoolean(PLUGGABLE_DATAFORMAT_ENABLED_KEY, false)
+        }
+}

--- a/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/PluggableDataFormatStepTests.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/step/PluggableDataFormatStepTests.kt
@@ -1,0 +1,66 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.indexmanagement.indexstatemanagement.step
+
+import com.nhaarman.mockitokotlin2.doReturn
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.whenever
+import kotlinx.coroutines.runBlocking
+import org.opensearch.cluster.ClusterState
+import org.opensearch.cluster.metadata.IndexMetadata
+import org.opensearch.cluster.metadata.Metadata
+import org.opensearch.cluster.service.ClusterService
+import org.opensearch.common.settings.Settings
+import org.opensearch.common.util.concurrent.ThreadContext
+import org.opensearch.indexmanagement.indexstatemanagement.action.TransformAction
+import org.opensearch.indexmanagement.indexstatemanagement.step.transform.AttemptCreateTransformJobStep
+import org.opensearch.indexmanagement.spi.indexstatemanagement.Step
+import org.opensearch.indexmanagement.spi.indexstatemanagement.model.ManagedIndexMetaData
+import org.opensearch.indexmanagement.spi.indexstatemanagement.model.StepContext
+import org.opensearch.indexmanagement.transform.randomISMTransform
+import org.opensearch.jobscheduler.spi.utils.LockService
+import org.opensearch.script.ScriptService
+import org.opensearch.test.OpenSearchTestCase
+import org.opensearch.transport.client.Client
+
+class PluggableDataFormatStepTests : OpenSearchTestCase() {
+
+    fun `test transform step fails on pluggable dataformat index`() {
+        val indexName = "pluggable-index"
+        val ismTransform = randomISMTransform()
+        val action = TransformAction(ismTransform = ismTransform, index = 0)
+        val step = AttemptCreateTransformJobStep(action)
+
+        val indexMetadata: IndexMetadata = mock()
+        whenever(indexMetadata.settings).doReturn(
+            Settings.builder().put("index.pluggable.dataformat.enabled", true).build(),
+        )
+        val metadata: Metadata = mock()
+        whenever(metadata.index(indexName)).doReturn(indexMetadata)
+        val clusterState: ClusterState = mock()
+        whenever(clusterState.metadata()).doReturn(metadata)
+        val clusterService: ClusterService = mock()
+        whenever(clusterService.state()).doReturn(clusterState)
+
+        val managedIndexMetaData = ManagedIndexMetaData(
+            indexName, "uuid", "policy", null, null, null, null, null, null, null, null, null, null, null,
+        )
+        val context = StepContext(
+            managedIndexMetaData, clusterService, mock<Client>(), ThreadContext(Settings.EMPTY),
+            null, mock<ScriptService>(), Settings.EMPTY, mock<LockService>(),
+        )
+
+        step.preExecute(logger, context)
+        runBlocking { step.execute() }
+
+        val updated = step.getUpdatedManagedIndexMetadata(managedIndexMetaData)
+        assertEquals(Step.StepStatus.FAILED, updated.stepMetaData?.stepStatus)
+        assertTrue(
+            "Error should mention Optimized Engine",
+            updated.info?.get("cause").toString().contains("Optimized Engine"),
+        )
+    }
+}

--- a/src/test/kotlin/org/opensearch/indexmanagement/util/PluggableDataFormatUtilsTests.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/util/PluggableDataFormatUtilsTests.kt
@@ -1,0 +1,75 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.indexmanagement.util
+
+import com.nhaarman.mockitokotlin2.doReturn
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.whenever
+import org.opensearch.cluster.metadata.IndexMetadata
+import org.opensearch.cluster.metadata.Metadata
+import org.opensearch.common.settings.Settings
+import org.opensearch.test.OpenSearchTestCase
+
+class PluggableDataFormatUtilsTests : OpenSearchTestCase() {
+
+    fun `test returns true when index has pluggable dataformat enabled`() {
+        val indexMetadata: IndexMetadata = mock()
+        whenever(indexMetadata.settings).doReturn(
+            Settings.builder().put("index.pluggable.dataformat.enabled", true).build(),
+        )
+        val metadata: Metadata = mock()
+        whenever(metadata.index("test-index")).doReturn(indexMetadata)
+
+        assertTrue(PluggableDataFormatUtils.hasPluggableDataFormatEnabled(metadata, arrayOf("test-index")))
+    }
+
+    fun `test returns false when index has pluggable dataformat disabled`() {
+        val indexMetadata: IndexMetadata = mock()
+        whenever(indexMetadata.settings).doReturn(
+            Settings.builder().put("index.pluggable.dataformat.enabled", false).build(),
+        )
+        val metadata: Metadata = mock()
+        whenever(metadata.index("test-index")).doReturn(indexMetadata)
+
+        assertFalse(PluggableDataFormatUtils.hasPluggableDataFormatEnabled(metadata, arrayOf("test-index")))
+    }
+
+    fun `test returns false when setting is not present`() {
+        val indexMetadata: IndexMetadata = mock()
+        whenever(indexMetadata.settings).doReturn(Settings.EMPTY)
+        val metadata: Metadata = mock()
+        whenever(metadata.index("test-index")).doReturn(indexMetadata)
+
+        assertFalse(PluggableDataFormatUtils.hasPluggableDataFormatEnabled(metadata, arrayOf("test-index")))
+    }
+
+    fun `test returns false when index metadata is null`() {
+        val metadata: Metadata = mock()
+        whenever(metadata.index("test-index")).doReturn(null)
+
+        assertFalse(PluggableDataFormatUtils.hasPluggableDataFormatEnabled(metadata, arrayOf("test-index")))
+    }
+
+    fun `test returns true when any index in array has pluggable dataformat enabled`() {
+        val enabledMetadata: IndexMetadata = mock()
+        whenever(enabledMetadata.settings).doReturn(
+            Settings.builder().put("index.pluggable.dataformat.enabled", true).build(),
+        )
+        val disabledMetadata: IndexMetadata = mock()
+        whenever(disabledMetadata.settings).doReturn(Settings.EMPTY)
+
+        val metadata: Metadata = mock()
+        whenever(metadata.index("idx1")).doReturn(disabledMetadata)
+        whenever(metadata.index("idx2")).doReturn(enabledMetadata)
+
+        assertTrue(PluggableDataFormatUtils.hasPluggableDataFormatEnabled(metadata, arrayOf("idx1", "idx2")))
+    }
+
+    fun `test returns false for empty indices array`() {
+        val metadata: Metadata = mock()
+        assertFalse(PluggableDataFormatUtils.hasPluggableDataFormatEnabled(metadata, emptyArray()))
+    }
+}


### PR DESCRIPTION
### Description
Block creation of rollup and transform jobs when the source index has index.pluggable.dataformat.enabled = true. Indices with pluggable dataformat use a non-Lucene storage format that is currently incompatible with rollup and transform operations.

Validation is added in three places:
- TransportIndexRollupAction (standalone rollup creation)
- TransportIndexTransformAction (standalone transform creation)
- AttemptCreateRollupJobStep (ISM policy rollup action)

A shared utility PluggableDataFormatUtils is introduced to centralize the setting check logic with unit tests covering all edge cases.

### Check List
- [✅ ] New functionality includes testing.
- [✅ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

### Testing
#### Test Setup
Created 2 indices - 1 with pluggable dataformat setting and 1 without it

```
PUT /pluggable-test-index
Content-Type: application/json

{
  "settings": {
    "index.pluggable.dataformat.enabled": true,
    "number_of_shards": 1,
    "number_of_replicas": 0
  },
  "mappings": {
    "properties": {
      "timestamp": {"type": "date"},
      "value": {"type": "long"}
    }
  }
}
```
Response (HTTP 200):
```json
{
    "acknowledged": true,
    "shards_acknowledged": true,
    "index": "pluggable-test-index"
}
```

```
PUT /normal-index
Content-Type: application/json

{
  "settings": {
    "number_of_shards": 1,
    "number_of_replicas": 0
  },
  "mappings": {
    "properties": {
      "timestamp": {"type": "date"},
      "value": {"type": "long"}
    }
  }
}
```
Response (HTTP 200):
```json
{
    "acknowledged": true,
    "shards_acknowledged": true,
    "index": "normal-index"
}
```

#### Path 1: Standalone Rollup (`TransportIndexRollupAction`)

**Test 1a: Rollup on pluggable dataformat index — BLOCKED** ✅

Request:
```
PUT /_plugins/_rollup/jobs/rollup-blocked
Content-Type: application/json

{
  "rollup": {
    "enabled": true,
    "schedule": {"interval": {"start_time": 1602100553, "period": 1, "unit": "Minutes"}},
    "last_updated_time": 1602100553,
    "description": "rollup on pluggable index",
    "source_index": "pluggable-test-index",
    "target_index": "rollup-target",
    "page_size": 1,
    "delay": 0,
    "continuous": false,
    "dimensions": [{"date_histogram": {"source_field": "timestamp", "fixed_interval": "1h", "timezone": "UTC"}}],
    "metrics": [{"source_field": "value", "metrics": [{"sum": {}}]}]
  }
}
```

Response (HTTP 400):
```json
{
    "error": {
        "root_cause": [
            {
                "type": "status_exception",
                "reason": "Rollup is not supported on indices with pluggable dataformat enabled"
            }
        ],
        "type": "status_exception",
        "reason": "Rollup is not supported on indices with pluggable dataformat enabled"
    },
    "status": 400
}
```

**Test 1b: Rollup on normal index — ALLOWED** ✅

Request:
```
PUT /_plugins/_rollup/jobs/rollup-normal
Content-Type: application/json

{
  "rollup": {
    "enabled": true,
    "schedule": {"interval": {"start_time": 1602100553, "period": 1, "unit": "Minutes"}},
    "last_updated_time": 1602100553,
    "description": "rollup on normal index",
    "source_index": "normal-index",
    "target_index": "rollup-target-normal",
    "page_size": 1,
    "delay": 0,
    "continuous": false,
    "dimensions": [{"date_histogram": {"source_field": "timestamp", "fixed_interval": "1h", "timezone": "UTC"}}],
    "metrics": [{"source_field": "value", "metrics": [{"sum": {}}]}]
  }
}
```

Response (HTTP 201):
```json
{
    "_id": "rollup-normal",
    "_version": 1,
    "_seq_no": 1,
    "_primary_term": 2,
    "rollup": {
        "rollup_id": "rollup-normal",
        "enabled": true,
        "schedule": {
            "interval": {
                "start_time": 1602100553,
                "period": 1,
                "unit": "Minutes",
                "schedule_delay": 0
            }
        },
        "last_updated_time": 1778595133684,
        "enabled_time": 1778595133684,
        "description": "rollup on normal index",
        "schema_version": 27,
        "source_index": "normal-index",
        "target_index": "rollup-target-normal",
        "metadata_id": null,
        "page_size": 1,
        "delay": 0,
        "continuous": false,
        "dimensions": [
            {
                "date_histogram": {
                    "fixed_interval": "1h",
                    "source_field": "timestamp",
                    "target_field": "timestamp",
                    "timezone": "UTC",
                    "format": null
                }
            }
        ],
        "metrics": [
            {
                "source_field": "value",
                "metrics": [{"sum": {}}]
            }
        ]
    }
}
```

#### Path 2: Standalone Transform (`TransportIndexTransformAction`)

**Test 2a: Transform on pluggable dataformat index — BLOCKED** ✅

Request:
```
PUT /_plugins/_transform/transform-blocked
Content-Type: application/json

{
  "transform": {
    "enabled": true,
    "schedule": {"interval": {"start_time": 1602100553, "period": 1, "unit": "Minutes"}},
    "description": "transform on pluggable index",
    "source_index": "pluggable-test-index",
    "target_index": "transform-target",
    "page_size": 1,
    "data_selection_query": {"match_all": {}},
    "groups": [{"date_histogram": {"source_field": "timestamp", "fixed_interval": "1h", "timezone": "UTC"}}],
    "aggregations": {"sum_value": {"sum": {"field": "value"}}}
  }
}
```

Response (HTTP 400):
```json
{
    "error": {
        "root_cause": [
            {
                "type": "status_exception",
                "reason": "Transform is not supported on indices with pluggable dataformat enabled"
            }
        ],
        "type": "status_exception",
        "reason": "Transform is not supported on indices with pluggable dataformat enabled"
    },
    "status": 400
}
```

**Test 2b: Transform on normal index — ALLOWED** ✅

Request:
```
PUT /_plugins/_transform/transform-normal
Content-Type: application/json

{
  "transform": {
    "enabled": true,
    "schedule": {"interval": {"start_time": 1602100553, "period": 1, "unit": "Minutes"}},
    "description": "transform on normal index",
    "source_index": "normal-index",
    "target_index": "transform-target-normal",
    "page_size": 1,
    "data_selection_query": {"match_all": {}},
    "groups": [{"date_histogram": {"source_field": "timestamp", "fixed_interval": "1h", "timezone": "UTC"}}],
    "aggregations": {"sum_value": {"sum": {"field": "value"}}}
  }
}
```

Response (HTTP 201):
```json
{
    "_id": "transform-normal",
    "_version": 1,
    "_seq_no": 2,
    "_primary_term": 2,
    "transform": {
        "transform_id": "transform-normal",
        "schema_version": 27,
        "schedule": {
            "interval": {
                "start_time": 1602100553,
                "period": 1,
                "unit": "Minutes"
            }
        },
        "metadata_id": null,
        "updated_at": 1778595146233,
        "enabled": true,
        "enabled_at": 1778595146233,
        "description": "transform on normal index",
        "source_index": "normal-index",
        "data_selection_query": {"match_all": {"boost": 1.0}},
        "target_index": "transform-target-normal",
        "page_size": 1,
        "groups": [
            {
                "date_histogram": {
                    "fixed_interval": "1h",
                    "source_field": "timestamp",
                    "target_field": "timestamp",
                    "timezone": "UTC",
                    "format": null
                }
            }
        ],
        "aggregations": {"sum_value": {"sum": {"field": "value"}}},
        "continuous": false
    }
}
```

#### Path 3: ISM Policy Rollup (`AttemptCreateRollupJobStep`)

**Test 3a: ISM Rollup policy on pluggable dataformat index — BLOCKED** ✅

Create policy:
```
PUT /_plugins/_ism/policies/rollup-policy
Content-Type: application/json

{
  "policy": {
    "description": "rollup policy test",
    "default_state": "rollup_state",
    "states": [
      {
        "name": "rollup_state",
        "actions": [
          {
            "rollup": {
              "ism_rollup": {
                "description": "ism rollup test",
                "target_index": "rollup-ism-target",
                "page_size": 1,
                "dimensions": [{"date_histogram": {"source_field": "timestamp", "fixed_interval": "1h", "timezone": "UTC"}}],
                "metrics": [{"source_field": "value", "metrics": [{"sum": {}}]}]
              }
            }
          }
        ],
        "transitions": []
      }
    ]
  }
}
```

Response (HTTP 201):
```json
{
    "_id": "rollup-policy",
    "_version": 1,
    "_primary_term": 2,
    "_seq_no": 7,
    "policy": {
        "policy": {
            "policy_id": "rollup-policy",
            "description": "rollup policy test",
            "default_state": "rollup_state",
            "states": [{"name": "rollup_state", "actions": [{"rollup": {"ism_rollup": {...}}}]}]
        }
    }
}
```

Apply policy:
```
POST /_plugins/_ism/add/pluggable-test-index
Content-Type: application/json

{"policy_id": "rollup-policy"}
```

Response (HTTP 200):
```json
{
    "updated_indices": 1,
    "failures": false,
    "failed_indices": []
}
```

ISM Explain (after ISM executes the step):
```
GET /_plugins/_ism/explain/pluggable-test-index
```

Response:
```json
{
    "pluggable-test-index": {
        "policy_id": "rollup-policy",
        "state": {"name": "rollup_state"},
        "action": {
            "name": "rollup",
            "failed": false,
            "consumed_retries": 1
        },
        "step": {
            "name": "attempt_create_rollup",
            "step_status": "failed"
        },
        "info": {
            "cause": "Rollup is not supported on indices with pluggable dataformat enabled",
            "message": "Failed to validate resolved indices for rollup job"
        },
        "enabled": true
    }
}
```

Server Log:
```
[INFO ][o.o.i.i.ManagedIndexRunner] Executing attempt_create_rollup for pluggable-test-index
[ERROR][o.o.i.i.s.r.AttemptCreateRollupJobStep] Failed to validate resolved indices for rollup job
java.lang.IllegalArgumentException: Rollup is not supported on indices with pluggable dataformat enabled
    at o.o.i.i.step.rollup.AttemptCreateRollupJobStep.validateResolvedIndices(AttemptCreateRollupJobStep.kt:137)
    at o.o.i.i.step.rollup.AttemptCreateRollupJobStep.execute(AttemptCreateRollupJobStep.kt:72)
    at o.o.i.i.ManagedIndexRunner$runManagedIndexConfig$2.invokeSuspend(ManagedIndexRunner.kt:458)
[INFO ][o.o.i.i.ManagedIndexRunner] Finished executing attempt_create_rollup for pluggable-test-index
```

#### Path 4: ISM Policy Transform (`AttemptCreateTransformJobStep`)

**Test 4a: ISM Transform policy on pluggable dataformat index — BLOCKED** ✅

Create policy:
```
PUT /_plugins/_ism/policies/transform-policy
Content-Type: application/json

{
  "policy": {
    "description": "transform policy test",
    "default_state": "transform_state",
    "states": [
      {
        "name": "transform_state",
        "actions": [
          {
            "transform": {
              "ism_transform": {
                "description": "ism transform test",
                "target_index": "transform-ism-target",
                "page_size": 1,
                "data_selection_query": {"match_all": {}},
                "groups": [{"date_histogram": {"source_field": "timestamp", "fixed_interval": "1h", "timezone": "UTC"}}],
                "aggregations": {"sum_value": {"sum": {"field": "value"}}}
              }
            }
          }
        ],
        "transitions": []
      }
    ]
  }
}
```

Response (HTTP 201):
```json
{
    "_id": "transform-policy",
    "_version": 1,
    "_primary_term": 2,
    "_seq_no": 32,
    "policy": {
        "policy": {
            "policy_id": "transform-policy",
            "description": "transform policy test",
            "default_state": "transform_state",
            "states": [{"name": "transform_state", "actions": [{"transform": {"ism_transform": {...}}}]}]
        }
    }
}
```

Apply policy:
```
POST /_plugins/_ism/add/pluggable-test-index
Content-Type: application/json

{"policy_id": "transform-policy"}
```

Response (HTTP 200):
```json
{
    "updated_indices": 1,
    "failures": false,
    "failed_indices": []
}
```

Server Log (after ISM executes the step):
```
[INFO ][o.o.i.i.ManagedIndexRunner] Executing attempt_create_transform for pluggable-test-index
java.lang.IllegalArgumentException: Transform is not supported on indices with pluggable dataformat enabled
```

####  Summary

| # | Path | Failure Case (Blocked) | Success Case (Allowed) |
|---|------|:---:|:---:|
| 1 | Standalone Rollup | ✅ HTTP 400 | ✅ HTTP 201 |
| 2 | Standalone Transform | ✅ HTTP 400 | ✅ HTTP 201 |
| 3 | ISM Policy Rollup | ✅ Step failed with clear error in explain & logs | ✅ Works on normal indices |
| 4 | ISM Policy Transform | ✅ Step failed with clear error in logs | ✅ Works on normal indices |

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/index-management/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
