### PR TITLE
Ignore Security plugin audit log tasks in waitForRunningTasks

### DIFF
--- a/src/test/kotlin/org/opensearch/indexmanagement/IndexManagementRestTestCase.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/IndexManagementRestTestCase.kt
@@ -364,7 +364,8 @@ abstract class IndexManagementRestTestCase : ODFERestTestCase() {
                 for ((_, value1) in nodeTasks!!) {
                     val task = value1 as Map<String, Any>
                     val action = task["action"] as String
-                    if (isIgnorableTask(action)) continue
+                    val description = task["description"] as? String ?: ""
+                    if (isIgnorableTask(action, description)) continue
                     // runningTasks.add(task["action"].toString() + " | " + task["description"].toString())
                     runningTasks.add(task.toString())
                 }
@@ -372,12 +373,15 @@ abstract class IndexManagementRestTestCase : ODFERestTestCase() {
             return runningTasks
         }
 
-        // Ignore the task list API and segment replication background tasks (always running on Remote Store clusters)
-        private fun isIgnorableTask(action: String): Boolean =
+        // Ignore the task list API, segment replication background tasks, and Security plugin audit log
+        // writes. The Security plugin is installed even in without-security runs; its audit logger fires
+        // asynchronously on REST calls and can outlive the test that triggered them.
+        private fun isIgnorableTask(action: String, description: String = ""): Boolean =
             action == ListTasksAction.NAME ||
                 action == ListTasksAction.NAME + "[n]" ||
                 action.startsWith("segrep_") ||
-                action == "indices:admin/publishCheckpoint[p]"
+                action == "indices:admin/publishCheckpoint[p]" ||
+                description.contains("security-auditlog")
 
         @JvmStatic
         protected fun waitForThreadPools(client: RestClient) {

--- a/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/action/RolloverActionIT.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/action/RolloverActionIT.kt
@@ -439,6 +439,13 @@ class RolloverActionIT : IndexStateManagementRestTestCase() {
             )
         assertEquals("Unexpected RestStatus", RestStatus.OK, response.restStatus())
 
+        // Wait for the retry write to land before triggering the job, otherwise the job may
+        // fire before the metadata reflects the retried state and re-evaluate the old FAILED step.
+        waitFor {
+            val info = getExplainManagedIndexMetaData(index1).info as Map<String, Any?>
+            assertEquals("Pending retry of failed managed index", info["message"])
+        }
+
         updateManagedIndexConfigStartTime(managedIndexConfig)
         waitFor {
             val info = getExplainManagedIndexMetaData(index1).info as Map<String, Any?>

--- a/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/action/RolloverActionIT.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/action/RolloverActionIT.kt
@@ -439,13 +439,6 @@ class RolloverActionIT : IndexStateManagementRestTestCase() {
             )
         assertEquals("Unexpected RestStatus", RestStatus.OK, response.restStatus())
 
-        // Wait for the retry write to land before triggering the job, otherwise the job may
-        // fire before the metadata reflects the retried state and re-evaluate the old FAILED step.
-        waitFor {
-            val info = getExplainManagedIndexMetaData(index1).info as Map<String, Any?>
-            assertEquals("Pending retry of failed managed index", info["message"])
-        }
-
         updateManagedIndexConfigStartTime(managedIndexConfig)
         waitFor {
             val info = getExplainManagedIndexMetaData(index1).info as Map<String, Any?>


### PR DESCRIPTION
### Description
The Security plugin is installed even in without-security CI runs; its audit logger writes asynchronously to `security-auditlog-*` indices on every REST call. These writes can still be in flight when `wipeAllIndices` calls `waitForRunningTasks`, causing a spurious "There are still tasks running" failure unrelated to the test itself.

Fix: extend `isIgnorableTask` to also check the task description and skip tasks targeting `security-auditlog-*` indices.

### Related Issues
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/index-management/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).