### PR TITLE
Add ci.opensearch.org/m2/ mirror for plugin resolution (index-management)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -72,8 +72,8 @@ buildscript {
 
     repositories {
         mavenLocal()
-        maven { url "https://ci.opensearch.org/m2/" }
         maven { url "https://ci.opensearch.org/maven2/" }
+        maven { url "https://ci.opensearch.org/m2/" }
         mavenCentral()
         maven { url "https://plugins.gradle.org/m2/" }
         maven { url "https://ci.opensearch.org/ci/dbc/snapshots/maven/" }

--- a/build.gradle
+++ b/build.gradle
@@ -72,6 +72,7 @@ buildscript {
 
     repositories {
         mavenLocal()
+        maven { url "https://ci.opensearch.org/m2/" }
         maven { url "https://ci.opensearch.org/maven2/" }
         mavenCentral()
         maven { url "https://plugins.gradle.org/m2/" }

--- a/settings.gradle
+++ b/settings.gradle
@@ -5,8 +5,8 @@
 
 pluginManagement {
     repositories {
-        maven { url = uri("https://ci.opensearch.org/m2/") }
         maven { url = uri("https://ci.opensearch.org/maven2/") }
+        maven { url = uri("https://ci.opensearch.org/m2/") }
         gradlePluginPortal()
         mavenCentral()
     }

--- a/settings.gradle
+++ b/settings.gradle
@@ -5,6 +5,7 @@
 
 pluginManagement {
     repositories {
+        maven { url = uri("https://ci.opensearch.org/m2/") }
         maven { url = uri("https://ci.opensearch.org/maven2/") }
         gradlePluginPortal()
         mavenCentral()

--- a/spi/build.gradle
+++ b/spi/build.gradle
@@ -53,6 +53,7 @@ jacocoTestReport {
 
 repositories {
     mavenLocal()
+    maven { url "https://ci.opensearch.org/m2/" }
     maven { url "https://ci.opensearch.org/maven2/" }
     mavenCentral()
     maven { url "https://plugins.gradle.org/m2/" }

--- a/spi/build.gradle
+++ b/spi/build.gradle
@@ -53,8 +53,8 @@ jacocoTestReport {
 
 repositories {
     mavenLocal()
-    maven { url "https://ci.opensearch.org/m2/" }
     maven { url "https://ci.opensearch.org/maven2/" }
+    maven { url "https://ci.opensearch.org/m2/" }
     mavenCentral()
     maven { url "https://plugins.gradle.org/m2/" }
     maven { url "https://ci.opensearch.org/ci/dbc/snapshots/maven/" }


### PR DESCRIPTION
### Description
Add ci.opensearch.org/m2/ mirror for plugin resolution (index-management)

### Issues Resolved
https://github.com/opensearch-project/opensearch-build/issues/6278#issuecomment-5135909975

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).