### PR TITLE
Add @Tarun-kishore as a maintainer

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*   @bowenlan-amzn @Hailong-am @vikasvb90 @tandonks @shiv0408 @soosinha
+*   @bowenlan-amzn @Hailong-am @vikasvb90 @tandonks @shiv0408 @soosinha @Tarun-kishore

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -12,6 +12,7 @@ This document contains a list of maintainers in this repo. See [opensearch-proje
 | Kshitij Tandon | [tandonks](https://github.com/tandonks) | Amazon |
 | Shivansh Arora | [shiv0408](https://github.com/shiv0408) | Apple |
 | Sooraj Sinha | [soosinha](https://github.com/soosinha) | Amazon |
+| Tarun Kishore | [Tarun-kishore](https://github.com/Tarun-kishore) | Uber |
 
 ## Emeritus
 


### PR DESCRIPTION
Following the [nomination process](https://github.com/opensearch-project/.github/blob/main/RESPONSIBILITIES.md#becoming-a-maintainer), I have nominated and other maintainers have agreed to add Tarun Kishore (@Tarun-kishore) as a co-maintainer of the Index Management repository. He has graciously accepted the invitation.

Tarun has made significant contributions to the project over the past year, including feature implementations across ISM and Snapshot Management, demonstrating deep understanding and strong development capabilities within the OpenSearch ecosystem.

Tracks: https://github.com/opensearch-project/.github/issues/563

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.