### PR TITLE
Suppress DEPRECATION warnings in compileTestKotlin to fix flaky tests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -927,6 +927,10 @@ compileKotlin {
 }
 
 compileTestKotlin {
+    // OpenSearchRestTestCase's client()/adminClient() still return the deprecated
+    // low-level RestClient, so disable deprecation warnings here specifically
+    // instead of turning off allWarningsAsErrors for all test compilation.
+    kotlinOptions.freeCompilerArgs = ['-Xwarning-level=DEPRECATION:disabled']
     kotlinOptions.allWarningsAsErrors = true
 }
 


### PR DESCRIPTION
### Description
`compileTestKotlin` was failing with `allWarningsAsErrors = true` because OpenSearchRestTestCase's client()/adminClient() return the deprecated low-level RestClient, which this repo's IT test infra uses throughout (IndexManagementRestTestCase, TestHelpers, SecurityRestTestCase, etc.).

 A full migration off RestClient isn't practical right now since it's baked into OpenSearchRestTestCase itself — the base test framework class hasn't moved off it either.

 This disables deprecation warnings specifically for test compilation (-Xwarning-level=DEPRECATION:disabled) rather than turning off allWarningsAsErrors entirely, so other warning categories in test code still fail the build.

 #### Test plan:
  - `./gradlew compileTestKotlin` now builds successfully
  - allWarningsAsErrors remains enabled for compileKotlin and for all non-deprecation warnings in compileTestKotlin

### Related Issues
Fix flaky test runs: https://github.com/opensearch-project/index-management/actions/runs/30034997708/job/89407413738?pr=1691

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/index-management/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
