### PR TITLE
Remove redundant waitForPendingTasks in wipeAllIndices teardown

### DIFF
--- a/src/test/kotlin/org/opensearch/indexmanagement/IndexManagementRestTestCase.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/IndexManagementRestTestCase.kt
@@ -327,10 +327,12 @@ abstract class IndexManagementRestTestCase : ODFERestTestCase() {
 
             waitFor {
                 if (!isMultiNode) {
+                    // waitForRunningTasks uses /_tasks?detailed (JSON) and has access to the full
+                    // task description, so isIgnorableTask can filter security-auditlog writes.
+                    // waitForPendingTasks uses /_cat/tasks (same data, columnar text) but the
+                    // framework strips everything after the first whitespace token, making the
+                    // description invisible to the predicate — it is redundant and removed.
                     waitForRunningTasks(client)
-                    waitForPendingTasks(client) { taskName ->
-                        taskName.startsWith("segrep_") || taskName.startsWith("indices:admin/publishCheckpoint")
-                    }
                     waitForThreadPools(client)
                 } else {
                     // Multi node test is not suitable to waitFor


### PR DESCRIPTION
### Description

`waitForPendingTasks` (from the OpenSearch test framework) uses `/_cat/tasks?detailed` but its predicate only receives the first whitespace token of each line — the task action name. The task description (e.g. the target index name `security-auditlog-*`) is silently stripped, so `isIgnorableTask` never had a chance to filter Security plugin audit log writes, causing spurious teardown failures.

`waitForRunningTasks` uses `/_tasks?detailed` (JSON), which exposes the full task description as a structured field. Since both methods check the same underlying task set, `waitForPendingTasks` is redundant and is removed. A comment explains the difference so the intent is clear to future readers.

### Related Issues

<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/index-management/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).