### PR TITLE
[Backport 2.19] Add CI mirror to avoid Maven Central throttling

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -70,6 +70,7 @@ buildscript {
 
     repositories {
         mavenLocal()
+        maven { url "https://ci.opensearch.org/maven2/" }
         mavenCentral()
         maven { url "https://plugins.gradle.org/m2/" }
         maven { url "https://ci.opensearch.org/ci/dbc/snapshots/maven/" }

--- a/settings.gradle
+++ b/settings.gradle
@@ -3,6 +3,14 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+pluginManagement {
+    repositories {
+        maven { url = uri("https://ci.opensearch.org/maven2/") }
+        gradlePluginPortal()
+        mavenCentral()
+    }
+}
+
 rootProject.name = 'opensearch-index-management'
 
 include "spi"

--- a/spi/build.gradle
+++ b/spi/build.gradle
@@ -48,6 +48,7 @@ check.dependsOn jacocoTestReport
 
 repositories {
     mavenLocal()
+    maven { url "https://ci.opensearch.org/maven2/" }
     mavenCentral()
     maven { url "https://plugins.gradle.org/m2/" }
     maven { url "https://ci.opensearch.org/ci/dbc/snapshots/maven/" }


### PR DESCRIPTION
### Description
Adds `https://ci.opensearch.org/maven2/` as a priority repository for plugin and dependency resolution to avoid Maven Central HTTP 429 throttling during builds on Jenkins.

### Changes
* `build.gradle` — Add CI mirror in buildscript repositories
* `spi/build.gradle` — Add CI mirror in repositories
* `settings.gradle` — Add `pluginManagement` block with CI mirror

### Testing
Build verification