### PR TITLE
Support mixed raw and rollup search when a queried field is missing from the rollup

### DIFF
--- a/src/main/kotlin/org/opensearch/indexmanagement/rollup/interceptor/RollupInterceptor.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/rollup/interceptor/RollupInterceptor.kt
@@ -16,6 +16,7 @@ import org.opensearch.index.query.BoostingQueryBuilder
 import org.opensearch.index.query.ConstantScoreQueryBuilder
 import org.opensearch.index.query.DisMaxQueryBuilder
 import org.opensearch.index.query.MatchAllQueryBuilder
+import org.opensearch.index.query.MatchNoneQueryBuilder
 import org.opensearch.index.query.MatchPhraseQueryBuilder
 import org.opensearch.index.query.QueryBuilder
 import org.opensearch.index.query.QueryStringQueryBuilder
@@ -46,6 +47,7 @@ import org.opensearch.search.aggregations.metrics.MaxAggregationBuilder
 import org.opensearch.search.aggregations.metrics.MinAggregationBuilder
 import org.opensearch.search.aggregations.metrics.SumAggregationBuilder
 import org.opensearch.search.aggregations.metrics.ValueCountAggregationBuilder
+import org.opensearch.search.builder.SearchSourceBuilder
 import org.opensearch.search.internal.ShardSearchRequest
 import org.opensearch.tasks.Task
 import org.opensearch.transport.TransportChannel
@@ -53,6 +55,7 @@ import org.opensearch.transport.TransportInterceptor
 import org.opensearch.transport.TransportRequest
 import org.opensearch.transport.TransportRequestHandler
 
+@Suppress("TooManyFunctions")
 class RollupInterceptor(
     val clusterService: ClusterService,
     val settings: Settings,
@@ -86,6 +89,14 @@ class RollupInterceptor(
          * "${BYPASS_MARKER_PREFIX}<level>" where <level> is an integer (BYPASS_ROLLUP_SEARCH or BYPASS_SIZE_CHECK).
          */
         const val BYPASS_MARKER_PREFIX = "_rollup_internal_bypass_"
+
+        /**
+         * Sentinel field name used to neutralize a rollup shard in a mixed raw + rollup search. It is
+         * intentionally chosen to never exist on any index so that aggregations referencing it resolve
+         * to empty (unmapped) results.
+         */
+        @Suppress("MemberVisibilityCanBePrivate") // internal for unit testing
+        const val NONEXISTENT_ROLLUP_FIELD = "__opensearch_rollup_nonexistent_field__"
     }
 
     /**
@@ -180,8 +191,14 @@ class RollupInterceptor(
 
                     val allMatchingRollupJobs = validateIndicies(concreteIndices, fieldMappings)
 
-                    // only rebuild if there is necessity to rebuild
-                    if (fieldMappings.isNotEmpty()) {
+                    if (fieldMappings.isNotEmpty() && allMatchingRollupJobs.isEmpty()) {
+                        // Mixed raw + rollup search where no rollup index can answer the queried fields
+                        // (e.g. the field exists only on the raw index). Neutralize this rollup shard so it
+                        // matches no documents and returns empty aggregations of the same shape as the request,
+                        // letting the raw indices serve the query instead of failing the entire search.
+                        neutralizeRollupShard(request)
+                    } else if (fieldMappings.isNotEmpty()) {
+                        // only rebuild if there is necessity to rebuild
                         rewriteShardSearchForRollupJobs(request, allMatchingRollupJobs)
                     }
                 }
@@ -213,10 +230,17 @@ class RollupInterceptor(
      * Validate that at least one index has a rollup job which matches field mappings from request.
      * Indices whose rollup jobs don't cover the queried fields are skipped, allowing queries across
      * multiple rollup indices with different dimension schemas.
+     *
+     * Returns the matching rollup jobs. The result may be empty when the search also spans raw
+     * (non-rollup) indices and no rollup index can answer the queried fields (for example, the field
+     * exists only on the raw index). In that case the rollup shard should contribute nothing and let
+     * the raw indices serve the query, instead of failing the entire search. The caller is responsible
+     * for neutralizing the rollup shard when this returns an empty map.
      * */
     internal fun validateIndicies(concreteIndices: Array<String>, fieldMappings: Set<RollupFieldMapping>): Map<Rollup, Set<RollupFieldMapping>> {
         var allMatchingRollupJobs: Map<Rollup, Set<RollupFieldMapping>> = mapOf()
         var lastIssues: Set<String> = emptySet()
+        var hasRawIndex = false
         for (concreteIndex in concreteIndices) {
             val rollupJobs = clusterService.state().metadata.index(concreteIndex).getRollupJobs()
             if (rollupJobs != null) {
@@ -229,10 +253,16 @@ class RollupInterceptor(
                 }
             } else if (!searchRawRollupIndices) {
                 throw IllegalArgumentException("Not all indices have rollup job")
+            } else {
+                // A raw (non-rollup) index is part of a mixed raw + rollup search.
+                hasRawIndex = true
             }
         }
 
-        if (allMatchingRollupJobs.isEmpty()) {
+        // Only fail the query when there is no raw index that could answer it. When raw indices are
+        // present, an empty result signals the caller to neutralize this rollup shard so the raw
+        // indices can serve the query (treating fields missing from the rollup as no contribution).
+        if (allMatchingRollupJobs.isEmpty() && !hasRawIndex) {
             throw IllegalArgumentException("Could not find a rollup job that can answer this query because $lastIssues")
         }
 
@@ -441,6 +471,89 @@ class RollupInterceptor(
         DateHistogramInterval(rollup.getDateHistogram().calendarInterval).estimateMillis()
     } else {
         DateHistogramInterval(rollup.getDateHistogram().fixedInterval).estimateMillis()
+    }
+
+    /**
+     * Builds a copy of [aggregationBuilder] that references a field which does not exist on the rollup
+     * index, preserving the aggregation name, type, and sub-aggregations. Running the copy against the
+     * rollup index yields an empty (unmapped) result of the same aggregation type that the raw indices
+     * produce, so the coordinator can reduce this rollup shard's empty contribution together with the
+     * raw shards' results. For bucketing aggregations (date_histogram, histogram) every setting that
+     * influences bucket boundaries and empty-bucket generation (interval, bounds, offset, min_doc_count,
+     * order, keyed and time_zone) must be copied verbatim; otherwise the neutralized shard rounds buckets
+     * differently from the raw shards and the coordinator's empty-bucket reduce produces misaligned or
+     * out-of-order keys, corrupting results or fatally tripping InternalDateHistogram.addEmptyBuckets.
+     */
+    @Suppress("CyclomaticComplexMethod", "LongMethod")
+    internal fun neutralizeAggregation(aggregationBuilder: AggregationBuilder): AggregationBuilder {
+        val neutralized: AggregationBuilder =
+            when (aggregationBuilder) {
+                is TermsAggregationBuilder -> TermsAggregationBuilder(aggregationBuilder.name).field(NONEXISTENT_ROLLUP_FIELD)
+
+                is DateHistogramAggregationBuilder -> {
+                    // Preserve every bucketing setting (interval, bounds, offset, min_doc_count, order, keyed and
+                    // especially time_zone) so the empty result this shard produces uses the exact same bucket
+                    // boundaries and rounding as the raw shards. Otherwise the coordinator's empty-bucket reduce
+                    // can generate out-of-order/misaligned bucket keys, which corrupts results or trips a fatal
+                    // assertion during InternalDateHistogram.addEmptyBuckets.
+                    DateHistogramAggregationBuilder(aggregationBuilder.name)
+                        .also { aggregationBuilder.calendarInterval?.apply { it.calendarInterval(this) } }
+                        .also { aggregationBuilder.fixedInterval?.apply { it.fixedInterval(this) } }
+                        .also { aggregationBuilder.extendedBounds()?.apply { it.extendedBounds(this) } }
+                        .keyed(aggregationBuilder.keyed())
+                        .also { if (aggregationBuilder.minDocCount() >= 0) it.minDocCount(aggregationBuilder.minDocCount()) }
+                        .offset(aggregationBuilder.offset())
+                        .also { aggregationBuilder.order()?.apply { it.order(this) } }
+                        .also { aggregationBuilder.timeZone()?.apply { it.timeZone(this) } }
+                        .field(NONEXISTENT_ROLLUP_FIELD)
+                }
+
+                is HistogramAggregationBuilder ->
+                    // Preserve the interval, bounds, offset, min_doc_count, order and keyed for the same reason as
+                    // date_histogram above.
+                    HistogramAggregationBuilder(aggregationBuilder.name)
+                        .interval(aggregationBuilder.interval())
+                        .also {
+                            if (aggregationBuilder.minBound().isFinite() && aggregationBuilder.maxBound().isFinite()) {
+                                it.extendedBounds(aggregationBuilder.minBound(), aggregationBuilder.maxBound())
+                            }
+                        }
+                        .keyed(aggregationBuilder.keyed())
+                        .also { if (aggregationBuilder.minDocCount() >= 0) it.minDocCount(aggregationBuilder.minDocCount()) }
+                        .offset(aggregationBuilder.offset())
+                        .also { aggregationBuilder.order()?.apply { it.order(this) } }
+                        .field(NONEXISTENT_ROLLUP_FIELD)
+
+                is SumAggregationBuilder -> SumAggregationBuilder(aggregationBuilder.name).field(NONEXISTENT_ROLLUP_FIELD)
+
+                is AvgAggregationBuilder -> AvgAggregationBuilder(aggregationBuilder.name).field(NONEXISTENT_ROLLUP_FIELD)
+
+                is MaxAggregationBuilder -> MaxAggregationBuilder(aggregationBuilder.name).field(NONEXISTENT_ROLLUP_FIELD)
+
+                is MinAggregationBuilder -> MinAggregationBuilder(aggregationBuilder.name).field(NONEXISTENT_ROLLUP_FIELD)
+
+                is ValueCountAggregationBuilder -> ValueCountAggregationBuilder(aggregationBuilder.name).field(NONEXISTENT_ROLLUP_FIELD)
+
+                is CardinalityAggregationBuilder -> CardinalityAggregationBuilder(aggregationBuilder.name).field(NONEXISTENT_ROLLUP_FIELD)
+
+                else -> throw IllegalArgumentException("The ${aggregationBuilder.type} aggregation is not currently supported in rollups")
+            }
+        aggregationBuilder.subAggregations.forEach { neutralized.subAggregation(neutralizeAggregation(it)) }
+        return neutralized
+    }
+
+    /**
+     * Neutralizes a rollup shard for a mixed raw + rollup search whose queried fields are not covered by
+     * any rollup job on this index. The shard is rewritten to match no documents and to return empty
+     * aggregations of the same shape as the request, so that the raw indices in the search can serve the
+     * query instead of the whole search failing.
+     */
+    private fun neutralizeRollupShard(request: ShardSearchRequest) {
+        val neutralized = SearchSourceBuilder().size(0).query(MatchNoneQueryBuilder())
+        request.source().aggregations()?.aggregatorFactories?.forEach {
+            neutralized.aggregation(neutralizeAggregation(it))
+        }
+        request.source(neutralized)
     }
 
     private fun rewriteShardSearchForRollupJobs(request: ShardSearchRequest, matchingRollupJobs: Map<Rollup, Set<RollupFieldMapping>>) {

--- a/src/test/kotlin/org/opensearch/indexmanagement/rollup/interceptor/RollupInterceptorIT.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/rollup/interceptor/RollupInterceptorIT.kt
@@ -1179,6 +1179,100 @@ class RollupInterceptorIT : RollupRestTestCase() {
         }
     }
 
+    fun `test mixed raw and rollup search when field missing in rollup index`() {
+        val sourceIndex = "source_rollup_search_missing_field"
+        val targetIndex = "target_rollup_search_missing_field"
+        generateNYCTaxiData(sourceIndex)
+        val rollupJob =
+            Rollup(
+                id = "missing_field_rollup_search",
+                enabled = true,
+                schemaVersion = 1L,
+                jobSchedule = IntervalSchedule(Instant.now(), 1, ChronoUnit.MINUTES),
+                jobLastUpdatedTime = Instant.now(),
+                jobEnabledTime = Instant.now(),
+                description = "missing field mixed search test",
+                sourceIndex = sourceIndex,
+                targetIndex = targetIndex,
+                targetIndexSettings = null,
+                metadataID = null,
+                roles = emptyList(),
+                pageSize = 10,
+                delay = 0,
+                continuous = false,
+                dimensions =
+                listOf(
+                    DateHistogram(sourceField = "tpep_pickup_datetime", fixedInterval = "1h"),
+                    Terms("RatecodeID", "RatecodeID"),
+                ),
+                metrics =
+                listOf(
+                    RollupMetrics(
+                        sourceField = "passenger_count", targetField = "passenger_count",
+                        metrics = listOf(Sum(), Min(), Max(), ValueCount(), Average()),
+                    ),
+                ),
+            ).let { createRollup(it, it.id) }
+
+        updateRollupStartTime(rollupJob)
+
+        waitFor {
+            val job = getRollup(rollupId = rollupJob.id)
+            assertNotNull("Rollup job doesn't have metadata set", job.metadataID)
+            val rollupMetadata = getRollupMetadata(job.metadataID!!)
+            assertEquals("Rollup is not finished", RollupMetadata.Status.FINISHED, rollupMetadata.status)
+        }
+
+        refreshAllIndices()
+
+        // The aggregation mixes an object-typed dimension field on the rollup index (tpep_pickup_datetime,
+        // stored nested as a date_histogram) with store_and_fwd_flag, which exists only on the raw source
+        // index and is not part of the rollup. This mirrors the reported "missing field" scenario.
+        val req =
+            """
+            {
+                "size": 0,
+                "aggs": {
+                    "by_time": {
+                        "date_histogram": { "field": "tpep_pickup_datetime", "fixed_interval": "1h" },
+                        "aggs": {
+                            "flag_terms": {
+                                "terms": { "field": "store_and_fwd_flag" }
+                            }
+                        }
+                    }
+                }
+            }
+            """.trimIndent()
+
+        // Enable mixed raw + rollup search
+        updateSearchRawRollupClusterSetting(true)
+        updateSearchAllJobsClusterSetting(true)
+
+        // Ground truth: query only the raw source index
+        val rawRes = client().makeRequest("POST", "/$sourceIndex/_search", emptyMap(), StringEntity(req, ContentType.APPLICATION_JSON))
+        assertTrue("Raw search failed", rawRes.restStatus() == RestStatus.OK)
+        val rawAggs = rawRes.asMap()["aggregations"] as Map<String, Map<String, Any>>
+        val rawBuckets = rawAggs.getValue("by_time")["buckets"] as List<Map<String, Any>>
+
+        // Mixed search across raw source + rollup target on a field that only the raw index has.
+        // Previously this failed with "Could not find a rollup job that can answer this query because
+        // [missing field store_and_fwd_flag]". It should now succeed with the rollup shard contributing nothing.
+        val mixedRes = client().makeRequest("POST", "/$sourceIndex,$targetIndex/_search", emptyMap(), StringEntity(req, ContentType.APPLICATION_JSON))
+        assertTrue("Mixed raw + rollup search on a raw-only field should succeed", mixedRes.restStatus() == RestStatus.OK)
+
+        val shards = mixedRes.asMap()["_shards"] as Map<String, Any>
+        assertEquals("Mixed raw + rollup search should have no failed shards", 0, shards["failed"])
+
+        val mixedAggs = mixedRes.asMap()["aggregations"] as Map<String, Map<String, Any>>
+        val mixedBuckets = mixedAggs.getValue("by_time")["buckets"] as List<Map<String, Any>>
+
+        // The rollup index contributes nothing, so the mixed result must match the raw-only ground truth.
+        assertTrue("Expected at least one time bucket in the raw-only search", rawBuckets.isNotEmpty())
+        assertEquals("Mixed search returned a different number of time buckets than the raw-only search", rawBuckets.size, mixedBuckets.size)
+        assertEquals("Mixed search aggregation did not match the raw-only search", rawAggs, mixedAggs)
+    }
+
     fun `test roll up search query_string query`() {
         val sourceIndex = "source_rollup_search_qsq_1"
         val targetIndex = "target_rollup_qsq_search_1"

--- a/src/test/kotlin/org/opensearch/indexmanagement/rollup/interceptor/RollupInterceptorTests.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/rollup/interceptor/RollupInterceptorTests.kt
@@ -20,10 +20,24 @@ import org.opensearch.indexmanagement.rollup.interceptor.RollupInterceptor.Compa
 import org.opensearch.indexmanagement.rollup.model.RollupFieldMapping
 import org.opensearch.indexmanagement.rollup.randomRollup
 import org.opensearch.indexmanagement.rollup.settings.RollupSettings
+import org.opensearch.search.aggregations.bucket.histogram.DateHistogramAggregationBuilder
+import org.opensearch.search.aggregations.bucket.histogram.DateHistogramInterval
+import org.opensearch.search.aggregations.bucket.histogram.HistogramAggregationBuilder
+import org.opensearch.search.aggregations.bucket.range.RangeAggregationBuilder
+import org.opensearch.search.aggregations.bucket.terms.TermsAggregationBuilder
+import org.opensearch.search.aggregations.metrics.AvgAggregationBuilder
+import org.opensearch.search.aggregations.metrics.CardinalityAggregationBuilder
+import org.opensearch.search.aggregations.metrics.MaxAggregationBuilder
+import org.opensearch.search.aggregations.metrics.MinAggregationBuilder
+import org.opensearch.search.aggregations.metrics.SumAggregationBuilder
+import org.opensearch.search.aggregations.metrics.ValueCountAggregationBuilder
+import org.opensearch.search.aggregations.support.ValuesSourceAggregationBuilder
 import org.opensearch.search.builder.SearchSourceBuilder
 import org.opensearch.search.fetch.subphase.FetchSourceContext
 import org.opensearch.search.internal.ShardSearchRequest
 import org.opensearch.test.OpenSearchTestCase
+import java.time.ZoneId
+import kotlin.test.assertFailsWith
 
 class RollupInterceptorTests : OpenSearchTestCase() {
 
@@ -191,6 +205,103 @@ class RollupInterceptorTests : OpenSearchTestCase() {
         assertEquals("Only the job with field2 should match", 1, matchingJobs.size)
         assertTrue("rollup_2 should be in matching jobs", matchingJobs.keys.any { it.id == "rollup_2" })
         assertTrue("Expected no issues", issues.isEmpty())
+    }
+
+    fun `test neutralizeAggregation rewrites supported aggregations to a nonexistent field`() {
+        val interceptor = createInterceptor()
+        val builders =
+            listOf(
+                TermsAggregationBuilder("agg_terms").field("category"),
+                DateHistogramAggregationBuilder("agg_date_histogram").field("timestamp"),
+                HistogramAggregationBuilder("agg_histogram").field("value").interval(10.0),
+                SumAggregationBuilder("agg_sum").field("value"),
+                AvgAggregationBuilder("agg_avg").field("value"),
+                MaxAggregationBuilder("agg_max").field("value"),
+                MinAggregationBuilder("agg_min").field("value"),
+                ValueCountAggregationBuilder("agg_value_count").field("value"),
+                CardinalityAggregationBuilder("agg_cardinality").field("value"),
+            )
+
+        for (builder in builders) {
+            val result = interceptor.neutralizeAggregation(builder)
+            assertEquals("Aggregation name should be preserved", builder.name, result.name)
+            assertEquals("Aggregation type should be preserved", builder.type, result.type)
+            assertEquals(
+                "Aggregation should be rewritten to the nonexistent field",
+                RollupInterceptor.NONEXISTENT_ROLLUP_FIELD,
+                (result as ValuesSourceAggregationBuilder<*>).field(),
+            )
+        }
+    }
+
+    fun `test neutralizeAggregation preserves nested sub-aggregations`() {
+        val interceptor = createInterceptor()
+        val builder =
+            DateHistogramAggregationBuilder("by_time").field("timestamp")
+                .subAggregation(
+                    TermsAggregationBuilder("by_vendor").field("vendor")
+                        .subAggregation(SumAggregationBuilder("total").field("amount")),
+                )
+
+        val result = interceptor.neutralizeAggregation(builder)
+
+        assertEquals("by_time", result.name)
+        assertEquals(RollupInterceptor.NONEXISTENT_ROLLUP_FIELD, (result as ValuesSourceAggregationBuilder<*>).field())
+
+        val vendorAgg = result.subAggregations.single()
+        assertEquals("by_vendor", vendorAgg.name)
+        assertEquals(RollupInterceptor.NONEXISTENT_ROLLUP_FIELD, (vendorAgg as ValuesSourceAggregationBuilder<*>).field())
+
+        val totalAgg = vendorAgg.subAggregations.single()
+        assertEquals("total", totalAgg.name)
+        assertEquals("sum", totalAgg.type)
+        assertEquals(RollupInterceptor.NONEXISTENT_ROLLUP_FIELD, (totalAgg as ValuesSourceAggregationBuilder<*>).field())
+    }
+
+    fun `test neutralizeAggregation throws on an unsupported aggregation type`() {
+        val interceptor = createInterceptor()
+        assertFailsWith(IllegalArgumentException::class) {
+            interceptor.neutralizeAggregation(RangeAggregationBuilder("agg_range").field("value"))
+        }
+    }
+
+    fun `test neutralizeAggregation preserves histogram intervals`() {
+        val interceptor = createInterceptor()
+
+        val fixedDh = DateHistogramAggregationBuilder("dh_fixed").field("ts").fixedInterval(DateHistogramInterval("30m"))
+        val nFixed = interceptor.neutralizeAggregation(fixedDh) as DateHistogramAggregationBuilder
+        assertEquals("fixed_interval should be preserved", DateHistogramInterval("30m"), nFixed.fixedInterval)
+        assertEquals(RollupInterceptor.NONEXISTENT_ROLLUP_FIELD, nFixed.field())
+
+        val calDh = DateHistogramAggregationBuilder("dh_cal").field("ts").calendarInterval(DateHistogramInterval("1d"))
+        val nCal = interceptor.neutralizeAggregation(calDh) as DateHistogramAggregationBuilder
+        assertEquals("calendar_interval should be preserved", DateHistogramInterval("1d"), nCal.calendarInterval)
+
+        val hist = HistogramAggregationBuilder("hist").field("v").interval(50.0)
+        val nHist = interceptor.neutralizeAggregation(hist) as HistogramAggregationBuilder
+        assertEquals("histogram interval should be preserved", 50.0, nHist.interval(), 0.0)
+    }
+
+    fun `test neutralizeAggregation preserves date_histogram bucketing settings`() {
+        val interceptor = createInterceptor()
+
+        // time_zone, offset and min_doc_count must be preserved: dropping them makes the neutralized shard round
+        // bucket boundaries differently from the raw shards, which corrupts the reduce (and fatally trips
+        // InternalDateHistogram.addEmptyBuckets when assertions are enabled).
+        val original =
+            DateHistogramAggregationBuilder("by_day").field("ts")
+                .calendarInterval(DateHistogramInterval("1d"))
+                .timeZone(ZoneId.of("+05:30"))
+                .offset(3600000L)
+                .minDocCount(0)
+
+        val neutralized = interceptor.neutralizeAggregation(original) as DateHistogramAggregationBuilder
+
+        assertEquals(RollupInterceptor.NONEXISTENT_ROLLUP_FIELD, neutralized.field())
+        assertEquals("calendar_interval should be preserved", DateHistogramInterval("1d"), neutralized.calendarInterval)
+        assertEquals("time_zone should be preserved", ZoneId.of("+05:30"), neutralized.timeZone())
+        assertEquals("offset should be preserved", 3600000L, neutralized.offset())
+        assertEquals("min_doc_count should be preserved", 0L, neutralized.minDocCount())
     }
 
     // Helper method to create interceptor instance


### PR DESCRIPTION
### Description
When a search spans both raw and rollup indices and references a field that no rollup index covers, the rollup shard
previously threw `Could not find a rollup job that can answer this query because [missing field <field>]`, failing the entire search, even though the raw indices could answer it.
This change lets such mixed searches succeed by having the rollup shard contribute nothing instead of failing.
If field is present in neither the raw nor any rollup index, it succeeds with an empty aggregation result.

###Changes
  
  1. **`validateIndicies`** now tracks whether a raw index is part of the search (`hasRawIndex`). The `Could not find a rollup job...` error is thrown only when no rollup can answer and there is no raw index to fall back on. When a raw index is present, it returns an empty match instead of throwing.
  
  2. **`neutralizeRollupShard`** handles that empty case. Because the coordinator waits for every shard to return its aggregation (dropping the aggregation causes the search to hang, and running the original query against the rollup's stored structure errors on nested dimension fields such as `timestamp`), the rollup shard is instead rewritten to:
     - a `match_none` query (matches no documents), and
     - each aggregation rebuilt (neutralizeAggregation) with the same name and type but pointed at a non-existent field, so it returns an empty result the coordinator can merge with the raw shards' results.
  
The raw indices then serve the query, and the coordinator reduces the rollup shard's empty contribution together with the raw results.

### Testing
1. mixed raw + rollup search where the field exists only in the raw index:

Aggregate terms(vendor) (raw-only field) across a raw index + a rollup index. Previously failed with Could not find a rollup job that can answer this query because [missing field vendor].
  
  POST /raw_index,rollup_index/_search
  {"size":0,"aggs":{"by_vendor":{"terms":{"field":"vendor"},"aggs":{"s":{"sum":{"field":"value"}}}}}}
  
  Result: 200 OK, "_shards":{"total":2,"successful":2,"failed":0}
  buckets: acme -> 1000, books -> 3000   (identical to querying the raw index alone)

2.  date_histogram + time_zone mixed:

POST /raw_index,rollup_index/_search
  {"size":0,"aggs":{"by_day":{"date_histogram":{"field":"timestamp","calendar_interval":"1d","time_zone":"+05:30"},
   "aggs":{"v":{"terms":{"field":"vendor"}}}}}}
  
  Result: 200 OK, "_shards":{...,"failed":0}
  Day buckets + vendor sub-buckets identical to the raw-only result.

Neutralized shard preserves the query's bucketing settings (interval/time_zone/offset/bounds), so bucket keys stay aligned across shards

3. rollup-only search still errors correctly:

 When no raw index is present and no rollup covers the field, behavior is unchanged:
  
  POST /rollup-all/_search   (rollup indices only)
  {"size":0,"aggs":{"b":{"terms":{"field":"nonexistent_field"}}}}
  
  Result: 400, "Could not find a rollup job that can answer this query because [missing field nonexistent_field]"

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/index-management/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
