### PR TITLE
Remove Wandalen/wretry.action wrapper from coverage upload

### DIFF
--- a/.github/workflows/test-and-build-workflow.yml
+++ b/.github/workflows/test-and-build-workflow.yml
@@ -178,14 +178,10 @@ jobs:
             echo "has_coverage=false" >> $GITHUB_OUTPUT
           fi
 
-      - name: Upload Coverage with retry
+      - name: Upload Coverage
         if: steps.check_coverage.outputs.has_coverage == 'true'
-        uses: Wandalen/wretry.action@e68c23e6309f2871ca8ae4763e7629b9c258e1ea # v3.8.0
+        uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4
         with:
-          attempt_limit: 5
-          attempt_delay: 2000
-          action: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4
-          with: |
-            token: ${{ secrets.CODECOV_TOKEN }}
-            fail_ci_if_error: true
-            verbose: true
+          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: false
+          verbose: true


### PR DESCRIPTION
### Description

Remove `Wandalen/wretry.action` from the `report-coverage` job and call `codecov/codecov-action` directly.

The wretry composite action's `action.yml` internally references itself at `Wandalen/wretry.action@v3.8.0_js_action` (by tag, not SHA — the JS implementation lives at a separate tag). GitHub resolves `uses:` in two passes: once for the workflow file, then again for nested references inside resolved actions. The org's SHA-pinning policy now rejects the second-pass tag reference even when the outer action is correctly pinned, producing:

```
The action wandalen/wretry.action@v3.8.0_js_action is not allowed in
opensearch-project/index-management because all actions must be pinned
to a full-length commit SHA.
```

This started failing around 2026-06-15 — the same workflow ran successfully on 2026-06-12 (run 27406457007) without code changes, suggesting an org-policy enforcement tightening on transitive references. Other opensearch-project repos hit the same class of issue: opensearch-project/dashboards-search-relevance#867, opensearch-project/observability-stack#300. The opensearch-build team's response was the same fix pattern — see opensearch-project/opensearch-build#6258, which removes wretry from the shared `setup-opensearch-dashboards` action.

### Behavior change

- The 5x outer retry around codecov upload is gone. The codecov uploader has its own retry on transient network errors, and `fail_ci_if_error: false` keeps a flaky upload from breaking CI — coverage reporting is best-effort, not a build gate.

### Failing run

https://github.com/opensearch-project/index-management/actions/runs/27568107212/job/82440499161

### Issues Resolved

N/A

### Check List

- [x] New functionality includes testing.
- [x] Commits are signed per the DCO using `--signoff`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).