### PR TITLE
Fix NoClassDefFoundError in ISM custom webhook error notifications by adding HttpClient 5 dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -233,6 +233,8 @@ dependencies {
     implementation "commons-codec:commons-codec:${versions.commonscodec}"
     implementation "org.apache.httpcomponents:httpclient:${versions.httpclient}"
     implementation "org.apache.httpcomponents:httpcore:${versions.httpcore}"
+    implementation "org.apache.httpcomponents.client5:httpclient5:${versions.httpclient5}"
+    implementation "org.apache.httpcomponents.core5:httpcore5:${versions.httpcore5}"
 
     testImplementation "org.opensearch.test:framework:${opensearch_version}"
     testImplementation "org.jetbrains.kotlin:kotlin-test:${kotlin_version}"


### PR DESCRIPTION
### Description
This PR fixes a critical bug where ISM policies with custom webhook error notifications cause JVM crashes due to a missing dependency

### Related Issues
Resolves #1641

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

### Solution

Added the missing Apache HttpClient 5 dependencies to `build.gradle`:
- `httpclient5`
- `httpcore5`


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/index-management/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
