### PR TITLE
Fix Rollup/Transform security ITs failing after security#6147 (own_index removal)

### DIFF
--- a/src/test/kotlin/org/opensearch/indexmanagement/security/RollupSecurityBehaviorIT.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/security/RollupSecurityBehaviorIT.kt
@@ -62,6 +62,7 @@ class RollupSecurityBehaviorIT : SecurityRestTestCase() {
                 EXPLAIN_ROLLUP,
                 UPDATE_ROLLUP,
                 DELETE_ROLLUP,
+                BULK_WRITE_INDEX,
             )
 
         val indexPermissions =

--- a/src/test/kotlin/org/opensearch/indexmanagement/security/TransformSecurityBehaviorIT.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/security/TransformSecurityBehaviorIT.kt
@@ -64,6 +64,7 @@ class TransformSecurityBehaviorIT : SecurityRestTestCase() {
                 DELETE_TRANSFORM,
                 HEALTH,
                 GET_TRANSFORMS,
+                BULK_WRITE_INDEX,
             )
 
         val indexPermissions =


### PR DESCRIPTION
### Description

Two security integration tests have started failing deterministically on every recent PR run after `opensearch-project/security#6147` ([fix(config)!: remove own_index default roles mapping](https://github.com/opensearch-project/security/pull/6147)) merged on 2026-06-10:

- `RollupSecurityBehaviorIT.test rollup successful execution` — `Rollup is not finished expected:<finished> but was:<failed>`
- `TransformSecurityBehaviorIT.test transform successful execution` — `Transform has not finished expected:<finished> but was:<failed>`

This PR fixes the test fixtures so they no longer rely on the removed `own_index` implicit grant.

### Root cause

Both tests create `helpdesk_role` and assign it to user `john`, then schedule a Rollup/Transform job under that user's security context. The background runner reaches the bulk transport action `indices:data/write/bulk` at the **cluster** layer (it is classified as `cluster_composite_ops` in the security plugin's `static_action_groups.yml`).

Before #6147, every authenticated user was implicitly mapped to the static role `own_index` via `roles_mapping.yml`'s `own_index: users: [\"*\"]`. That static role grants `cluster_permissions: [cluster_composite_ops]`, which transitively includes `indices:data/write/bulk`. So `helpdesk_role` was effectively backed by an implicit cluster-level bulk grant the test fixture never declared.

After #6147, `helpdesk_role` no longer receives that grant. The cluster log shows the precise denial:

\`\`\`
[PrivilegesEvaluatorImpl] No cluster-level perm match for User [name=plugin, ...]
  [Action [indices:data/write/bulk]] [RolesChecked [helpdesk_role]].
  No permissions for [indices:data/write/bulk]
\`\`\`

`helpdesk_role` declared `BULK_WRITE_INDEX = \"indices:data/write/bulk*\"` only under `index_permissions`, which matches the shard-level action `indices:data/write/bulk[s]` — not the cluster-level transport action.

### Fix

Add `BULK_WRITE_INDEX` to the **cluster permissions** list in both `RollupSecurityBehaviorIT` and `TransformSecurityBehaviorIT`. The fixture is now self-sufficient and does not depend on any default roles mapping.

### Verification

Reproduced both failures locally on `main` against the current `3.7.0-SNAPSHOT` security plugin (post-#6147), then confirmed both pass with the fix:

\`\`\`
./gradlew :integTest -Dsecurity=true -Dhttps=true \\
  --tests '*.RollupSecurityBehaviorIT.test rollup successful execution' \\
  --tests '*.TransformSecurityBehaviorIT.test transform successful execution'
# BUILD SUCCESSFUL in 1m 35s
\`\`\`

### Issues Resolved

Unblocks every PR's `Security test workflow` since 2026-06-10. Most visibly affects #1663, but the failure is environment-driven and would land on any new PR.

### Check List
- [x] New functionality includes testing
- [x] All tests pass
- [x] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff