### PR TITLE
Fix flaky RestGetRollupActionIT and RestGetTransformActionIT

### DIFF
--- a/src/test/kotlin/org/opensearch/indexmanagement/rollup/runner/RollupRunnerIT.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/rollup/runner/RollupRunnerIT.kt
@@ -731,6 +731,12 @@ class RollupRunnerIT : RollupRestTestCase() {
             assertEquals("Rollup is not finished", RollupMetadata.Status.FINISHED, rollupMetadata.status)
             assertNull("Had a failure reason", rollupMetadata.failureReason)
         }
+
+        client().makeRequest(
+            "PUT",
+            "/_cluster/settings",
+            StringEntity("""{"persistent":{"search.max_buckets":null, "${ROLLUP_SEARCH_BACKOFF_COUNT.key}": null}}""", ContentType.APPLICATION_JSON),
+        )
     }
 
     // Tests that a continuous rollup will not be processed until the end of the interval plus delay passes

--- a/src/test/kotlin/org/opensearch/indexmanagement/transform/resthandler/RestGetTransformActionIT.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/transform/resthandler/RestGetTransformActionIT.kt
@@ -13,6 +13,7 @@ import org.opensearch.indexmanagement.makeRequest
 import org.opensearch.indexmanagement.transform.TransformRestTestCase
 import org.opensearch.indexmanagement.transform.action.get.GetTransformsRequest.Companion.DEFAULT_SIZE
 import org.opensearch.indexmanagement.transform.randomTransform
+import org.opensearch.indexmanagement.waitFor
 import org.opensearch.test.OpenSearchTestCase
 import org.opensearch.test.junit.annotations.TestLogging
 
@@ -52,12 +53,13 @@ class RestGetTransformActionIT : TransformRestTestCase() {
     fun `test getting all transforms`() {
         val transforms = randomList(1, 15) { createTransform(randomTransform()) }
 
-        // TODO: Delete existing transforms before test once delete API is available
         // Using a larger response size than the default in case leftover transforms prevent the ones created in this test from being returned
-        val res = client().makeRequest("GET", "$TRANSFORM_BASE_URI?size=100")
-        val map = res.asMap()
-        val totalTransforms = map["total_transforms"] as Int
-        val resTransforms = map["transforms"] as List<Map<String, Any?>>
+        // Wrap in waitFor to handle transient shard recovery (IllegalIndexShardStateException)
+        val resMap = waitFor {
+            client().makeRequest("GET", "$TRANSFORM_BASE_URI?size=100").asMap()
+        }
+        val totalTransforms = resMap["total_transforms"] as Int
+        val resTransforms = resMap["transforms"] as List<Map<String, Any?>>
 
         // There can be leftover transforms from previous tests, so we will have at least transforms.size or more
         assertTrue("Total transforms was not the same", transforms.size <= totalTransforms)


### PR DESCRIPTION
## Summary

- **RestGetRollupActionIT**: `RollupRunnerIT.test search max buckets breaker` sets `search.max_buckets=50` as a persistent cluster setting but never resets it. Later tests on the shared cluster create enabled rollup jobs whose composite aggregations exceed 50 buckets → `TooManyBucketsException`. Fix: reset the setting to null after the test.
- **RestGetTransformActionIT**: `test getting all transforms` can hit `IllegalIndexShardStateException` when shards are still in RECOVERING state. Fix: wrap the GET request in `waitFor` to retry through transient shard recovery.

## Test plan

- [ ] Run `./gradlew :integTest --tests 'org.opensearch.indexmanagement.rollup.runner.RollupRunnerIT.test search max buckets breaker'` — passes and resets settings
- [ ] Run `./gradlew :integTest --tests 'org.opensearch.indexmanagement.rollup.resthandler.RestGetRollupActionIT.test getting all rollups'` — no longer hits TooManyBucketsException
- [ ] Run `./gradlew :integTest --tests 'org.opensearch.indexmanagement.transform.resthandler.RestGetTransformActionIT.test getting all transforms'` — retries through transient shard recovery
- [ ] Full integ test suite passes

Signed-off-by: bowenlan-amzn <bowenlan.amzn@gmail.com>